### PR TITLE
Handle abTestVariant in CmpMsgData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "1.1.0-beta.5",
+    "version": "1.1.0",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "1.0.2",
+    "version": "1.1.0-beta-5",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "1.1.0-beta-5",
+    "version": "1.1.0-beta.5",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/consent-storage.ts
+++ b/src/consent-storage.ts
@@ -18,6 +18,7 @@ export const save = ({
     iabVendorList,
     allowedPurposes,
     allowedVendors,
+    abTestVariant,
 }: CmpMsgData): Promise<Response> => {
     const consentData = new ConsentString();
     consentData.setGlobalVendorList(iabVendorList);
@@ -62,7 +63,7 @@ export const save = ({
             personalisedAdvertising: pAdvertising,
         },
         browserId: browserID,
-        variant: 'CmpUiIab-variant',
+        variant: abTestVariant,
     };
 
     return fetch(CMP_LOGS_URL, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type CmpMsgData = {
     iabVendorList: IabVendorList;
     allowedPurposes: number[];
     allowedVendors: number[];
+    abTestVariant: string;
 };
 
 export type GuResponsivePurposeEventId = 'functional' | 'performance';


### PR DESCRIPTION
Currently we've hardcoded the value of `variant` in the consent log data to be 'CmpUiIab-variant', this PR changes that so instead we set the value of `variant` to the value of `abTestVariant`, a new property that the CMP UI includes in the `CMP_SAVED_MSG` post message.