### PR TITLE
Replace boolean | null with ItemState type

### DIFF
--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,5 +1,5 @@
 import * as Cookies from 'js-cookie';
-import { Purpose, PurposeCallback, PurposeEvent } from './types';
+import { Purpose, PurposeCallback, PurposeEvent, ItemState } from './types';
 import { CMP_DOMAIN, CMP_SAVED_MSG, GU_AD_CONSENT_COOKIE } from './config';
 
 let cmpIsReady = false;
@@ -37,7 +37,7 @@ const receiveMessage = (event: MessageEvent): void => {
     }
 };
 
-const getAdConsentState = (): boolean | null => {
+const getAdConsentState = (): ItemState => {
     const cookie = Cookies.get(GU_AD_CONSENT_COOKIE);
 
     if (!cookie) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,16 @@
+export type ItemState = boolean | null;
+
 export type PurposeEvent = 'functional' | 'performance' | 'advertisement';
 
-export type PurposeCallback = (state: boolean | null) => void;
+export type PurposeCallback = (state: ItemState) => void;
 
 export interface Purpose {
-    state: boolean | null;
+    state: ItemState;
     callbacks: PurposeCallback[];
 }
 
 export interface GuPurposeState {
-    [key: string]: boolean | null;
+    [key: string]: ItemState;
 }
 
 export interface GuPurposeList {
@@ -29,7 +31,7 @@ export interface GuIntegration {
 }
 
 export interface IabPurposeState {
-    [key: number]: boolean | null;
+    [key: number]: ItemState;
 }
 
 export interface IabPurpose {


### PR DESCRIPTION
We use `boolean | null` for states in a lot of places. Better to have a type for it  instead of retyping it every time. Also better if we ever need to change this type.