### PR TITLE
Use js-cookie library

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
-        "build": "tsc --esModuleInterop",
+        "build": "tsc",
         "test": "jest --config jestconfig.json",
         "lint": "eslint src/**/*.ts",
-        "tsc": "tsc --esModuleInterop --noEmit",
+        "tsc": "tsc --noEmit",
         "validate": "yarn tsc && yarn lint && yarn test",
         "fix": "yarn validate --fix"
     },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc --esModuleInterop",
         "test": "jest --config jestconfig.json",
         "lint": "eslint src/**/*.ts",
-        "tsc": "tsc --noEmit",
+        "tsc": "tsc --esModuleInterop --noEmit",
         "validate": "yarn tsc && yarn lint && yarn test",
         "fix": "yarn validate --fix"
     },
@@ -24,7 +24,11 @@
         "Ricardo Costa <ricardo.costa@guardian.co.uk>"
     ],
     "license": "Apache-2.0",
+    "dependencies": {
+        "js-cookie": "^2.2.1"
+    },
     "devDependencies": {
+        "@types/js-cookie": "^2.2.2",
         "@types/jest": "^24.0.16",
         "@typescript-eslint/eslint-plugin": "^1.13.0",
         "@typescript-eslint/parser": "^1.13.0",

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,4 +1,4 @@
-import { addCookie, getCookie, _ } from './cookies';
+import { addCookie, getCookie } from './cookies';
 
 // Mock the Date constructor to always return the beginning of time
 const OriginalDate = global.Date;
@@ -32,6 +32,7 @@ describe('Cookies', () => {
 
     afterAll(() => {
         global.Date = OriginalDate;
+
         expect(new Date().toString()).not.toMatch(
             new RegExp('Thu Jan 01 1970'),
         );
@@ -41,35 +42,18 @@ describe('Cookies', () => {
         cookieValue = '';
     });
 
-    describe('isValidCookieValue', () => {
-        const { isValidCookieValue } = _;
-        it('should be able to detect malformed cookies', () => {
-            expect(isValidCookieValue('bad,cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad;cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad  cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad=cookie')).toBeFalsy();
-        });
-
-        it('should be able to detect good cookies', () => {
-            expect(isValidCookieValue('good-cookie')).toBeTruthy();
-            expect(isValidCookieValue('cool.cookie')).toBeTruthy();
-        });
-    });
-
     it('should be able to set a cookie', () => {
         addCookie('cookie-1-name', 'cookie-1-value');
         expect(document.cookie).toMatch(
-            new RegExp(
-                'cookie-1-name=cookie-1-value; path=/; expires=Mon, 01 Jun 1970 00:00:00 GMT; domain=.theguardian.com',
-            ),
+            'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
         );
     });
 
     it('should be able to set a cookie for a specific number of days', () => {
-        addCookie('cookie-1-name', 'cookie-1-value', 7);
-        expect(document.cookie).toEqual(
-            'cookie-1-name=cookie-1-value; path=/; expires=Thu, 08 Jan 1970 00:00:00 GMT; domain=.theguardian.com',
+        addCookie('cookie-1-name', 'cookie-1-value', 1);
+
+        expect(document.cookie).toMatch(
+            'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com; expires=Thu, 01 Jan 1970 00:00:00 GMT',
         );
     });
 

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -43,17 +43,27 @@ describe('Cookies', () => {
     });
 
     it('should be able to set a cookie', () => {
-        addCookie('cookie-1-name', 'cookie-1-value');
+        addCookie('cookie-1-name', {
+            foo: 'bar',
+            bar: 'foo',
+        });
         expect(document.cookie).toMatch(
-            'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
+            'cookie-1-name={%22foo%22:%22bar%22%2C%22bar%22:%22foo%22}; path=/; domain=.theguardian.com',
         );
     });
 
     it('should be able to set a cookie for a specific number of days', () => {
-        addCookie('cookie-1-name', 'cookie-1-value', 1);
+        addCookie(
+            'cookie-1-name',
+            {
+                foo: 'bar',
+                bar: 'foo',
+            },
+            1,
+        );
 
         expect(document.cookie).toMatch(
-            'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com; expires=Thu, 01 Jan 1970 00:00:00 GMT',
+            'cookie-1-name={%22foo%22:%22bar%22%2C%22bar%22:%22foo%22}; path=/; domain=.theguardian.com; expires=Thu, 01 Jan 1970 00:00:00 GMT',
         );
     });
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,6 +1,4 @@
-// subset of https://github.com/guzzle/guzzle/pull/1131
-const isValidCookieValue = (name: string): boolean =>
-    !/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+import * as Cookies from 'js-cookie';
 
 const getShortDomain = (): string => {
     const domain = document.domain || '';
@@ -15,56 +13,25 @@ const getShortDomain = (): string => {
 
 const getDomainAttribute = (): string => {
     const shortDomain = getShortDomain();
-    return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+
+    return shortDomain === 'localhost' ? '' : shortDomain;
 };
 
 const addCookie = (name: string, value: string, daysToLive?: number): void => {
-    const expires = new Date();
-
-    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-        return;
-    }
+    const options: {
+        domain: string;
+        expires?: number;
+    } = {
+        domain: getDomainAttribute(),
+    };
 
     if (daysToLive) {
-        expires.setDate(expires.getDate() + daysToLive);
-    } else {
-        expires.setMonth(expires.getMonth() + 5);
-        expires.setDate(1);
+        options.expires = daysToLive;
     }
 
-    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
+    Cookies.set(name, value, options);
 };
 
-const getCookieValues = (name: string): string[] => {
-    const nameEq = `${name}=`;
-    const cookies = document.cookie.split(';');
-
-    return cookies.reduce((acc: string[], cookie: string): string[] => {
-        const cookieTrimmed = cookie.trim();
-
-        if (cookieTrimmed.indexOf(nameEq) === 0) {
-            acc.push(
-                cookieTrimmed.substring(nameEq.length, cookieTrimmed.length),
-            );
-        }
-
-        return acc;
-    }, []);
-};
-
-const getCookie = (name: string): string | null => {
-    const cookieVal = getCookieValues(name);
-
-    if (cookieVal.length > 0) {
-        return cookieVal[0];
-    }
-
-    return null;
-};
+const getCookie = (name: string): string | void => Cookies.get(name);
 
 export { addCookie, getCookie };
-
-// Export for testing purposes
-export const _ = {
-    isValidCookieValue,
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/js-cookie@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.2.tgz#84e8848e14d44418726ceb52dd887c7bfe45d678"
+  integrity sha512-vkuGzldF9mNsWS9cmmMFfW1rufa7IdPUorS150gKoU/2fzLJ/0LXiMMtRqIBWz0sZ/VF2VxwB25WXEOo6akU6w==
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -2473,6 +2478,11 @@ jest@^24.8.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR introdices the js-cookie library. This provides a simple API for saving and retrieving cookies, it is lightweight (g-zipped ~1.1k) and it ensures the values saved are [RFC-6265](https://tools.ietf.org/html/rfc6265#section-4.1.1) compliant.