### PR TITLE
Bump version to 0.1.0-alpha2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "0.1.0-alpha.1",
+    "version": "0.1.0-alpha.2",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/cmp.js",
     "types": "lib/cmp.d.ts",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc && cp src/index.d.ts lib/",
         "test": "jest --config jestconfig.json",
         "lint": "eslint src/**/*.ts",
         "tsc": "tsc --noEmit",


### PR DESCRIPTION
Bumps version to 0.1.0-alpha2 as well as update the build command so the type definition is included in the build. 