### PR TITLE
Introduce cmp module to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,28 @@
 
 Welcome to the Consent Management Platform, a library of useful utilities for managing consent state across \*.theguardian.com.
 
-## Development prerequisites
+## What useful utilities does this offer?
 
-### Node.js
+### cmp
 
-Make sure you have installed [Node.js](https://nodejs.org). Our reccommended version is `10.15.3`.
+If you need to conditionally run some code based on a user's consent state you can use the `cmp` module.
 
-We recommend using [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
+This module exposes a function `onConsentNotification`. This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code your running eg. "functional", "performance" or "advertisement", and the second is a callback (a `function`).
 
-### Yarn
+When `onConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which inidicates the users consent state at that time for the given purpose name.
 
-We use [Yarn](https://yarnpkg.com/en/) for managing our dependencies. Our reccommended version is `1.17.3`.
+The `cmp` module also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument (a `boolean` or `null`) which inidicates the user's updated consent state for the given purpose name.
 
-## Running instructions
+#### cmp example
 
-```
-$ git clone git@github.com:guardian/consent-management-platform.git
-$ cd consent-management-platform
-$ yarn
-```
+```js
+import { onConsentNotification } from 'consent-management-platform/cmp';
 
-## Code Quality
-
-You can ensure your code passes code quality tests by running:
-
-```
-$ yarn validate
+onConsentNotification('functional', functionalConsentState => {
+    console.log(functionalConsentState); // true || false || null
+});
 ```
 
-This runs our linting tool, the TypeScript compiler and our tests.
+## Developer instructions
 
-You can also run these tasks individually:
-
-```
-$ yarn lint
-$ yarn tsc
-$ yarn test
-```
-
-If you get lint errors, you can attempt to automatically fix them with:
-
-```
-$ yarn fix
-```
-
-## IDE setup
-
-We recommend using [VSCode](https://code.visualstudio.com/).
-
-### Extensions
-
-VSCode should prompt you to install our recommended extensions when you open the project.
-
-You can also find these extensions by searching for `@recommended` in the extensions pane.
+If you're looking to develop on the `consent-management-platform` please read our [development instructions](docs/01-development-instructions.md) document.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `cmp` module also listens for subsequent changes to the user's consent state
 #### cmp example
 
 ```js
-import { onConsentNotification } from 'consent-management-platform/cmp';
+import { onConsentNotification } from 'consent-management-platform';
 
 onConsentNotification('functional', functionalConsentState => {
     console.log(functionalConsentState); // true || false || null

--- a/docs/01-development-instructions.md
+++ b/docs/01-development-instructions.md
@@ -1,0 +1,55 @@
+# Development instructions
+
+## Prerequisites
+
+### Node.js
+
+Make sure you have installed [Node.js](https://nodejs.org). Our reccommended version is `10.15.3`.
+
+We recommend using [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
+
+### Yarn
+
+We use [Yarn](https://yarnpkg.com/en/) for managing our dependencies. Our reccommended version is `1.17.3`.
+
+## Running instructions
+
+```
+$ git clone git@github.com:guardian/consent-management-platform.git
+$ cd consent-management-platform
+$ yarn
+```
+
+## Code Quality
+
+You can ensure your code passes code quality tests by running:
+
+```
+$ yarn validate
+```
+
+This runs our linting tool, the TypeScript compiler and our tests.
+
+You can also run these tasks individually:
+
+```
+$ yarn lint
+$ yarn tsc
+$ yarn test
+```
+
+If you get lint errors, you can attempt to automatically fix them with:
+
+```
+$ yarn fix
+```
+
+## IDE setup
+
+We recommend using [VSCode](https://code.visualstudio.com/).
+
+### Extensions
+
+VSCode should prompt you to install our recommended extensions when you open the project.
+
+You can also find these extensions by searching for `@recommended` in the extensions pane.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "consent-management-platform",
+    "name": "@guardian/consent-management-platform",
     "version": "1.0.0-alpha.1",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
@@ -10,7 +10,8 @@
         "lint": "eslint src/**/*.ts",
         "tsc": "tsc --noEmit",
         "validate": "yarn tsc && yarn lint && yarn test",
-        "fix": "yarn validate --fix"
+        "fix": "yarn validate --fix",
+        "prepublishOnly": "yarn validate && yarn build"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "@guardian/consent-management-platform",
     "version": "1.0.0-alpha.1",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
+    "main": "lib/cmp.js",
+    "types": "lib/cmp.d.ts",
     "scripts": {
         "build": "tsc",
         "test": "jest --config jestconfig.json",

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -4,9 +4,7 @@ import { onConsentNotification, _ } from './cmp';
 const Cookies = _Cookies;
 
 jest.mock('js-cookie', () => ({
-    set: jest.fn(),
     get: jest.fn(),
-    getJSON: jest.fn(),
 }));
 
 describe('cmp', () => {

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -1,0 +1,106 @@
+import * as _Cookies from 'js-cookie';
+import { onConsentNotification, _ } from './cmp';
+
+const Cookies = _Cookies;
+
+jest.mock('js-cookie', () => ({
+    set: jest.fn(),
+    get: jest.fn(),
+    getJSON: jest.fn(),
+}));
+
+describe('cmp', () => {
+    beforeEach(() => {
+        _.resetCmp();
+        jest.resetAllMocks();
+    });
+
+    describe('onConsentNotification', () => {
+        const purposes = ['functional', 'performance', 'advertisement'];
+
+        describe('if cmpIsReady is TRUE when onConsentNotification called', () => {
+            purposes.forEach(purpose => {
+                it(`executes ${purpose} callback immediately`, () => {
+                    const myCallBack = jest.fn();
+
+                    onConsentNotification(purpose, myCallBack);
+
+                    expect(myCallBack).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            it('executes functional callback with initial functional state', () => {
+                const myCallBack = jest.fn();
+
+                onConsentNotification('functional', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes performance callback with initial performance state', () => {
+                const myCallBack = jest.fn();
+
+                onConsentNotification('performance', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
+                Cookies.get.mockReturnValue('1.54321');
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
+                Cookies.get.mockReturnValue('0.54321');
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(false);
+            });
+
+            it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
+                Cookies.get.mockReturnValue(undefined);
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(null);
+            });
+
+            it('executes advertisement callback each time consent nofication triggered', () => {
+                Cookies.get.mockReturnValue('1.54321');
+
+                const myCallBack = jest.fn();
+                const expectedArguments = [[true]];
+
+                onConsentNotification('advertisement', myCallBack);
+
+                const triggerCount = 5;
+
+                /**
+                 * TODO: Once the module under test handles
+                 * updates to state we should update this test
+                 * to handle 5 updates to state (with differing values)
+                 * rather than triggering consent notifications manually
+                 * so we can test the callback is receiving the correct
+                 * latest state.
+                 */
+                for (let i = 0; i < triggerCount; i += 1) {
+                    _.triggerConsentNotification();
+                    expectedArguments.push([true]);
+                }
+
+                expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
+                expect(myCallBack.mock.calls).toEqual(expectedArguments);
+            });
+        });
+    });
+});

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,8 +1,5 @@
 import * as Cookies from 'js-cookie';
-
-const CMP_DOMAIN = 'https://manage.theguardian.com';
-const CMP_SAVED_MSG = 'savedCmp';
-const GU_AD_CONSENT_COOKIE = 'GU_TK';
+import { CMP_DOMAIN, CMP_SAVED_MSG, GU_AD_CONSENT_COOKIE } from './config';
 
 let cmpIsReady = false;
 

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,0 +1,106 @@
+import * as Cookies from 'js-cookie';
+
+const CMP_DOMAIN = 'https://manage.theguardian.com';
+const CMP_SAVED_MSG = 'savedCmp';
+const GU_AD_CONSENT_COOKIE = 'GU_TK';
+
+let cmpIsReady = false;
+
+const purposes: { [key in PurposeEvent]: Purpose } = {
+    functional: {
+        state: null,
+        callbacks: [],
+    },
+    performance: {
+        state: null,
+        callbacks: [],
+    },
+    advertisement: {
+        state: null,
+        callbacks: [],
+    },
+};
+
+const triggerConsentNotification = (): void => {
+    Object.keys(purposes).forEach((key: string): void => {
+        const purpose = purposes[key as PurposeEvent];
+        purpose.callbacks.forEach((callback: PurposeCallback): void =>
+            callback(purpose.state),
+        );
+    });
+};
+
+const receiveMessage = (event: MessageEvent): void => {
+    const { origin, data } = event;
+
+    // triggerConsentNotification when CMP_SAVED_MSG emitted from CMP_DOMAIN
+    if (origin === CMP_DOMAIN && data === CMP_SAVED_MSG) {
+        triggerConsentNotification();
+    }
+};
+
+const getAdConsentState = (): boolean | null => {
+    const cookie = Cookies.get(GU_AD_CONSENT_COOKIE);
+
+    if (!cookie) {
+        return null;
+    }
+
+    const cookieParsed = cookie.split('.')[0];
+
+    if (cookieParsed === '1') {
+        return true;
+    }
+
+    if (cookieParsed === '0') {
+        return false;
+    }
+
+    return null;
+};
+
+const checkCmpReady = (): void => {
+    if (cmpIsReady) {
+        return;
+    }
+
+    /**
+     * These state assignments are temporary
+     * and will eventually be replaced by values
+     * read from the CMP cookie.
+     * */
+    purposes.functional.state = true;
+    purposes.performance.state = true;
+    purposes.advertisement.state = getAdConsentState();
+
+    // listen for postMessage events from CMP UI
+    window.addEventListener('message', receiveMessage, false);
+
+    cmpIsReady = true;
+};
+
+export const onConsentNotification = (
+    purposeName: PurposeEvent,
+    callback: PurposeCallback,
+): void => {
+    checkCmpReady();
+
+    const purpose = purposes[purposeName];
+
+    callback(purpose.state);
+
+    purpose.callbacks.push(callback);
+};
+
+// Exposed for testing purposes
+export const _ = {
+    triggerConsentNotification,
+    resetCmp: (): void => {
+        cmpIsReady = false;
+        Object.keys(purposes).forEach((key: string): void => {
+            const purpose = purposes[key as PurposeEvent];
+            purpose.state = null;
+            purpose.callbacks = [];
+        });
+    },
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+export const CMP_DOMAIN = 'https://manage.theguardian.com';
+export const CMP_SAVED_MSG = 'savedCmp';
+export const GU_AD_CONSENT_COOKIE = 'GU_TK';
+export const GU_COOKIE_NAME = 'guconsent';
+export const IAB_COOKIE_NAME = 'euconsent';
+export const COOKIE_MAX_AGE = 395; // 13 months

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -4,12 +4,10 @@ import {
     readIabCookie,
     writeGuCookie,
     writeIabCookie,
-    _,
 } from './cookies';
+import { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } from './config';
 
 const Cookies = _Cookies;
-
-const { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } = _;
 
 jest.mock('js-cookie', () => ({
     set: jest.fn(),

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,8 +1,5 @@
 import * as Cookies from 'js-cookie';
-
-const GU_COOKIE_NAME = 'guconsent';
-const IAB_COOKIE_NAME = 'euconsent';
-const COOKIE_MAX_AGE = 395; // 13 months
+import { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } from './config';
 
 const getShortDomain = (): string => {
     const domain = document.domain || '';
@@ -52,10 +49,3 @@ const writeIabCookie = (iabString: string): void =>
     addCookie(IAB_COOKIE_NAME, iabString);
 
 export { readGuCookie, readIabCookie, writeGuCookie, writeIabCookie };
-
-// exposed for testing purpose
-export const _ = {
-    GU_COOKIE_NAME,
-    IAB_COOKIE_NAME,
-    COOKIE_MAX_AGE,
-};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,12 @@
 interface GuPurposeState {
     [key: string]: boolean | null;
 }
+
+type PurposeEvent = 'functional' | 'performance' | 'advertisement';
+
+type PurposeCallback = (state: boolean | null) => void;
+
+interface Purpose {
+    state: boolean | null;
+    callbacks: PurposeCallback[];
+}


### PR DESCRIPTION
This PR copies the `cmp` module from frontend into the library (earlier PR adding it to frontend is here: https://github.com/guardian/frontend/pull/21705).  The plan is to remove it from frontend and start using the library in it's place.

