### PR TITLE
CMP restructure phase 5

### DIFF
--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -4,7 +4,7 @@ import { mobileLandscape, palette, space } from '@guardian/src-foundations';
 import { Logo } from './svgs/Logo';
 import { ConsentPreferencesDashboard } from './ConsentPreferencesDashboard';
 import { SCROLLABLE_ID, CONTENT_ID } from './utils/config';
-import { setSource } from '../store';
+import { setSource, setVariant } from '../store';
 
 const TRANSITION_TIME = 1000;
 
@@ -150,7 +150,7 @@ class ConsentManagementPlatform extends Component<Props, State> {
         }
 
         if (props.variant) {
-            setSource(props.variant);
+            setVariant(props.variant);
         }
     }
 

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -4,6 +4,7 @@ import { mobileLandscape, palette, space } from '@guardian/src-foundations';
 import { Logo } from './svgs/Logo';
 import { ConsentPreferencesDashboard } from './ConsentPreferencesDashboard';
 import { SCROLLABLE_ID, CONTENT_ID } from './utils/config';
+import { setSource } from '../store';
 
 const TRANSITION_TIME = 1000;
 
@@ -127,6 +128,8 @@ interface State {
 
 interface Props {
     onClose: () => void;
+    source?: string;
+    variant?: string;
 }
 
 class ConsentManagementPlatform extends Component<Props, State> {
@@ -141,6 +144,14 @@ class ConsentManagementPlatform extends Component<Props, State> {
             active: false,
             visible: false,
         };
+
+        if (props.source) {
+            setSource(props.source);
+        }
+
+        if (props.variant) {
+            setSource(props.variant);
+        }
     }
 
     public render(): React.ReactNode {

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -2,8 +2,17 @@ import { GuPurposeState } from './types';
 import { readBwidCookie } from './cookies';
 import { isProd } from './config';
 
+interface LogsPaylod {
+    version: string;
+    iab: string;
+    source: string;
+    purposes: { personalisedAdvertising: boolean };
+    browserId: string;
+    variant?: string;
+}
+
 const LOGS_VERSION = '1';
-const DUMMY_BROWSER_ID = `No bwid available`;
+const DUMMY_BROWSER_ID = 'No bwid available';
 
 const CMP_LOGS_PROD_URL = 'https://consent-logs.guardianapis.com/report';
 const CMP_LOGS_NOT_PROD_URL =
@@ -24,7 +33,7 @@ export const postConsentState = (
         throw new Error(`Error getting browserID in PROD`);
     }
 
-    const logInfo = {
+    const logInfo: LogsPaylod = {
         version: LOGS_VERSION,
         iab: iabString,
         source,
@@ -32,8 +41,11 @@ export const postConsentState = (
             personalisedAdvertising: pAdvertisingState,
         },
         browserId: browserID,
-        variant: variant || '',
     };
+
+    if (variant) {
+        logInfo.variant = variant;
+    }
 
     return fetch(CMP_LOGS_URL, {
         method: 'POST',

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -6,6 +6,7 @@ import {
     getConsentState,
     setConsentState,
     _,
+    setVariant,
 } from './store';
 import { readIabCookie, readLegacyCookie, writeStateCookies } from './cookies';
 import { postConsentState } from './logs';
@@ -243,15 +244,31 @@ describe('Store', () => {
             });
         });
 
-        it('calls postConsentState', () => {
-            return setConsentState(guMixedState, iabTrueState).then(() => {
-                expect(postConsentState).toHaveBeenCalledTimes(1);
-                expect(postConsentState).toHaveBeenLastCalledWith(
-                    guMixedState,
-                    fakeIabString,
-                    true,
-                    'www',
-                );
+        describe('calls postConsentState correctly', () => {
+            it('with default variant', () => {
+                return setConsentState(guMixedState, iabTrueState).then(() => {
+                    expect(postConsentState).toHaveBeenCalledTimes(1);
+                    expect(postConsentState).toHaveBeenLastCalledWith(
+                        guMixedState,
+                        fakeIabString,
+                        true,
+                        'www',
+                    );
+                });
+            });
+            it('after setting variant', () => {
+                const variantStr = 'test variant';
+                setVariant(variantStr);
+                return setConsentState(guMixedState, iabTrueState).then(() => {
+                    expect(postConsentState).toHaveBeenCalledTimes(1);
+                    expect(postConsentState).toHaveBeenLastCalledWith(
+                        guMixedState,
+                        fakeIabString,
+                        true,
+                        'www',
+                        variantStr,
+                    );
+                });
             });
         });
     });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -8,6 +8,7 @@ import {
     _,
     setVariant,
     setSource,
+    getVariant,
 } from './store';
 import { readIabCookie, readLegacyCookie, writeStateCookies } from './cookies';
 import { postConsentState } from './logs';
@@ -329,6 +330,18 @@ describe('Store', () => {
                     `${notOkResponse.status} | ${notOkResponse.statusText}`,
                 );
             });
+        });
+    });
+
+    describe('getVariant', () => {
+        it('returns null when no variant has been set ', () => {
+            expect(getVariant()).toBeNull();
+        });
+
+        it('returns the correct variant when one has been set ', () => {
+            const variantString = 'test variant';
+            setVariant(variantString);
+            expect(getVariant()).toBe(variantString);
         });
     });
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -7,6 +7,7 @@ import {
     setConsentState,
     _,
     setVariant,
+    setSource,
 } from './store';
 import { readIabCookie, readLegacyCookie, writeStateCookies } from './cookies';
 import { postConsentState } from './logs';
@@ -122,6 +123,7 @@ describe('Store', () => {
                 iabState: iabDefaultState,
             });
         });
+
         it('when the euconsents cookie is available', () => {
             readIabCookie.mockImplementation(() => 'foo');
             readLegacyCookie.mockImplementation(() => legacyTrueCookie);
@@ -131,6 +133,7 @@ describe('Store', () => {
                 iabState: iabTrueState,
             });
         });
+
         it('falls back to legacy GU_TK cookie if available when euconsents cookie is unavailable', () => {
             readLegacyCookie.mockImplementation(() => legacyTrueCookie);
 
@@ -139,6 +142,7 @@ describe('Store', () => {
                 iabState: iabTrueState,
             });
         });
+
         it('after a state change', () => {
             expect(getConsentState()).toMatchObject({
                 guState: guDefaultState,
@@ -165,18 +169,22 @@ describe('Store', () => {
             registerStateChangeHandler(myCallBack);
             registerStateChangeHandler(myCallBack);
         });
+
         it('when getVendorList is called first', () => {
             getVendorList();
             getVendorList();
         });
+
         it('when getGuPurposeList is called first', () => {
             getGuPurposeList();
             getGuPurposeList();
         });
+
         it('when getConsentState is called first', () => {
             getConsentState();
             getConsentState();
         });
+
         it('when setConsentState is called first', () => {
             setConsentState(guMixedState, iabTrueState);
             setConsentState(guMixedState, iabTrueState);
@@ -219,6 +227,7 @@ describe('Store', () => {
                 ).toHaveBeenCalledWith(allowedPurposes);
             });
         });
+
         it('calls setVendorsAllowed correctly', () => {
             const allowedVendors = fakeVendorList.vendors.map(
                 vendor => vendor.id,
@@ -233,6 +242,7 @@ describe('Store', () => {
                 ).toHaveBeenCalledWith(allowedVendors);
             });
         });
+
         it('calls writeStateCookies correctly', () => {
             return setConsentState(guMixedState, iabTrueState).then(() => {
                 expect(writeStateCookies).toHaveBeenCalledTimes(1);
@@ -252,10 +262,26 @@ describe('Store', () => {
                         guMixedState,
                         fakeIabString,
                         true,
-                        'www',
+                        _.DEFAULT_SOURCE,
                     );
                 });
             });
+
+            it('after setting source', () => {
+                const sourceStr = 'test source';
+                setSource(sourceStr);
+
+                return setConsentState(guMixedState, iabTrueState).then(() => {
+                    expect(postConsentState).toHaveBeenCalledTimes(1);
+                    expect(postConsentState).toHaveBeenLastCalledWith(
+                        guMixedState,
+                        fakeIabString,
+                        true,
+                        sourceStr,
+                    );
+                });
+            });
+
             it('after setting variant', () => {
                 const variantStr = 'test variant';
                 setVariant(variantStr);
@@ -265,7 +291,7 @@ describe('Store', () => {
                         guMixedState,
                         fakeIabString,
                         true,
-                        'www',
+                        _.DEFAULT_SOURCE,
                         variantStr,
                     );
                 });
@@ -282,6 +308,7 @@ describe('Store', () => {
                 );
             });
         });
+
         it('fetches the vendor list from the correct URL when in PROD', () => {
             isProd.mockReturnValue(true);
             return getVendorList().then(result => {
@@ -291,6 +318,7 @@ describe('Store', () => {
                 );
             });
         });
+
         it('reports an error when the reply from fetch is an error code ', () => {
             global.fetch = jest
                 .fn()

--- a/src/store.ts
+++ b/src/store.ts
@@ -179,11 +179,11 @@ const setConsentState = (
         });
 };
 
-const setSource = (newSource: string) => {
+const setSource = (newSource: string): void => {
     source = newSource;
 };
 
-const setVariant = (newVariant: string) => {
+const setVariant = (newVariant: string): void => {
     variant = newVariant;
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,7 +26,7 @@ const IAB_VENDOR_LIST_NOT_PROD_URL =
 
 let initialised = false;
 let source = DEFAULT_SOURCE;
-let variant: string;
+let variant: string | null = null;
 let vendorListPromise: Promise<IabVendorList>;
 const onStateChange: onStateChangeFn[] = [];
 
@@ -79,6 +79,10 @@ const getConsentState = (): {
 } => {
     init();
     return { guState, iabState };
+};
+
+const getVariant = (): string | null => {
+    return variant;
 };
 
 const getGuStateFromCookie = (): GuPurposeState => {
@@ -188,6 +192,7 @@ export {
     getGuPurposeList,
     getVendorList,
     getConsentState,
+    getVariant,
     setConsentState,
     setSource,
     setVariant,
@@ -201,7 +206,7 @@ export const _ = {
         guState = { functional: true, performance: true };
         iabState = { 1: null, 2: null, 3: null, 4: null, 5: null };
         onStateChange.length = 0;
-        variant = '';
+        variant = null;
         source = DEFAULT_SOURCE;
         initialised = false;
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,7 @@ const IAB_VENDOR_LIST_NOT_PROD_URL =
     'https://code.dev-theguardian.com/commercial/cmp/vendorlist.json';
 
 let initialised = false;
+let variant = 'www';
 let vendorListPromise: Promise<IabVendorList>;
 const onStateChange: onStateChangeFn[] = [];
 
@@ -151,7 +152,7 @@ const setConsentState = (
             const pAdvertisingState = allowedPurposes.length === 5;
 
             writeStateCookies(guState, iabStr, pAdvertisingState);
-            postConsentState(guState, iabStr, pAdvertisingState, 'www');
+            postConsentState(guState, iabStr, pAdvertisingState, variant);
         })
         .finally(() => {
             onStateChange.forEach((callback: onStateChangeFn): void => {
@@ -162,12 +163,17 @@ const setConsentState = (
         });
 };
 
+const setVariant = (newVariant: string) => {
+    variant = newVariant;
+};
+
 export {
     registerStateChangeHandler,
     getGuPurposeList,
     getVendorList,
     getConsentState,
     setConsentState,
+    setVariant,
 };
 
 export const _ = {

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,7 +24,7 @@ const IAB_VENDOR_LIST_NOT_PROD_URL =
     'https://code.dev-theguardian.com/commercial/cmp/vendorlist.json';
 
 let initialised = false;
-let variant = 'www';
+let variant: string;
 let vendorListPromise: Promise<IabVendorList>;
 const onStateChange: onStateChangeFn[] = [];
 
@@ -152,7 +152,17 @@ const setConsentState = (
             const pAdvertisingState = allowedPurposes.length === 5;
 
             writeStateCookies(guState, iabStr, pAdvertisingState);
-            postConsentState(guState, iabStr, pAdvertisingState, variant);
+            if (variant) {
+                postConsentState(
+                    guState,
+                    iabStr,
+                    pAdvertisingState,
+                    'www',
+                    variant,
+                );
+            } else {
+                postConsentState(guState, iabStr, pAdvertisingState, 'www');
+            }
         })
         .finally(() => {
             onStateChange.forEach((callback: onStateChangeFn): void => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ type onStateChangeFn = (
     iabState: IabPurposeState,
 ) => void;
 
+const DEFAULT_SOURCE = 'www';
 const IAB_CMP_ID = 112;
 const IAB_CMP_VERSION = 1;
 const IAB_CONSENT_SCREEN = 0;
@@ -24,6 +25,7 @@ const IAB_VENDOR_LIST_NOT_PROD_URL =
     'https://code.dev-theguardian.com/commercial/cmp/vendorlist.json';
 
 let initialised = false;
+let source = DEFAULT_SOURCE;
 let variant: string;
 let vendorListPromise: Promise<IabVendorList>;
 const onStateChange: onStateChangeFn[] = [];
@@ -157,11 +159,11 @@ const setConsentState = (
                     guState,
                     iabStr,
                     pAdvertisingState,
-                    'www',
+                    source,
                     variant,
                 );
             } else {
-                postConsentState(guState, iabStr, pAdvertisingState, 'www');
+                postConsentState(guState, iabStr, pAdvertisingState, source);
             }
         })
         .finally(() => {
@@ -171,6 +173,10 @@ const setConsentState = (
 
             return Promise.resolve();
         });
+};
+
+const setSource = (newSource: string) => {
+    source = newSource;
 };
 
 const setVariant = (newVariant: string) => {
@@ -183,16 +189,20 @@ export {
     getVendorList,
     getConsentState,
     setConsentState,
+    setSource,
     setVariant,
 };
 
 export const _ = {
+    DEFAULT_SOURCE,
     IAB_VENDOR_LIST_PROD_URL,
     IAB_VENDOR_LIST_NOT_PROD_URL,
     reset: (): void => {
         guState = { functional: true, performance: true };
         iabState = { 1: null, 2: null, 3: null, 4: null, 5: null };
         onStateChange.length = 0;
+        variant = '';
+        source = DEFAULT_SOURCE;
         initialised = false;
     },
 };


### PR DESCRIPTION
This PR executes phase five of the CMP restructure, which includes:

- Pass variant into the UI component, save it in `store.ts` and send it in the logs
- Pass source into the UI component, save it in `store.ts` and send it in the logs
- Expose a `getVariant()` function in `store.ts` 
- Add unit tests for the new functions

Notes:
- Moved some code around inside `store.ts` to improve its organisation, such as grouping similar variables together and grouping setter and getter functions.
- Fixed an issue in `logs.ts` that would send an empty string in the variant when the value passed is null or undefined. It now removes the field from the payload entirely, as expected by the consent logs API.