### PR TITLE
Refactor save/log consent state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/cmp-ui.ts
+++ b/src/cmp-ui.ts
@@ -1,5 +1,5 @@
 import { readIabCookie } from './cookies';
-import { logConsent } from './consent-logs';
+import { save } from './consent-store';
 import {
     CMP_DOMAIN,
     CMP_READY_MSG,
@@ -39,7 +39,7 @@ export const setupMessageHandlers = (
                 withErrorHandling(onCloseCmp);
                 break;
             case CMP_SAVED_MSG:
-                logConsent(msgData)
+                save(msgData)
                     .then(response => {
                         if (!response.ok) {
                             throw new Error(

--- a/src/cmp-ui.ts
+++ b/src/cmp-ui.ts
@@ -1,5 +1,5 @@
 import { readIabCookie } from './cookies';
-import { save } from './consent-store';
+import { save } from './consent-storage';
 import {
     CMP_DOMAIN,
     CMP_READY_MSG,

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ const isRunningOnProd = (): boolean => {
     return shortDomain === 'theguardian.com';
 };
 
-const isProd = isRunningOnProd();
+export const isProd = isRunningOnProd();
 
 const cmpDomain = (): string =>
     isProd

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ export const IAB_CONSENT_LANGUAGE = 'en';
 export const CMP_READY_MSG = 'readyCmp';
 export const CMP_SAVED_MSG = 'savedCmp';
 export const CMP_CLOSE_MSG = 'closeCmp';
+export const LEGACY_COOKIE_NAME = 'GU_TK';
 export const GU_PURPOSE_LIST: GuPurposeList = {
     purposes: [
         {

--- a/src/consent-storage.ts
+++ b/src/consent-storage.ts
@@ -8,7 +8,7 @@ import {
     CMP_LOGS_URL,
     isProd,
 } from './config';
-import { writeIabCookie } from './cookies';
+import { writeIabCookie, writeLegacyCookie } from './cookies';
 import { updateStateOnSave } from './cmp';
 import { IabPurposeState, CmpMsgData } from './types';
 
@@ -45,6 +45,8 @@ export const save = ({
     const pAdvertising = Object.keys(newIabState).every(
         id => newIabState[parseInt(id, 10)] === true,
     );
+
+    writeLegacyCookie(pAdvertising);
 
     const browserID = Cookies.get('bwid') || DUMMY_BROWSER_ID;
 

--- a/src/consent-store.ts
+++ b/src/consent-store.ts
@@ -1,5 +1,5 @@
 import * as Cookies from 'js-cookie';
-import { ConsentString, VendorList } from 'consent-string';
+import { ConsentString } from 'consent-string';
 import {
     IAB_CMP_ID,
     IAB_CMP_VERSION,
@@ -10,21 +10,15 @@ import {
 } from './config';
 import { writeIabCookie } from './cookies';
 import { updateStateOnSave } from './cmp';
-import { IabPurposeState } from './types';
+import { IabPurposeState, CmpMsgData } from './types';
 
 const DUMMY_BROWSER_ID = `No bwid available`;
-
-type MsgData = {
-    iabVendorList: VendorList;
-    allowedPurposes: number[];
-    allowedVendors: number[];
-};
 
 export const save = ({
     iabVendorList,
     allowedPurposes,
     allowedVendors,
-}: MsgData): Promise<Response> => {
+}: CmpMsgData): Promise<Response> => {
     const consentData = new ConsentString();
     consentData.setGlobalVendorList(iabVendorList);
     consentData.setCmpId(IAB_CMP_ID);

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -5,6 +5,7 @@ import {
     GU_COOKIE_VERSION,
     IAB_COOKIE_NAME,
     COOKIE_MAX_AGE,
+    LEGACY_COOKIE_NAME,
 } from './config';
 
 const getShortDomain = (): string => {
@@ -57,4 +58,13 @@ const writeGuCookie = (guState: GuPurposeState): void =>
 const writeIabCookie = (iabString: string): void =>
     addCookie(IAB_COOKIE_NAME, iabString);
 
-export { readGuCookie, readIabCookie, writeGuCookie, writeIabCookie };
+const writeLegacyCookie = (state: boolean): void =>
+    addCookie(LEGACY_COOKIE_NAME, [state ? '1' : '0', Date.now()].join('.'));
+
+export {
+    readGuCookie,
+    readIabCookie,
+    writeGuCookie,
+    writeIabCookie,
+    writeLegacyCookie,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type CmpMsgData = {
-    iabVendorList: VendorList;
+    iabVendorList: IabVendorList;
     allowedPurposes: number[];
     allowedVendors: number[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export type CmpMsgData = {
+    iabVendorList: VendorList;
+    allowedPurposes: number[];
+    allowedVendors: number[];
+};
+
 export type GuResponsivePurposeEventId = 'functional' | 'performance';
 
 export type GuPurposeEventId = 'essential' | GuResponsivePurposeEventId;


### PR DESCRIPTION
This PR does two things:
- Refactors the code that saves and logs the consent state
- Adds saving the GU_TK cookie (So that consent state remains consistent after the CMP test ends) 