### PR TITLE
Expose CMP_URL as a package constant

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ const cmpDomain = (): string => {
 };
 
 export const CMP_DOMAIN = cmpDomain();
+export const CMP_URL = `${CMP_DOMAIN}/consent`;
 export const COOKIE_MAX_AGE = 395; // 13 months
 export const GU_AD_CONSENT_COOKIE = 'GU_TK';
 export const GU_COOKIE_NAME = 'guconsent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,5 @@
 import {
-    CMP_DOMAIN,
-    COOKIE_MAX_AGE,
-    GU_AD_CONSENT_COOKIE,
-    GU_COOKIE_NAME,
-    IAB_VENDOR_LIST_URL,
-    IAB_COOKIE_NAME,
-    IAB_CMP_ID,
-    IAB_CMP_VERSION,
-    IAB_CONSENT_SCREEN,
-    IAB_CONSENT_LANGUAGE,
+    CMP_URL,
     CMP_READY_MSG,
     CMP_SAVED_MSG,
     CMP_CLOSE_MSG,
@@ -19,16 +10,7 @@ import * as cookie from './cookies';
 export * from './cmp';
 export const cmpCookie = cookie;
 export const cmpConfig = {
-    CMP_DOMAIN,
-    COOKIE_MAX_AGE,
-    GU_AD_CONSENT_COOKIE,
-    GU_COOKIE_NAME,
-    IAB_VENDOR_LIST_URL,
-    IAB_COOKIE_NAME,
-    IAB_CMP_ID,
-    IAB_CMP_VERSION,
-    IAB_CONSENT_SCREEN,
-    IAB_CONSENT_LANGUAGE,
+    CMP_URL,
     CMP_READY_MSG,
     CMP_SAVED_MSG,
     CMP_CLOSE_MSG,


### PR DESCRIPTION
...so that it's available to any platforms that need to show the CMP UI. Also removes some unnecessary items from the `cmpConfig` object we expose in the package.