### PR TITLE
Pull the temporary legacy cookie reading code into cookie.ts

### DIFF
--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -1,11 +1,13 @@
-import * as _Cookies from 'js-cookie';
 import { ConsentString } from 'consent-string';
 import { onGuConsentNotification, onIabConsentNotification, _ } from './cmp';
 import { GU_PURPOSE_LIST } from './config';
-import { readIabCookie as _readIabCookie } from './cookies';
+import {
+    readIabCookie as _readIabCookie,
+    readLegacyCookie as _readLegacyCookie,
+} from './cookies';
 
-const Cookies = _Cookies;
 const readIabCookie = _readIabCookie;
+const readLegacyCookie = _readLegacyCookie;
 const iabTrueState = {
     1: true,
     2: true,
@@ -28,12 +30,9 @@ const iabNullState = {
     5: null,
 };
 
-jest.mock('js-cookie', () => ({
-    get: jest.fn(),
-}));
-
 jest.mock('./cookies', () => ({
     readIabCookie: jest.fn(),
+    readLegacyCookie: jest.fn(),
 }));
 
 jest.mock('consent-string');
@@ -77,7 +76,7 @@ describe('cmp', () => {
             });
 
             it('executes advertisement callback with true state if GU_TK cookie is true', () => {
-                Cookies.get.mockReturnValue('1.54321');
+                readLegacyCookie.mockReturnValue('1.54321');
 
                 const myCallBack = jest.fn();
 
@@ -87,7 +86,7 @@ describe('cmp', () => {
             });
 
             it('executes advertisement callback with false state if GU_TK cookie is false', () => {
-                Cookies.get.mockReturnValue('0.54321');
+                readLegacyCookie.mockReturnValue('0.54321');
 
                 const myCallBack = jest.fn();
 
@@ -97,7 +96,7 @@ describe('cmp', () => {
             });
 
             it('executes advertisement callback with null state if GU_TK cookie is null', () => {
-                Cookies.get.mockReturnValue(undefined);
+                readLegacyCookie.mockReturnValue(null);
 
                 const myCallBack = jest.fn();
 
@@ -107,7 +106,7 @@ describe('cmp', () => {
             });
 
             it('executes advertisement callback each time consent nofication triggered with updated state', () => {
-                Cookies.get.mockReturnValue(undefined); // first call
+                readLegacyCookie.mockReturnValue(null); // first call
 
                 const myCallBack = jest.fn();
                 const expectedArguments = [[iabNullState]];

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import { ConsentString } from 'consent-string';
 import {
     GuPurposeCallback,
@@ -10,8 +9,8 @@ import {
     IabPurposeState,
     ItemState,
 } from './types';
-import { GU_AD_CONSENT_COOKIE, GU_PURPOSE_LIST } from './config';
-import { readIabCookie } from './cookies';
+import { GU_PURPOSE_LIST } from './config';
+import { readIabCookie, readLegacyCookie } from './cookies';
 
 let cmpIsReady = false;
 
@@ -88,8 +87,8 @@ const getIabStateFromCookie = (): IabPurposeState | null => {
     return iabState;
 };
 
-const getGuTkStateFromCookie = (): IabPurposeState => {
-    const cookie = Cookies.get(GU_AD_CONSENT_COOKIE);
+const getLegacyStateFromCookie = (): IabPurposeState => {
+    const cookie = readLegacyCookie();
     const iabState = {
         ...iabPurposeRegister.state,
     };
@@ -123,7 +122,7 @@ const setStateFromCookies = (): void => {
     guPurposeRegister.functional.state = true;
     guPurposeRegister.performance.state = true;
     iabPurposeRegister.state =
-        getIabStateFromCookie() || getGuTkStateFromCookie();
+        getIabStateFromCookie() || getLegacyStateFromCookie();
 
     triggerConsentNotification();
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,6 @@ export const CMP_DOMAIN = cmpDomain();
 export const CMP_URL = `${CMP_DOMAIN}/consent`;
 export const CMP_LOGS_URL = cmpLogsUrl();
 export const COOKIE_MAX_AGE = 395; // 13 months
-export const GU_AD_CONSENT_COOKIE = 'GU_TK';
 export const GU_COOKIE_NAME = 'guconsent';
 export const GU_COOKIE_VERSION = 1;
 export const IAB_VENDOR_LIST_URL = iabVendorListUrl();

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -2,17 +2,22 @@ import * as _Cookies from 'js-cookie';
 import {
     readGuCookie,
     readIabCookie,
+    readLegacyCookie,
     writeGuCookie,
     writeIabCookie,
+    writeLegacyCookie,
 } from './cookies';
 import {
     GU_COOKIE_NAME,
     GU_COOKIE_VERSION,
     IAB_COOKIE_NAME,
     COOKIE_MAX_AGE,
+    LEGACY_COOKIE_NAME,
 } from './config';
 
 const Cookies = _Cookies;
+
+const OriginalDate = global.Date; // Mock the Date constructor to always return the beginning of time
 
 jest.mock('js-cookie', () => ({
     set: jest.fn(),
@@ -36,9 +41,19 @@ describe('Cookies', () => {
     const iabConsentString = 'heL10W0rLd';
 
     beforeAll(() => {
+        global.Date = {
+            now: () => '12345',
+        };
         Object.defineProperty(document, 'domain', {
             value: 'www.theguardian.com',
         });
+    });
+
+    afterAll(() => {
+        global.Date = OriginalDate;
+        expect(new Date().toString()).not.toMatch(
+            new RegExp('Thu Jan 01 1970'),
+        );
     });
 
     afterEach(() => {
@@ -67,6 +82,28 @@ describe('Cookies', () => {
         );
     });
 
+    it('should be able to set the legacy cookie to true', () => {
+        writeLegacyCookie(true);
+
+        expect(Cookies.set).toHaveBeenCalledTimes(1);
+        expect(Cookies.set).toHaveBeenCalledWith(
+            LEGACY_COOKIE_NAME,
+            '1.12345',
+            cookieOptions,
+        );
+    });
+
+    it('should be able to set the legacy cookie to true', () => {
+        writeLegacyCookie(false);
+
+        expect(Cookies.set).toHaveBeenCalledTimes(1);
+        expect(Cookies.set).toHaveBeenCalledWith(
+            LEGACY_COOKIE_NAME,
+            '0.12345',
+            cookieOptions,
+        );
+    });
+
     it('should be able to read the GU cookie', () => {
         Cookies.getJSON.mockImplementation(() => guCookie);
 
@@ -87,6 +124,17 @@ describe('Cookies', () => {
         expect(readCookie).toBe(iabConsentString);
     });
 
+    it('should be able to read the legacy cookie', () => {
+        const fakeCookieValue = 'foo';
+        Cookies.get.mockImplementation(() => fakeCookieValue);
+
+        const readCookie = readLegacyCookie();
+
+        expect(Cookies.get).toHaveBeenCalledTimes(1);
+        expect(Cookies.get).toHaveBeenCalledWith(LEGACY_COOKIE_NAME);
+        expect(readCookie).toBe(fakeCookieValue);
+    });
+
     it('returns null if no GU cookie', () => {
         Cookies.getJSON.mockImplementation(() => undefined);
 
@@ -104,6 +152,16 @@ describe('Cookies', () => {
 
         expect(Cookies.get).toHaveBeenCalledTimes(1);
         expect(Cookies.get).toHaveBeenCalledWith(IAB_COOKIE_NAME);
+        expect(readCookie).toBeNull();
+    });
+
+    it('returns null if no legacy cookie', () => {
+        Cookies.get.mockImplementation(() => undefined);
+
+        const readCookie = readLegacyCookie();
+
+        expect(Cookies.get).toHaveBeenCalledTimes(1);
+        expect(Cookies.get).toHaveBeenCalledWith(LEGACY_COOKIE_NAME);
         expect(readCookie).toBeNull();
     });
 });

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -17,7 +17,7 @@ import {
 
 const Cookies = _Cookies;
 
-const OriginalDate = global.Date; // Mock the Date constructor to always return the beginning of time
+const OriginalDate = global.Date;
 
 jest.mock('js-cookie', () => ({
     set: jest.fn(),
@@ -39,10 +39,11 @@ describe('Cookies', () => {
         expires: COOKIE_MAX_AGE,
     };
     const iabConsentString = 'heL10W0rLd';
+    const fakeNow = '12345';
 
     beforeAll(() => {
         global.Date = {
-            now: () => '12345',
+            now: () => fakeNow,
         };
         Object.defineProperty(document, 'domain', {
             value: 'www.theguardian.com',
@@ -51,9 +52,7 @@ describe('Cookies', () => {
 
     afterAll(() => {
         global.Date = OriginalDate;
-        expect(new Date().toString()).not.toMatch(
-            new RegExp('Thu Jan 01 1970'),
-        );
+        expect(Date.now()).not.toMatch(fakeNow);
     });
 
     afterEach(() => {
@@ -88,7 +87,7 @@ describe('Cookies', () => {
         expect(Cookies.set).toHaveBeenCalledTimes(1);
         expect(Cookies.set).toHaveBeenCalledWith(
             LEGACY_COOKIE_NAME,
-            '1.12345',
+            `1.${fakeNow}`,
             cookieOptions,
         );
     });
@@ -99,7 +98,7 @@ describe('Cookies', () => {
         expect(Cookies.set).toHaveBeenCalledTimes(1);
         expect(Cookies.set).toHaveBeenCalledWith(
             LEGACY_COOKIE_NAME,
-            '0.12345',
+            `0.${fakeNow}`,
             cookieOptions,
         );
     });

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -53,6 +53,12 @@ const readIabCookie = (): string | null => {
     return cookie || null;
 };
 
+const readLegacyCookie = (): string | null => {
+    const cookie = Cookies.get(LEGACY_COOKIE_NAME);
+
+    return cookie || null;
+};
+
 const writeGuCookie = (guState: GuPurposeState): void =>
     addCookie(GU_COOKIE_NAME, { version: GU_COOKIE_VERSION, state: guState });
 
@@ -65,6 +71,7 @@ const writeLegacyCookie = (state: boolean): void =>
 export {
     readGuCookie,
     readIabCookie,
+    readLegacyCookie,
     writeGuCookie,
     writeIabCookie,
     writeLegacyCookie,


### PR DESCRIPTION
Pulls the temporary legacy cookie reading code into `cookie.ts` by exposing new `readLegacyCookie` function on it.