### PR TITLE
Introduce version number to GU cookie

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export const CMP_DOMAIN = cmpDomain();
 export const COOKIE_MAX_AGE = 395; // 13 months
 export const GU_AD_CONSENT_COOKIE = 'GU_TK';
 export const GU_COOKIE_NAME = 'guconsent';
+export const GU_COOKIE_VERSION = 1;
 export const IAB_VENDOR_LIST_URL =
     'https://www.theguardian.com/commercial/cmp/vendorlist.json';
 export const IAB_COOKIE_NAME = 'euconsent';

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -5,7 +5,12 @@ import {
     writeGuCookie,
     writeIabCookie,
 } from './cookies';
-import { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } from './config';
+import {
+    GU_COOKIE_NAME,
+    GU_COOKIE_VERSION,
+    IAB_COOKIE_NAME,
+    COOKIE_MAX_AGE,
+} from './config';
 
 const Cookies = _Cookies;
 
@@ -19,6 +24,10 @@ describe('Cookies', () => {
     const guConsentState = {
         foo: true,
         bar: false,
+    };
+    const guCookie = {
+        version: GU_COOKIE_VERSION,
+        state: guConsentState,
     };
     const cookieOptions = {
         domain: '.theguardian.com',
@@ -42,7 +51,7 @@ describe('Cookies', () => {
         expect(Cookies.set).toHaveBeenCalledTimes(1);
         expect(Cookies.set).toHaveBeenCalledWith(
             GU_COOKIE_NAME,
-            guConsentState,
+            guCookie,
             cookieOptions,
         );
     });
@@ -59,42 +68,42 @@ describe('Cookies', () => {
     });
 
     it('should be able to read the GU cookie', () => {
-        Cookies.getJSON.mockImplementation(() => guConsentState);
+        Cookies.getJSON.mockImplementation(() => guCookie);
 
-        const guCookie = readGuCookie();
+        const readCookie = readGuCookie();
 
         expect(Cookies.getJSON).toHaveBeenCalledTimes(1);
         expect(Cookies.getJSON).toHaveBeenCalledWith(GU_COOKIE_NAME);
-        expect(guCookie).toBe(guConsentState);
+        expect(readCookie).toBe(guConsentState);
     });
 
     it('should be able to read the IAB cookie', () => {
         Cookies.get.mockImplementation(() => iabConsentString);
 
-        const iabCookie = readIabCookie();
+        const readCookie = readIabCookie();
 
         expect(Cookies.get).toHaveBeenCalledTimes(1);
         expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
-        expect(iabCookie).toBe(iabConsentString);
+        expect(readCookie).toBe(iabConsentString);
     });
 
     it('returns null if no GU cookie', () => {
         Cookies.getJSON.mockImplementation(() => undefined);
 
-        const guCookie = readGuCookie();
+        const readCookie = readGuCookie();
 
         expect(Cookies.getJSON).toHaveBeenCalledTimes(1);
         expect(Cookies.getJSON).toHaveBeenCalledWith(GU_COOKIE_NAME);
-        expect(guCookie).toBeNull();
+        expect(readCookie).toBeNull();
     });
 
     it('returns null if no IAB cookie', () => {
         Cookies.get.mockImplementation(() => undefined);
 
-        const iabCookie = readIabCookie();
+        const readCookie = readIabCookie();
 
         expect(Cookies.get).toHaveBeenCalledTimes(1);
         expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
-        expect(iabCookie).toBeNull();
+        expect(readCookie).toBeNull();
     });
 });

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,6 +1,11 @@
 import * as Cookies from 'js-cookie';
-import { GuPurposeState } from './types';
-import { GU_COOKIE_NAME, IAB_COOKIE_NAME, COOKIE_MAX_AGE } from './config';
+import { GuCookie, GuPurposeState } from './types';
+import {
+    GU_COOKIE_NAME,
+    GU_COOKIE_VERSION,
+    IAB_COOKIE_NAME,
+    COOKIE_MAX_AGE,
+} from './config';
 
 const getShortDomain = (): string => {
     const domain = document.domain || '';
@@ -16,7 +21,7 @@ const getDomainAttribute = (): string => {
     return shortDomain === 'localhost' ? '' : shortDomain;
 };
 
-const addCookie = (name: string, value: string | GuPurposeState): void => {
+const addCookie = (name: string, value: string | GuCookie): void => {
     const options: {
         domain: string;
         expires: number;
@@ -31,7 +36,13 @@ const addCookie = (name: string, value: string | GuPurposeState): void => {
 const readGuCookie = (): GuPurposeState | null => {
     const cookie = Cookies.getJSON(GU_COOKIE_NAME);
 
-    return cookie || null;
+    if (cookie) {
+        if (cookie.version === 1) {
+            return cookie.state || null;
+        }
+    }
+
+    return null;
 };
 
 const readIabCookie = (): string | null => {
@@ -41,7 +52,7 @@ const readIabCookie = (): string | null => {
 };
 
 const writeGuCookie = (guState: GuPurposeState): void =>
-    addCookie(GU_COOKIE_NAME, guState);
+    addCookie(GU_COOKIE_NAME, { version: GU_COOKIE_VERSION, state: guState });
 
 const writeIabCookie = (iabString: string): void =>
     addCookie(IAB_COOKIE_NAME, iabString);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,11 @@ export interface Purpose {
     callbacks: PurposeCallback[];
 }
 
+export interface GuCookie {
+    version: number;
+    state: GuPurposeState;
+}
+
 export interface GuPurposeState {
     [key: string]: boolean | null;
 }


### PR DESCRIPTION
Introduce a version number to the GU cookie so we can differentiate between version if we want to change the cookie structure at a later date.