### PR TITLE
Add types and variables needed for CMP UI

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,3 +12,52 @@ export const IAB_CONSENT_LANGUAGE = 'en';
 export const CMP_READY_MSG = 'readyCmp';
 export const CMP_SAVED_MSG = 'savedCmp';
 export const CMP_CLOSE_MSG = 'closeCmp';
+export const GU_PURPOSE_LIST: GuPurposeList = {
+    purposes: [
+        {
+            id: 0,
+            name: 'Essential',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            integrations: [
+                {
+                    name: 'Ophan',
+                    policyUrl: 'https://www.theguardian.com/info/privacy',
+                },
+                {
+                    name: 'Confiant',
+                    policyUrl: 'https://www.confiant.com/privacy',
+                },
+            ],
+            hideRadio: true,
+        },
+        {
+            id: 1,
+            name: 'Functional',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque quis malesuada ante.',
+            integrations: [
+                {
+                    name: 'Pinterest',
+                    policyUrl: 'https://policy.pinterest.com/',
+                },
+            ],
+        },
+        {
+            id: 2,
+            name: 'Performance',
+            description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque quis malesuada ante. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.',
+            integrations: [
+                {
+                    name: 'Sentry',
+                    policyUrl: 'https://sentry.io/privacy/',
+                },
+                {
+                    name: 'Google Analytics',
+                    policyUrl: 'https://policies.google.com/privacy?hl=en-US',
+                },
+            ],
+        },
+    ],
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,14 @@
 export const CMP_DOMAIN = 'https://manage.theguardian.com';
-export const CMP_SAVED_MSG = 'savedCmp';
+export const COOKIE_MAX_AGE = 395; // 13 months
 export const GU_AD_CONSENT_COOKIE = 'GU_TK';
 export const GU_COOKIE_NAME = 'guconsent';
+export const IAB_VENDOR_LIST_URL =
+    'https://assets.guim.co.uk/data/vendor/4f4a6324c7fe376c17ceb2288a84a076/cmp_vendorlist.json';
 export const IAB_COOKIE_NAME = 'euconsent';
-export const COOKIE_MAX_AGE = 395; // 13 months
+export const IAB_CMP_ID = 112;
+export const IAB_CMP_VERSION = 1;
+export const IAB_CONSENT_SCREEN = 0;
+export const IAB_CONSENT_LANGUAGE = 'en';
+export const CMP_READY_MSG = 'readyCmp';
+export const CMP_SAVED_MSG = 'savedCmp';
+export const CMP_CLOSE_MSG = 'closeCmp';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,3 @@
-interface GuPurposeState {
-    [key: string]: boolean | null;
-}
-
 type PurposeEvent = 'functional' | 'performance' | 'advertisement';
 
 type PurposeCallback = (state: boolean | null) => void;
@@ -9,4 +5,58 @@ type PurposeCallback = (state: boolean | null) => void;
 interface Purpose {
     state: boolean | null;
     callbacks: PurposeCallback[];
+}
+
+interface GuPurposeState {
+    [key: string]: boolean | null;
+}
+
+interface GuPurposeList {
+    purposes: GuPurpose[];
+}
+
+interface GuPurpose {
+    id: number;
+    name: string;
+    description: string;
+    integrations: GuIntegration[];
+    hideRadio?: boolean;
+}
+
+interface GuIntegration {
+    name: string;
+    policyUrl: string;
+}
+
+interface IabPurposeState {
+    [key: number]: boolean | null;
+}
+
+interface IabPurpose {
+    id: number;
+    name: string;
+    description: string;
+}
+
+interface IabFeature {
+    id: number;
+    name: string;
+    description: string;
+}
+
+interface IabVendor {
+    id: number;
+    name: string;
+    policyUrl: string;
+    purposeIds: number[];
+    legIntPurposeIds: number[];
+    featureIds: number[];
+}
+
+interface IabVendorList {
+    vendorListVersion: number;
+    lastUpdated: string;
+    purposes: IabPurpose[];
+    features: IabFeature[];
+    vendors: IabVendor[];
 }


### PR DESCRIPTION
Adding shared types and variables that currently live in manage-frontend so that the CMP UI can instead import them from this library.