### PR TITLE
Boilerplate changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         "prettier/prettier": 2,
         "import/no-default-export": 2,
         "interface-over-type-literal": 0,
+        "@typescript-eslint/prefer-interface": 0,
         "import-name": 0,
         "object-literal-sort-keys": 0,
         "interface-name": 0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "esbenp.prettier-vscode",
         "wix.vscode-import-cost",
         "orta.vscode-jest",
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "dbaeumer.vscode-eslint"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "format": "yarn validate --fix",
         "validate": "tsc --noEmit && eslint src/**/*.ts",
         "prepare": "yarn build",
-        "prepublishOnly": "yarn test && yarn validate",
+        "prepublishOnly": " yarn validate && yarn test",
         "preversion": "yarn validate",
         "version": "yarn format && git add -A src",
         "postversion": "git push && git push --tags"
@@ -23,6 +23,9 @@
     "repository": "https://github.com/guardian/consent-management-platform.git",
     "homepage": "https://github.com/guardian/consent-management-platform.git",
     "author": "George Haberis <george.haberis@guardian.co.uk>",
+    "contributors": [
+        "Ricardo Costa <ricardo.costa@guardian.co.uk>"
+    ],
     "license": "Apache-2.0",
     "devDependencies": {
         "@types/jest": "^24.0.16",


### PR DESCRIPTION
- Inverted the order of the two commands ran by prepublishOnly
- Added myself to contributors
- Added eslint to vscode suggested plugins
- Added `@typescript-eslint/prefer-interface` lint rule