### PR TITLE
Refactor cmp.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This module exposes two functions `onGuConsentNotification` and `onIabConsentNot
 
 #### onGuConsentNotification
 
-This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code your running eg. "functional", "performance", and the second is a callback (a `function`).
+This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code you're running eg. "functional" OR "performance", and the second is a callback (a `function`).
 
-When `onGuConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which indicates the users consent state at that time for the given purpose name.
+When `onGuConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which indicates the user's consent state at that time for the given purpose name.
 
 The `cmp` module also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument (a `boolean` or `null`) which inidicates the user's updated consent state for the given purpose name.
 
-##### onGuConsentNotification example
+**Example:**
 
 ```js
 import { onGuConsentNotification } from '@guardian/consent-management-platform';
@@ -40,18 +40,28 @@ When `onIabConsentNotification` is called it will execute the callback immediate
 }
 ```
 
-The keys in this object will match the IAB purpose IDs from the IAB vendor list.
+The keys in this object will match the IAB purpose IDs from the [IAB vendor list](https://vendorlist.consensu.org/vendorlist.json).
 
 The `cmp` module will also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument, an object which reflects the latest consent granted to the IAB purposes.
 
-##### onIabConsentNotification example
+**Example:**
 
 ```js
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 
 onIabConsentNotification(iabConsentState => {
-    console.log(iabConsentState); // { 0: true || false || null, 1: true || false || null, }
+    console.log(iabConsentState); // { 0: true || false || null, 1: true || false || null, ... }
 });
+```
+
+### cmpConfig
+
+The file `cmpConfig` exposes some useful config variables realted to the CMP.
+
+##### example:
+
+```js
+import { cmpConfig } from '@guardian/consent-management-platform';
 ```
 
 ## Developer instructions

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ onIabConsentNotification(iabConsentState => {
 
 ### cmpConfig
 
-The file `cmpConfig` exposes some useful config variables realted to the CMP.
+The file `cmpConfig` exposes some useful config variables related to the CMP.
 
 ##### example:
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,49 @@ Welcome to the Consent Management Platform, a library of useful utilities for ma
 
 If you need to conditionally run some code based on a user's consent state you can use the `cmp` module.
 
-This module exposes a function `onConsentNotification`. This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code your running eg. "functional", "performance" or "advertisement", and the second is a callback (a `function`).
+This module exposes two functions `onGuConsentNotification` and `onIabConsentNotification`.
 
-When `onConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which indicates the users consent state at that time for the given purpose name.
+#### onGuConsentNotification
+
+This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code your running eg. "functional", "performance", and the second is a callback (a `function`).
+
+When `onGuConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which indicates the users consent state at that time for the given purpose name.
 
 The `cmp` module also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument (a `boolean` or `null`) which inidicates the user's updated consent state for the given purpose name.
 
-#### cmp example
+##### onGuConsentNotification example
 
 ```js
-import { onConsentNotification } from '@guardian/consent-management-platform';
+import { onGuConsentNotification } from '@guardian/consent-management-platform';
 
-onConsentNotification('functional', functionalConsentState => {
+onGuConsentNotification('functional', functionalConsentState => {
     console.log(functionalConsentState); // true || false || null
+});
+```
+
+#### onIabConsentNotification
+
+This function takes 1 argument, a callback (a `function`).
+
+When `onIabConsentNotification` is called it will execute the callback immediately, passing it a single argument, an object which reflects the consent granted to the IAB purposes. The signature for this object will be:
+
+```
+{
+    [key: number]: boolean | null;
+}
+```
+
+The keys in this object will match the IAB purpose IDs from the IAB vendor list.
+
+The `cmp` module will also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument, an object which reflects the latest consent granted to the IAB purposes.
+
+##### onIabConsentNotification example
+
+```js
+import { onIabConsentNotification } from '@guardian/consent-management-platform';
+
+onIabConsentNotification(iabConsentState => {
+    console.log(iabConsentState); // { 0: true || false || null, 1: true || false || null, }
 });
 ```
 

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -1,5 +1,6 @@
 import * as _Cookies from 'js-cookie';
-import { onConsentNotification, _ } from './cmp';
+import { onGuConsentNotification, onIabConsentNotification, _ } from './cmp';
+import { GU_PURPOSE_LIST } from './config';
 
 const Cookies = _Cookies;
 
@@ -13,24 +14,28 @@ describe('cmp', () => {
         jest.resetAllMocks();
     });
 
-    describe('onConsentNotification', () => {
-        const purposes = ['functional', 'performance', 'advertisement'];
+    describe('onGuConsentNotification', () => {
+        const { purposes } = GU_PURPOSE_LIST;
 
-        describe('if cmpIsReady is TRUE when onConsentNotification called', () => {
+        describe('if cmpIsReady is TRUE when onGuConsentNotification called', () => {
             purposes.forEach(purpose => {
-                it(`executes ${purpose} callback immediately`, () => {
-                    const myCallBack = jest.fn();
+                const { eventId, alwaysEnabled } = purpose;
 
-                    onConsentNotification(purpose, myCallBack);
+                if (!alwaysEnabled) {
+                    it(`executes ${eventId} callback immediately`, () => {
+                        const myCallBack = jest.fn();
 
-                    expect(myCallBack).toHaveBeenCalledTimes(1);
-                });
+                        onGuConsentNotification(eventId, myCallBack);
+
+                        expect(myCallBack).toHaveBeenCalledTimes(1);
+                    });
+                }
             });
 
             it('executes functional callback with initial functional state', () => {
                 const myCallBack = jest.fn();
 
-                onConsentNotification('functional', myCallBack);
+                onGuConsentNotification('functional', myCallBack);
 
                 expect(myCallBack).toBeCalledWith(true);
             });
@@ -38,7 +43,7 @@ describe('cmp', () => {
             it('executes performance callback with initial performance state', () => {
                 const myCallBack = jest.fn();
 
-                onConsentNotification('performance', myCallBack);
+                onGuConsentNotification('performance', myCallBack);
 
                 expect(myCallBack).toBeCalledWith(true);
             });
@@ -48,9 +53,15 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                onConsentNotification('advertisement', myCallBack);
+                onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith(true);
+                expect(myCallBack).toBeCalledWith({
+                    1: true,
+                    2: true,
+                    3: true,
+                    4: true,
+                    5: true,
+                });
             });
 
             it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
@@ -58,9 +69,15 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                onConsentNotification('advertisement', myCallBack);
+                onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith(false);
+                expect(myCallBack).toBeCalledWith({
+                    1: false,
+                    2: false,
+                    3: false,
+                    4: false,
+                    5: false,
+                });
             });
 
             it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
@@ -68,18 +85,34 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                onConsentNotification('advertisement', myCallBack);
+                onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith(null);
+                expect(myCallBack).toBeCalledWith({
+                    1: null,
+                    2: null,
+                    3: null,
+                    4: null,
+                    5: null,
+                });
             });
 
             it('executes advertisement callback each time consent nofication triggered', () => {
                 Cookies.get.mockReturnValue('1.54321');
 
                 const myCallBack = jest.fn();
-                const expectedArguments = [[true]];
+                const expectedArguments = [
+                    [
+                        {
+                            1: true,
+                            2: true,
+                            3: true,
+                            4: true,
+                            5: true,
+                        },
+                    ],
+                ];
 
-                onConsentNotification('advertisement', myCallBack);
+                onIabConsentNotification(myCallBack);
 
                 const triggerCount = 5;
 
@@ -93,7 +126,15 @@ describe('cmp', () => {
                  */
                 for (let i = 0; i < triggerCount; i += 1) {
                     _.triggerConsentNotification();
-                    expectedArguments.push([true]);
+                    expectedArguments.push([
+                        {
+                            1: true,
+                            2: true,
+                            3: true,
+                            4: true,
+                            5: true,
+                        },
+                    ]);
                 }
 
                 expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -7,6 +7,7 @@ import {
     IabPurposeCallback,
     IabPurposeRegister,
     IabPurposeState,
+    ItemState,
 } from './types';
 import {
     CMP_DOMAIN,
@@ -78,7 +79,7 @@ const getAdConsentState = (): IabPurposeState => {
     const state = {
         ...iabPurposeRegister.state,
     };
-    let adConsentState: null | boolean = null;
+    let adConsentState: ItemState = null;
 
     if (cookie) {
         const cookieParsed = cookie.split('.')[0];

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,7 +1,7 @@
 import * as Cookies from 'js-cookie';
 import {
     GuPurposeCallback,
-    GuPurposeEvent,
+    GuPurposeResponsiveEvent,
     GuPurpose,
     GuPurposeRegister,
     IabPurposeCallback,
@@ -53,7 +53,7 @@ const iabPurposeRegister: IabPurposeRegister = {
 const triggerConsentNotification = (): void => {
     // Iterate over guPurposeRegister callbacks
     Object.keys(guPurposeRegister).forEach((key: string): void => {
-        const guPurpose = guPurposeRegister[key as GuPurposeEvent];
+        const guPurpose = guPurposeRegister[key as GuPurposeResponsiveEvent];
         guPurpose.callbacks.forEach((callback: GuPurposeCallback): void =>
             callback(guPurpose.state),
         );
@@ -130,7 +130,7 @@ export const onIabConsentNotification = (
 };
 
 export const onGuConsentNotification = (
-    purposeName: GuPurposeEvent,
+    purposeName: GuPurposeResponsiveEvent,
     callback: GuPurposeCallback,
 ): void => {
     checkCmpReady();
@@ -151,7 +151,8 @@ export const _ = {
         cmpIsReady = false;
         // reset guPurposeRegister
         Object.keys(guPurposeRegister).forEach((key: string): void => {
-            const guPurpose = guPurposeRegister[key as GuPurposeEvent];
+            const guPurpose =
+                guPurposeRegister[key as GuPurposeResponsiveEvent];
 
             guPurpose.state = null;
             guPurpose.callbacks = [];

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,7 +1,7 @@
 import * as Cookies from 'js-cookie';
 import {
     GuPurposeCallback,
-    GuPurposeResponsiveEvent,
+    GuResponsivePurposeEventId,
     GuPurpose,
     GuPurposeRegister,
     IabPurposeCallback,
@@ -53,7 +53,7 @@ const iabPurposeRegister: IabPurposeRegister = {
 const triggerConsentNotification = (): void => {
     // Iterate over guPurposeRegister callbacks
     Object.keys(guPurposeRegister).forEach((key: string): void => {
-        const guPurpose = guPurposeRegister[key as GuPurposeResponsiveEvent];
+        const guPurpose = guPurposeRegister[key as GuResponsivePurposeEventId];
         guPurpose.callbacks.forEach((callback: GuPurposeCallback): void =>
             callback(guPurpose.state),
         );
@@ -130,7 +130,7 @@ export const onIabConsentNotification = (
 };
 
 export const onGuConsentNotification = (
-    purposeName: GuPurposeResponsiveEvent,
+    purposeName: GuResponsivePurposeEventId,
     callback: GuPurposeCallback,
 ): void => {
     checkCmpReady();
@@ -152,7 +152,7 @@ export const _ = {
         // reset guPurposeRegister
         Object.keys(guPurposeRegister).forEach((key: string): void => {
             const guPurpose =
-                guPurposeRegister[key as GuPurposeResponsiveEvent];
+                guPurposeRegister[key as GuResponsivePurposeEventId];
 
             guPurpose.state = null;
             guPurpose.callbacks = [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export const GU_PURPOSE_LIST: GuPurposeList = {
         {
             id: 0,
             name: 'Essential',
+            eventId: 'essential',
             description:
                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             integrations: [
@@ -52,11 +53,12 @@ export const GU_PURPOSE_LIST: GuPurposeList = {
                     policyUrl: 'https://www.confiant.com/privacy',
                 },
             ],
-            hideRadio: true,
+            alwaysEnabled: true,
         },
         {
             id: 1,
             name: 'Functional',
+            eventId: 'functional',
             description:
                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque quis malesuada ante.',
             integrations: [
@@ -69,6 +71,7 @@ export const GU_PURPOSE_LIST: GuPurposeList = {
         {
             id: 2,
             name: 'Performance',
+            eventId: 'performance',
             description:
                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque quis malesuada ante. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.',
             integrations: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export type GuPurposeResponsiveEvent = 'functional' | 'performance';
+export type GuResponsivePurposeEventId = 'functional' | 'performance';
 
-export type GuPurposeEvent = 'essential' | GuPurposeResponsiveEvent;
+export type GuPurposeEventId = 'essential' | GuResponsivePurposeEventId;
 
 export type AdPurposeEvent = 'advertisement';
 
@@ -9,7 +9,7 @@ export type GuPurposeCallback = (state: boolean | null) => void;
 export type IabPurposeCallback = (state: IabPurposeState) => void;
 
 export type GuPurposeRegister = {
-    [key in GuPurposeEvent]: GuPurposeRegisterItem;
+    [key in GuPurposeEventId]: GuPurposeRegisterItem;
 };
 
 export interface IabPurposeRegister {
@@ -38,7 +38,7 @@ export interface GuPurposeList {
 export interface GuPurpose {
     id: number;
     name: string;
-    eventId: GuPurposeEvent;
+    eventId: GuPurposeEventId;
     description: string;
     integrations: GuIntegration[];
     alwaysEnabled?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,10 @@ export interface GuPurposeList {
 export interface GuPurpose {
     id: number;
     name: string;
+    eventId: PurposeEvent | 'essential';
     description: string;
     integrations: GuIntegration[];
-    hideRadio?: boolean;
+    alwaysEnabled?: boolean;
 }
 
 export interface GuIntegration {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,23 @@
-export type ItemState = boolean | null;
+export type GuPurposeEvent = 'essential' | 'functional' | 'performance';
 
-export type PurposeEvent = 'functional' | 'performance' | 'advertisement';
+export type AdPurposeEvent = 'advertisement';
 
-export type PurposeCallback = (state: ItemState) => void;
+export type GuPurposeCallback = (state: boolean | null) => void;
 
-export interface Purpose {
-    state: ItemState;
-    callbacks: PurposeCallback[];
+export type IabPurposeCallback = (state: IabPurposeState) => void;
+
+export type GuPurposeRegister = {
+    [key in GuPurposeEvent]: GuPurposeRegisterItem;
+};
+
+export interface IabPurposeRegister {
+    state: IabPurposeState;
+    callbacks: IabPurposeCallback[];
+}
+
+export interface GuPurposeRegisterItem {
+    state: boolean | null;
+    callbacks: GuPurposeCallback[];
 }
 
 export interface GuCookie {
@@ -25,7 +36,7 @@ export interface GuPurposeList {
 export interface GuPurpose {
     id: number;
     name: string;
-    eventId: PurposeEvent | 'essential';
+    eventId: GuPurposeEvent;
     description: string;
     integrations: GuIntegration[];
     alwaysEnabled?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,9 @@ export type GuPurposeEventId = 'essential' | GuResponsivePurposeEventId;
 
 export type AdPurposeEvent = 'advertisement';
 
-export type GuPurposeCallback = (state: boolean | null) => void;
+export type ItemState = boolean | null;
+
+export type GuPurposeCallback = (state: ItemState) => void;
 
 export type IabPurposeCallback = (state: IabPurposeState) => void;
 
@@ -18,7 +20,7 @@ export interface IabPurposeRegister {
 }
 
 export interface GuPurposeRegisterItem {
-    state: boolean | null;
+    state: ItemState;
     callbacks: GuPurposeCallback[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-export type GuPurposeEvent = 'essential' | 'functional' | 'performance';
+export type GuPurposeResponsiveEvent = 'functional' | 'performance';
+
+export type GuPurposeEvent = 'essential' | GuPurposeResponsiveEvent;
 
 export type AdPurposeEvent = 'advertisement';
 


### PR DESCRIPTION
- Replace `purposes` in `./cmp.ts` with `guPurposeRegister` and `iabPurposeRegister`.
- Construct `guPurposeRegister` using the `GU_PURPOSE_LIST`  from `./config.ts`.
- We now have two new methods exposed on the interface of `./cmp.ts`, `onIabConsentNotification` and `onGuConsentNotification`, these replace the method `onConsentNotification`.