### PR TITLE
Update interface of cookies.ts

### DIFF
--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,77 +1,74 @@
-import { addCookie, getCookie } from './cookies';
+import * as _Cookies from 'js-cookie';
+import {
+    readGuCookie,
+    readIabCookie,
+    writeGuCookie,
+    writeIabCookie,
+    _,
+} from './cookies';
 
-// Mock the Date constructor to always return the beginning of time
-const OriginalDate = global.Date;
+const Cookies = _Cookies;
 
-global.Date = jest.fn(() => new OriginalDate(0));
+const { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } = _;
+
+jest.mock('js-cookie', () => ({
+    set: jest.fn(),
+    get: jest.fn(),
+}));
 
 describe('Cookies', () => {
-    let cookieValue = '';
+    const consentState = {
+        foo: true,
+        bar: false,
+    };
+    const cookieOptions = {
+        domain: '.theguardian.com',
+        expires: COOKIE_MAX_AGE,
+    };
 
     beforeAll(() => {
         Object.defineProperty(document, 'domain', {
             value: 'www.theguardian.com',
         });
-
-        Object.defineProperty(document, 'cookie', {
-            get() {
-                return cookieValue
-                    .replace('|', ';')
-                    .replace(/^[;|]|[;|]$/g, '');
-            },
-            set(value) {
-                const name = value.split('=')[0];
-                const newVal = cookieValue
-                    .split('|')
-                    .filter(cookie => cookie.split('=')[0] !== name);
-                newVal.push(value);
-                cookieValue = newVal.join('|');
-            },
-        });
     });
 
-    afterAll(() => {
-        global.Date = OriginalDate;
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
 
-        expect(new Date().toString()).not.toMatch(
-            new RegExp('Thu Jan 01 1970'),
+    it('should be able to set the GU cookie', () => {
+        writeGuCookie(consentState);
+
+        expect(Cookies.set).toHaveBeenCalledTimes(1);
+        expect(Cookies.set).toHaveBeenCalledWith(
+            GU_COOKIE_NAME,
+            consentState,
+            cookieOptions,
         );
     });
 
-    beforeEach(() => {
-        cookieValue = '';
-    });
+    it('should be able to set the IAB cookie', () => {
+        writeIabCookie(consentState);
 
-    it('should be able to set a cookie', () => {
-        addCookie('cookie-1-name', {
-            foo: 'bar',
-            bar: 'foo',
-        });
-        expect(document.cookie).toMatch(
-            'cookie-1-name={%22foo%22:%22bar%22%2C%22bar%22:%22foo%22}; path=/; domain=.theguardian.com',
+        expect(Cookies.set).toHaveBeenCalledTimes(1);
+        expect(Cookies.set).toHaveBeenCalledWith(
+            IAB_COOKIE_NAME,
+            consentState,
+            cookieOptions,
         );
     });
 
-    it('should be able to set a cookie for a specific number of days', () => {
-        addCookie(
-            'cookie-1-name',
-            {
-                foo: 'bar',
-                bar: 'foo',
-            },
-            1,
-        );
+    it('should be able to read the GU cookie', () => {
+        readGuCookie();
 
-        expect(document.cookie).toMatch(
-            'cookie-1-name={%22foo%22:%22bar%22%2C%22bar%22:%22foo%22}; path=/; domain=.theguardian.com; expires=Thu, 01 Jan 1970 00:00:00 GMT',
-        );
+        expect(Cookies.get).toHaveBeenCalledTimes(1);
+        expect(Cookies.get).toHaveBeenCalledWith(GU_COOKIE_NAME);
     });
 
-    it('should be able to get a cookie', () => {
-        document.cookie =
-            'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
-        expect(getCookie('s_vi')).toEqual(
-            '[CS]v1|29AB343C05013259-4000014980021C3D[CE]',
-        );
+    it('should be able to read the IAB cookie', () => {
+        readIabCookie();
+
+        expect(Cookies.get).toHaveBeenCalledTimes(1);
+        expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
     });
 });

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -14,10 +14,11 @@ const { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } = _;
 jest.mock('js-cookie', () => ({
     set: jest.fn(),
     get: jest.fn(),
+    getJSON: jest.fn(),
 }));
 
 describe('Cookies', () => {
-    const consentState = {
+    const guConsentState = {
         foo: true,
         bar: false,
     };
@@ -25,6 +26,7 @@ describe('Cookies', () => {
         domain: '.theguardian.com',
         expires: COOKIE_MAX_AGE,
     };
+    const iabConsentString = 'heL10W0rLd';
 
     beforeAll(() => {
         Object.defineProperty(document, 'domain', {
@@ -37,38 +39,64 @@ describe('Cookies', () => {
     });
 
     it('should be able to set the GU cookie', () => {
-        writeGuCookie(consentState);
+        writeGuCookie(guConsentState);
 
         expect(Cookies.set).toHaveBeenCalledTimes(1);
         expect(Cookies.set).toHaveBeenCalledWith(
             GU_COOKIE_NAME,
-            consentState,
+            guConsentState,
             cookieOptions,
         );
     });
 
     it('should be able to set the IAB cookie', () => {
-        writeIabCookie(consentState);
+        writeIabCookie(iabConsentString);
 
         expect(Cookies.set).toHaveBeenCalledTimes(1);
         expect(Cookies.set).toHaveBeenCalledWith(
             IAB_COOKIE_NAME,
-            consentState,
+            iabConsentString,
             cookieOptions,
         );
     });
 
     it('should be able to read the GU cookie', () => {
-        readGuCookie();
+        Cookies.getJSON.mockImplementation(() => guConsentState);
 
-        expect(Cookies.get).toHaveBeenCalledTimes(1);
-        expect(Cookies.get).toHaveBeenCalledWith(GU_COOKIE_NAME);
+        const guCookie = readGuCookie();
+
+        expect(Cookies.getJSON).toHaveBeenCalledTimes(1);
+        expect(Cookies.getJSON).toHaveBeenCalledWith(GU_COOKIE_NAME);
+        expect(guCookie).toBe(guConsentState);
     });
 
     it('should be able to read the IAB cookie', () => {
-        readIabCookie();
+        Cookies.get.mockImplementation(() => iabConsentString);
+
+        const iabCookie = readIabCookie();
 
         expect(Cookies.get).toHaveBeenCalledTimes(1);
         expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
+        expect(iabCookie).toBe(iabConsentString);
+    });
+
+    it('returns null if no GU cookie', () => {
+        Cookies.getJSON.mockImplementation(() => undefined);
+
+        const guCookie = readGuCookie();
+
+        expect(Cookies.getJSON).toHaveBeenCalledTimes(1);
+        expect(Cookies.getJSON).toHaveBeenCalledWith(GU_COOKIE_NAME);
+        expect(guCookie).toBeNull();
+    });
+
+    it('returns null if no IAB cookie', () => {
+        Cookies.get.mockImplementation(() => undefined);
+
+        const iabCookie = readIabCookie();
+
+        expect(Cookies.get).toHaveBeenCalledTimes(1);
+        expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
+        expect(iabCookie).toBeNull();
     });
 });

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -33,26 +33,18 @@ const addCookie = (name: string, value: string | GuPurposeState): void => {
     Cookies.set(name, value, options);
 };
 
-const getCookie = (name: string): string | undefined => Cookies.get(name);
+// const getCookie = (name: string): string | undefined => Cookies.get(name);
 
 const readGuCookie = (): GuPurposeState | null => {
-    const cookie = getCookie(GU_COOKIE_NAME);
+    const cookie = Cookies.getJSON(GU_COOKIE_NAME);
 
-    if (!cookie) {
-        return null;
-    }
-
-    return JSON.parse(cookie);
+    return cookie || null;
 };
 
 const readIabCookie = (): string | null => {
-    const cookie = getCookie(IAB_COOKIE_NAME);
+    const cookie = Cookies.get(IAB_COOKIE_NAME);
 
-    if (!cookie) {
-        return null;
-    }
-
-    return cookie;
+    return cookie || null;
 };
 
 const writeGuCookie = (guState: GuPurposeState): void =>

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,5 +1,9 @@
 import * as Cookies from 'js-cookie';
 
+const GU_COOKIE_NAME = 'guconsent';
+const IAB_COOKIE_NAME = 'euconsent';
+const COOKIE_MAX_AGE = 395; // 13 months
+
 const getShortDomain = (): string => {
     const domain = document.domain || '';
 
@@ -17,21 +21,51 @@ const getDomainAttribute = (): string => {
     return shortDomain === 'localhost' ? '' : shortDomain;
 };
 
-const addCookie = (name: string, value: string, daysToLive?: number): void => {
+const addCookie = (name: string, value: string | GuPurposeState): void => {
     const options: {
         domain: string;
-        expires?: number;
+        expires: number;
     } = {
         domain: getDomainAttribute(),
+        expires: COOKIE_MAX_AGE,
     };
-
-    if (daysToLive) {
-        options.expires = daysToLive;
-    }
 
     Cookies.set(name, value, options);
 };
 
-const getCookie = (name: string): string | void => Cookies.get(name);
+const getCookie = (name: string): string | undefined => Cookies.get(name);
 
-export { addCookie, getCookie };
+const readGuCookie = (): GuPurposeState | null => {
+    const cookie = getCookie(GU_COOKIE_NAME);
+
+    if (!cookie) {
+        return null;
+    }
+
+    return JSON.parse(cookie);
+};
+
+const readIabCookie = (): string | null => {
+    const cookie = getCookie(IAB_COOKIE_NAME);
+
+    if (!cookie) {
+        return null;
+    }
+
+    return cookie;
+};
+
+const writeGuCookie = (guState: GuPurposeState): void =>
+    addCookie(GU_COOKIE_NAME, guState);
+
+const writeIabCookie = (iabString: string): void =>
+    addCookie(IAB_COOKIE_NAME, iabString);
+
+export { readGuCookie, readIabCookie, writeGuCookie, writeIabCookie };
+
+// exposed for testing purpose
+export const _ = {
+    GU_COOKIE_NAME,
+    IAB_COOKIE_NAME,
+    COOKIE_MAX_AGE,
+};

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -33,8 +33,6 @@ const addCookie = (name: string, value: string | GuPurposeState): void => {
     Cookies.set(name, value, options);
 };
 
-// const getCookie = (name: string): string | undefined => Cookies.get(name);
-
 const readGuCookie = (): GuPurposeState | null => {
     const cookie = Cookies.getJSON(GU_COOKIE_NAME);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,3 @@
+interface GuPurposeState {
+    [key: string]: boolean | null;
+}


### PR DESCRIPTION
Update interface of cookies.ts to expose 4 functions:

- readGuCookie
- readIabCookie
- writeGuCookie
- writeIabCookie

Inspired by https://github.com/guardian/manage-frontend/pull/261