### PR TITLE
onIabConsentNotification return IAB state derived from IAB Cookie if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
+        "consent-string": "^1.5.1",
         "js-cookie": "^2.2.1"
     },
     "devDependencies": {

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -50,20 +50,12 @@ describe('cmp', () => {
     });
 
     describe('onIabConsentNotification', () => {
-        beforeEach(() => {
-            ConsentString.mockImplementation(() => {
-                return {
-                    isPurposeAllowed: jest.fn(() => true),
-                };
-            });
-        });
-
         describe('if no IAB cookie available', () => {
             beforeEach(() => {
                 readIabCookie.mockReturnValue(null);
             });
 
-            it('executes advertisement callback with true if GU_TK cookie is true', () => {
+            it('executes advertisement callback with true state if GU_TK cookie is true', () => {
                 Cookies.get.mockReturnValue('1.54321');
 
                 const myCallBack = jest.fn();
@@ -79,7 +71,7 @@ describe('cmp', () => {
                 });
             });
 
-            it('executes advertisement callback with true if GU_TK cookie is false', () => {
+            it('executes advertisement callback with false state if GU_TK cookie is false', () => {
                 Cookies.get.mockReturnValue('0.54321');
 
                 const myCallBack = jest.fn();
@@ -95,7 +87,7 @@ describe('cmp', () => {
                 });
             });
 
-            it('executes advertisement callback with null if GU_TK cookie is null', () => {
+            it('executes advertisement callback with null state if GU_TK cookie is null', () => {
                 Cookies.get.mockReturnValue(undefined);
 
                 const myCallBack = jest.fn();
@@ -158,130 +150,114 @@ describe('cmp', () => {
                 expect(myCallBack.mock.calls).toEqual(expectedArguments);
             });
         });
+
+        describe('if IAB cookie available', () => {
+            const fakeIabCookie = 'foo';
+
+            beforeEach(() => {
+                readIabCookie.mockReturnValue(fakeIabCookie);
+            });
+
+            it('executes advertisement callback with true state if IAB cookie is available', () => {
+                ConsentString.mockImplementation(() => {
+                    return {
+                        isPurposeAllowed: jest.fn(() => true),
+                    };
+                });
+
+                const myCallBack = jest.fn();
+
+                onIabConsentNotification(myCallBack);
+
+                expect(ConsentString).toHaveBeenCalledTimes(1);
+                expect(ConsentString).toHaveBeenCalledWith(fakeIabCookie);
+                expect(myCallBack).toBeCalledWith({
+                    1: true,
+                    2: true,
+                    3: true,
+                    4: true,
+                    5: true,
+                });
+            });
+
+            it('executes advertisement callback with false state if IAB cookie is available', () => {
+                ConsentString.mockImplementation(() => {
+                    return {
+                        isPurposeAllowed: jest.fn(() => false),
+                    };
+                });
+
+                const myCallBack = jest.fn();
+
+                onIabConsentNotification(myCallBack);
+
+                expect(ConsentString).toHaveBeenCalledTimes(1);
+                expect(ConsentString).toHaveBeenCalledWith(fakeIabCookie);
+                expect(myCallBack).toBeCalledWith({
+                    1: false,
+                    2: false,
+                    3: false,
+                    4: false,
+                    5: false,
+                });
+            });
+
+            it('executes advertisement callback each time consent nofication triggered with updated state', () => {
+                ConsentString.mockImplementation(() => {
+                    return {
+                        isPurposeAllowed: jest.fn(() => false),
+                    };
+                });
+
+                const myCallBack = jest.fn();
+                const expectedArguments = [
+                    [
+                        {
+                            1: false,
+                            2: false,
+                            3: false,
+                            4: false,
+                            5: false,
+                        },
+                    ],
+                ];
+
+                onIabConsentNotification(myCallBack);
+
+                ConsentString.mockImplementation(() => {
+                    return {
+                        isPurposeAllowed: jest.fn(() => true),
+                    };
+                });
+
+                const triggerCount = 5;
+
+                /**
+                 * TODO: Once the module under test handles
+                 * updates to state we should update this test
+                 * to handle 5 updates to state (with differing values)
+                 * rather than triggering consent notifications manually
+                 * so we can test the callback is receiving the correct
+                 * latest state.
+                 */
+                for (let i = 0; i < triggerCount; i += 1) {
+                    _.setStateFromCookies();
+                    expectedArguments.push([
+                        {
+                            1: true,
+                            2: true,
+                            3: true,
+                            4: true,
+                            5: true,
+                        },
+                    ]);
+                }
+
+                expect(ConsentString).toHaveBeenCalledTimes(triggerCount + 1);
+                expect(ConsentString).toHaveBeenCalledWith(fakeIabCookie);
+                expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
+                expect(myCallBack.mock.calls).toEqual(expectedArguments);
+            });
+        });
     });
-
-    // describe('if cmpIsReady is TRUE when onGuConsentNotification called', () => {
-    //     purposes.forEach(purpose => {
-    //         const { eventId, alwaysEnabled } = purpose;
-
-    //         if (!alwaysEnabled) {
-    //             it(`executes ${eventId} callback immediately`, () => {
-    //                 const myCallBack = jest.fn();
-
-    //                 onGuConsentNotification(eventId, myCallBack);
-
-    //                 expect(myCallBack).toHaveBeenCalledTimes(1);
-    //             });
-    //         }
-    //     });
-
-    //     it('executes functional callback with initial functional state', () => {
-    //         const myCallBack = jest.fn();
-
-    //         onGuConsentNotification('functional', myCallBack);
-
-    //         expect(myCallBack).toBeCalledWith(true);
-    //     });
-
-    //     it('executes performance callback with initial performance state', () => {
-    //         const myCallBack = jest.fn();
-
-    //         onGuConsentNotification('performance', myCallBack);
-
-    //         expect(myCallBack).toBeCalledWith(true);
-    //     });
-
-    //     it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
-    //         Cookies.get.mockReturnValue('1.54321');
-
-    //         const myCallBack = jest.fn();
-
-    //         onIabConsentNotification(myCallBack);
-
-    //         expect(myCallBack).toBeCalledWith({
-    //             1: true,
-    //             2: true,
-    //             3: true,
-    //             4: true,
-    //             5: true,
-    //         });
-    //     });
-
-    //     it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
-    //         Cookies.get.mockReturnValue('0.54321');
-
-    //         const myCallBack = jest.fn();
-
-    //         onIabConsentNotification(myCallBack);
-
-    //         expect(myCallBack).toBeCalledWith({
-    //             1: false,
-    //             2: false,
-    //             3: false,
-    //             4: false,
-    //             5: false,
-    //         });
-    //     });
-
-    //     it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
-    //         Cookies.get.mockReturnValue(undefined);
-
-    //         const myCallBack = jest.fn();
-
-    //         onIabConsentNotification(myCallBack);
-
-    //         expect(myCallBack).toBeCalledWith({
-    //             1: null,
-    //             2: null,
-    //             3: null,
-    //             4: null,
-    //             5: null,
-    //         });
-    //     });
-
-    //     it('executes advertisement callback each time consent nofication triggered', () => {
-    //         Cookies.get.mockReturnValue('1.54321');
-
-    //         const myCallBack = jest.fn();
-    //         const expectedArguments = [
-    //             [
-    //                 {
-    //                     1: true,
-    //                     2: true,
-    //                     3: true,
-    //                     4: true,
-    //                     5: true,
-    //                 },
-    //             ],
-    //         ];
-
-    //         onIabConsentNotification(myCallBack);
-
-    //         const triggerCount = 5;
-
-    //         /**
-    //          * TODO: Once the module under test handles
-    //          * updates to state we should update this test
-    //          * to handle 5 updates to state (with differing values)
-    //          * rather than triggering consent notifications manually
-    //          * so we can test the callback is receiving the correct
-    //          * latest state.
-    //          */
-    //         for (let i = 0; i < triggerCount; i += 1) {
-    //             _.triggerConsentNotification();
-    //             expectedArguments.push([
-    //                 {
-    //                     1: true,
-    //                     2: true,
-    //                     3: true,
-    //                     4: true,
-    //                     5: true,
-    //                 },
-    //             ]);
-    //         }
-
-    //         expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
-    //         expect(myCallBack.mock.calls).toEqual(expectedArguments);
-    //     });
-    // });
 });

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -6,6 +6,27 @@ import { readIabCookie as _readIabCookie } from './cookies';
 
 const Cookies = _Cookies;
 const readIabCookie = _readIabCookie;
+const iabTrueState = {
+    1: true,
+    2: true,
+    3: true,
+    4: true,
+    5: true,
+};
+const iabFalseState = {
+    1: false,
+    2: false,
+    3: false,
+    4: false,
+    5: false,
+};
+const iabNullState = {
+    1: null,
+    2: null,
+    3: null,
+    4: null,
+    5: null,
+};
 
 jest.mock('js-cookie', () => ({
     get: jest.fn(),
@@ -62,13 +83,7 @@ describe('cmp', () => {
 
                 onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith({
-                    1: true,
-                    2: true,
-                    3: true,
-                    4: true,
-                    5: true,
-                });
+                expect(myCallBack).toBeCalledWith(iabTrueState);
             });
 
             it('executes advertisement callback with false state if GU_TK cookie is false', () => {
@@ -78,13 +93,7 @@ describe('cmp', () => {
 
                 onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith({
-                    1: false,
-                    2: false,
-                    3: false,
-                    4: false,
-                    5: false,
-                });
+                expect(myCallBack).toBeCalledWith(iabFalseState);
             });
 
             it('executes advertisement callback with null state if GU_TK cookie is null', () => {
@@ -94,13 +103,7 @@ describe('cmp', () => {
 
                 onIabConsentNotification(myCallBack);
 
-                expect(myCallBack).toBeCalledWith({
-                    1: null,
-                    2: null,
-                    3: null,
-                    4: null,
-                    5: null,
-                });
+                expect(myCallBack).toBeCalledWith(iabNullState);
             });
 
             it('executes advertisement callback each time consent nofication triggered with updated state', () => {
@@ -109,17 +112,7 @@ describe('cmp', () => {
                     .mockReturnValueOnce(undefined); // first call
 
                 const myCallBack = jest.fn();
-                const expectedArguments = [
-                    [
-                        {
-                            1: null,
-                            2: null,
-                            3: null,
-                            4: null,
-                            5: null,
-                        },
-                    ],
-                ];
+                const expectedArguments = [[iabNullState]];
 
                 onIabConsentNotification(myCallBack);
 
@@ -135,15 +128,7 @@ describe('cmp', () => {
                  */
                 for (let i = 0; i < triggerCount; i += 1) {
                     _.setStateFromCookies();
-                    expectedArguments.push([
-                        {
-                            1: true,
-                            2: true,
-                            3: true,
-                            4: true,
-                            5: true,
-                        },
-                    ]);
+                    expectedArguments.push([iabTrueState]);
                 }
 
                 expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
@@ -171,13 +156,7 @@ describe('cmp', () => {
 
                 expect(ConsentString).toHaveBeenCalledTimes(1);
                 expect(ConsentString).toHaveBeenCalledWith(fakeIabCookie);
-                expect(myCallBack).toBeCalledWith({
-                    1: true,
-                    2: true,
-                    3: true,
-                    4: true,
-                    5: true,
-                });
+                expect(myCallBack).toBeCalledWith(iabTrueState);
             });
 
             it('executes advertisement callback with false state if IAB cookie is available', () => {
@@ -193,13 +172,7 @@ describe('cmp', () => {
 
                 expect(ConsentString).toHaveBeenCalledTimes(1);
                 expect(ConsentString).toHaveBeenCalledWith(fakeIabCookie);
-                expect(myCallBack).toBeCalledWith({
-                    1: false,
-                    2: false,
-                    3: false,
-                    4: false,
-                    5: false,
-                });
+                expect(myCallBack).toBeCalledWith(iabFalseState);
             });
 
             it('executes advertisement callback each time consent nofication triggered with updated state', () => {
@@ -210,17 +183,7 @@ describe('cmp', () => {
                 });
 
                 const myCallBack = jest.fn();
-                const expectedArguments = [
-                    [
-                        {
-                            1: false,
-                            2: false,
-                            3: false,
-                            4: false,
-                            5: false,
-                        },
-                    ],
-                ];
+                const expectedArguments = [[iabFalseState]];
 
                 onIabConsentNotification(myCallBack);
 
@@ -242,15 +205,7 @@ describe('cmp', () => {
                  */
                 for (let i = 0; i < triggerCount; i += 1) {
                     _.setStateFromCookies();
-                    expectedArguments.push([
-                        {
-                            1: true,
-                            2: true,
-                            3: true,
-                            4: true,
-                            5: true,
-                        },
-                    ]);
+                    expectedArguments.push([iabTrueState]);
                 }
 
                 expect(ConsentString).toHaveBeenCalledTimes(triggerCount + 1);

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -1,12 +1,21 @@
 import * as _Cookies from 'js-cookie';
+import { ConsentString } from 'consent-string';
 import { onGuConsentNotification, onIabConsentNotification, _ } from './cmp';
 import { GU_PURPOSE_LIST } from './config';
+import { readIabCookie as _readIabCookie } from './cookies';
 
 const Cookies = _Cookies;
+const readIabCookie = _readIabCookie;
 
 jest.mock('js-cookie', () => ({
     get: jest.fn(),
 }));
+
+jest.mock('./cookies', () => ({
+    readIabCookie: jest.fn(),
+}));
+
+jest.mock('consent-string');
 
 describe('cmp', () => {
     beforeEach(() => {
@@ -17,38 +26,44 @@ describe('cmp', () => {
     describe('onGuConsentNotification', () => {
         const { purposes } = GU_PURPOSE_LIST;
 
-        describe('if cmpIsReady is TRUE when onGuConsentNotification called', () => {
-            purposes.forEach(purpose => {
-                const { eventId, alwaysEnabled } = purpose;
+        purposes.forEach(purpose => {
+            const { eventId, alwaysEnabled } = purpose;
 
-                if (!alwaysEnabled) {
-                    it(`executes ${eventId} callback immediately`, () => {
-                        const myCallBack = jest.fn();
+            if (!alwaysEnabled) {
+                it(`executes ${eventId} callback immediately`, () => {
+                    const myCallBack = jest.fn();
 
-                        onGuConsentNotification(eventId, myCallBack);
+                    onGuConsentNotification(eventId, myCallBack);
 
-                        expect(myCallBack).toHaveBeenCalledTimes(1);
-                    });
-                }
+                    expect(myCallBack).toHaveBeenCalledTimes(1);
+                });
+
+                it(`executes ${eventId} callback with initial functional state`, () => {
+                    const myCallBack = jest.fn();
+
+                    onGuConsentNotification(eventId, myCallBack);
+
+                    expect(myCallBack).toBeCalledWith(true);
+                });
+            }
+        });
+    });
+
+    describe('onIabConsentNotification', () => {
+        beforeEach(() => {
+            ConsentString.mockImplementation(() => {
+                return {
+                    isPurposeAllowed: jest.fn(() => true),
+                };
+            });
+        });
+
+        describe('if no IAB cookie available', () => {
+            beforeEach(() => {
+                readIabCookie.mockReturnValue(null);
             });
 
-            it('executes functional callback with initial functional state', () => {
-                const myCallBack = jest.fn();
-
-                onGuConsentNotification('functional', myCallBack);
-
-                expect(myCallBack).toBeCalledWith(true);
-            });
-
-            it('executes performance callback with initial performance state', () => {
-                const myCallBack = jest.fn();
-
-                onGuConsentNotification('performance', myCallBack);
-
-                expect(myCallBack).toBeCalledWith(true);
-            });
-
-            it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
+            it('executes advertisement callback with true if GU_TK cookie is true', () => {
                 Cookies.get.mockReturnValue('1.54321');
 
                 const myCallBack = jest.fn();
@@ -64,7 +79,7 @@ describe('cmp', () => {
                 });
             });
 
-            it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
+            it('executes advertisement callback with true if GU_TK cookie is false', () => {
                 Cookies.get.mockReturnValue('0.54321');
 
                 const myCallBack = jest.fn();
@@ -80,7 +95,7 @@ describe('cmp', () => {
                 });
             });
 
-            it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
+            it('executes advertisement callback with null if GU_TK cookie is null', () => {
                 Cookies.get.mockReturnValue(undefined);
 
                 const myCallBack = jest.fn();
@@ -96,18 +111,20 @@ describe('cmp', () => {
                 });
             });
 
-            it('executes advertisement callback each time consent nofication triggered', () => {
-                Cookies.get.mockReturnValue('1.54321');
+            it('executes advertisement callback each time consent nofication triggered with updated state', () => {
+                Cookies.get
+                    .mockReturnValue('1.54321') // default
+                    .mockReturnValueOnce(undefined); // first call
 
                 const myCallBack = jest.fn();
                 const expectedArguments = [
                     [
                         {
-                            1: true,
-                            2: true,
-                            3: true,
-                            4: true,
-                            5: true,
+                            1: null,
+                            2: null,
+                            3: null,
+                            4: null,
+                            5: null,
                         },
                     ],
                 ];
@@ -125,7 +142,7 @@ describe('cmp', () => {
                  * latest state.
                  */
                 for (let i = 0; i < triggerCount; i += 1) {
-                    _.triggerConsentNotification();
+                    _.setStateFromCookies();
                     expectedArguments.push([
                         {
                             1: true,
@@ -142,4 +159,129 @@ describe('cmp', () => {
             });
         });
     });
+
+    // describe('if cmpIsReady is TRUE when onGuConsentNotification called', () => {
+    //     purposes.forEach(purpose => {
+    //         const { eventId, alwaysEnabled } = purpose;
+
+    //         if (!alwaysEnabled) {
+    //             it(`executes ${eventId} callback immediately`, () => {
+    //                 const myCallBack = jest.fn();
+
+    //                 onGuConsentNotification(eventId, myCallBack);
+
+    //                 expect(myCallBack).toHaveBeenCalledTimes(1);
+    //             });
+    //         }
+    //     });
+
+    //     it('executes functional callback with initial functional state', () => {
+    //         const myCallBack = jest.fn();
+
+    //         onGuConsentNotification('functional', myCallBack);
+
+    //         expect(myCallBack).toBeCalledWith(true);
+    //     });
+
+    //     it('executes performance callback with initial performance state', () => {
+    //         const myCallBack = jest.fn();
+
+    //         onGuConsentNotification('performance', myCallBack);
+
+    //         expect(myCallBack).toBeCalledWith(true);
+    //     });
+
+    //     it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
+    //         Cookies.get.mockReturnValue('1.54321');
+
+    //         const myCallBack = jest.fn();
+
+    //         onIabConsentNotification(myCallBack);
+
+    //         expect(myCallBack).toBeCalledWith({
+    //             1: true,
+    //             2: true,
+    //             3: true,
+    //             4: true,
+    //             5: true,
+    //         });
+    //     });
+
+    //     it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
+    //         Cookies.get.mockReturnValue('0.54321');
+
+    //         const myCallBack = jest.fn();
+
+    //         onIabConsentNotification(myCallBack);
+
+    //         expect(myCallBack).toBeCalledWith({
+    //             1: false,
+    //             2: false,
+    //             3: false,
+    //             4: false,
+    //             5: false,
+    //         });
+    //     });
+
+    //     it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
+    //         Cookies.get.mockReturnValue(undefined);
+
+    //         const myCallBack = jest.fn();
+
+    //         onIabConsentNotification(myCallBack);
+
+    //         expect(myCallBack).toBeCalledWith({
+    //             1: null,
+    //             2: null,
+    //             3: null,
+    //             4: null,
+    //             5: null,
+    //         });
+    //     });
+
+    //     it('executes advertisement callback each time consent nofication triggered', () => {
+    //         Cookies.get.mockReturnValue('1.54321');
+
+    //         const myCallBack = jest.fn();
+    //         const expectedArguments = [
+    //             [
+    //                 {
+    //                     1: true,
+    //                     2: true,
+    //                     3: true,
+    //                     4: true,
+    //                     5: true,
+    //                 },
+    //             ],
+    //         ];
+
+    //         onIabConsentNotification(myCallBack);
+
+    //         const triggerCount = 5;
+
+    //         /**
+    //          * TODO: Once the module under test handles
+    //          * updates to state we should update this test
+    //          * to handle 5 updates to state (with differing values)
+    //          * rather than triggering consent notifications manually
+    //          * so we can test the callback is receiving the correct
+    //          * latest state.
+    //          */
+    //         for (let i = 0; i < triggerCount; i += 1) {
+    //             _.triggerConsentNotification();
+    //             expectedArguments.push([
+    //                 {
+    //                     1: true,
+    //                     2: true,
+    //                     3: true,
+    //                     4: true,
+    //                     5: true,
+    //                 },
+    //             ]);
+    //         }
+
+    //         expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
+    //         expect(myCallBack.mock.calls).toEqual(expectedArguments);
+    //     });
+    // });
 });

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -136,7 +136,7 @@ const setStateFromCookies = (): void => {
 const receiveMessage = (event: MessageEvent): void => {
     const { origin, data } = event;
 
-    // triggerConsentNotification when CMP_SAVED_MSG emitted from CMP_DOMAIN
+    // setStateFromCookies when CMP_SAVED_MSG emitted from CMP_DOMAIN
     if (origin === CMP_DOMAIN && data === CMP_SAVED_MSG) {
         setStateFromCookies();
     }
@@ -182,7 +182,7 @@ export const onGuConsentNotification = (
 
 // Exposed for testing
 export const _ = {
-    triggerConsentNotification,
+    setStateFromCookies,
     resetCmp: (): void => {
         cmpIsReady = false;
         // reset guPurposeRegister

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,4 +1,5 @@
 import * as Cookies from 'js-cookie';
+import { ConsentString } from 'consent-string';
 import {
     GuPurposeCallback,
     GuResponsivePurposeEventId,
@@ -15,6 +16,7 @@ import {
     GU_AD_CONSENT_COOKIE,
     GU_PURPOSE_LIST,
 } from './config';
+import { readIabCookie } from './cookies';
 
 let cmpIsReady = false;
 
@@ -70,18 +72,30 @@ const triggerConsentNotification = (): void => {
     );
 };
 
-const receiveMessage = (event: MessageEvent): void => {
-    const { origin, data } = event;
+const getIabStateFromCookie = (): IabPurposeState | null => {
+    const cookie = readIabCookie();
 
-    // triggerConsentNotification when CMP_SAVED_MSG emitted from CMP_DOMAIN
-    if (origin === CMP_DOMAIN && data === CMP_SAVED_MSG) {
-        triggerConsentNotification();
+    if (!cookie) {
+        return null;
     }
+
+    const iabState = {
+        ...iabPurposeRegister.state,
+    };
+
+    const iabData = new ConsentString(cookie);
+
+    Object.keys(iabState).forEach((key: string): void => {
+        const purposeId = parseInt(key, 10);
+        iabState[purposeId] = iabData.isPurposeAllowed(purposeId);
+    });
+
+    return iabState;
 };
 
-const getAdConsentState = (): IabPurposeState => {
+const getGuTkStateFromCookie = (): IabPurposeState => {
     const cookie = Cookies.get(GU_AD_CONSENT_COOKIE);
-    const state = {
+    const iabState = {
         ...iabPurposeRegister.state,
     };
     let adConsentState: ItemState = null;
@@ -98,18 +112,14 @@ const getAdConsentState = (): IabPurposeState => {
         }
     }
 
-    Object.keys(state).forEach((key: string): void => {
-        state[parseInt(key, 10)] = adConsentState;
+    Object.keys(iabState).forEach((key: string): void => {
+        iabState[parseInt(key, 10)] = adConsentState;
     });
 
-    return state;
+    return iabState;
 };
 
-const checkCmpReady = (): void => {
-    if (cmpIsReady) {
-        return;
-    }
-
+const setStateFromCookies = (): void => {
     /**
      * These state assignments are temporary
      * and will eventually be replaced by values
@@ -117,7 +127,27 @@ const checkCmpReady = (): void => {
      * */
     guPurposeRegister.functional.state = true;
     guPurposeRegister.performance.state = true;
-    iabPurposeRegister.state = getAdConsentState();
+    iabPurposeRegister.state =
+        getIabStateFromCookie() || getGuTkStateFromCookie();
+
+    triggerConsentNotification();
+};
+
+const receiveMessage = (event: MessageEvent): void => {
+    const { origin, data } = event;
+
+    // triggerConsentNotification when CMP_SAVED_MSG emitted from CMP_DOMAIN
+    if (origin === CMP_DOMAIN && data === CMP_SAVED_MSG) {
+        setStateFromCookies();
+    }
+};
+
+const checkCmpReady = (): void => {
+    if (cmpIsReady) {
+        return;
+    }
+
+    setStateFromCookies();
 
     // listen for postMessage events from CMP UI
     window.addEventListener('message', receiveMessage, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,6 +668,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -915,6 +920,13 @@ confusing-browser-globals@^1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
   integrity sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==
+
+consent-string@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.1.tgz#0700828dd257226a24f570c0474243578518fd3f"
+  integrity sha512-hB2Cg/lCPNR6S2MvNCHdtm6IfbnDyokmt1xW2ujKpJ5zT6G1/c2qruTpVLF5hOTFcS/lo4A0U03HncX1U36yRw==
+  dependencies:
+    base-64 "^0.1.0"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR updates the `cmp.ts` module. 

Callbacks currently passed to `onIabConsentNotification` are executed with the `iabPurposeRegister.state` as their first argument. Currently the value of `iabPurposeRegister.state` is derived from the `GU_TK` cookie. For example, If `GU_TK === '1.54321'` then `iabPurposeRegister.state = {1: true, 2: true, 3: true, ...}` OR If `GU_TK === '0.54321'` then `iabPurposeRegister.state = {1: false, 2: false, 3: false, ...}`.

This PR updates the `cmp.ts` module so callbacks passed to `onIabConsentNotification` are now executed with an `iabPurposeRegister.state` derived from the IAB string cookie if it exists. If the IAB string cookie does not exist then we then fallback to trying the `GU_TK` cookie (as before).