### PR TITLE
CMP restructure phase 6

### DIFF
--- a/src/component/ConsentPreferencesDashboard.tsx
+++ b/src/component/ConsentPreferencesDashboard.tsx
@@ -248,12 +248,8 @@ export class ConsentPreferencesDashboard extends Component<Props, State> {
             .then(remoteVendorList => {
                 return this.buildState(parseIabVendorList(remoteVendorList));
             })
-            .then(() => {
-                showCmp();
-            })
-            .catch(() => {
-                hideCmp();
-            });
+            .then(showCmp)
+            .catch(hideCmp);
     }
 
     public render(): React.ReactNode {

--- a/src/component/ConsentPreferencesDashboard.tsx
+++ b/src/component/ConsentPreferencesDashboard.tsx
@@ -242,19 +242,17 @@ export class ConsentPreferencesDashboard extends Component<Props, State> {
     }
 
     public componentDidMount(): void {
+        const { showCmp, hideCmp } = this.props;
+
         getVendorList()
             .then(remoteVendorList => {
                 return this.buildState(parseIabVendorList(remoteVendorList));
             })
             .then(() => {
-                const { showCmp } = this.props;
-
                 showCmp();
             })
-            .catch(error => {
-                // TODO: Handle error by removing the component
-                // eslint-disable-next-line no-console
-                console.log('Error', error);
+            .catch(() => {
+                hideCmp();
             });
     }
 

--- a/src/component/ConsentPreferencesDashboard.tsx
+++ b/src/component/ConsentPreferencesDashboard.tsx
@@ -252,7 +252,7 @@ export class ConsentPreferencesDashboard extends Component<Props, State> {
                 showCmp();
             })
             .catch(error => {
-                // TODO: ERROR HANDLING
+                // TODO: Handle error by removing the component
                 // eslint-disable-next-line no-console
                 console.log('Error', error);
             });

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,14 +1,30 @@
 import { setErrorHandler, handleError } from './error';
 
-describe('Error', () => {
-    it('run the error handler correctly after one has been set ', () => {
-        const myCallback = jest.fn();
-        const errorMsg = 'An error happened';
+const myCallback = jest.fn();
+const errorMsg = 'An error happened';
 
+describe('Error', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('runs the error handler correctly after one has been set', () => {
         setErrorHandler(myCallback);
         handleError(errorMsg);
 
         expect(myCallback).toHaveBeenCalledTimes(1);
         expect(myCallback).toHaveBeenCalledWith(errorMsg);
+    });
+
+    it('runs the error handler everytime handleError is called', () => {
+        setErrorHandler(myCallback);
+
+        handleError(errorMsg);
+        handleError(errorMsg);
+        handleError(errorMsg);
+        handleError(errorMsg);
+        handleError(errorMsg);
+
+        expect(myCallback).toHaveBeenCalledTimes(5);
     });
 });

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -8,6 +8,17 @@ describe('Error', () => {
         jest.resetAllMocks();
     });
 
+    it('runs the default error handler correctly if no handler has been set', () => {
+        /* eslint-disable no-console */
+        console.error = jest.fn();
+
+        handleError(errorMsg);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith(errorMsg);
+        /* eslint-enable no-console */
+    });
+
     it('runs the error handler correctly after one has been set', () => {
         setErrorHandler(myCallback);
         handleError(errorMsg);

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,0 +1,14 @@
+import { setErrorHandler, handleError } from './error';
+
+describe('Error', () => {
+    it('run the error handler correctly after one has been set ', () => {
+        const myCallback = jest.fn();
+        const errorMsg = 'An error happened';
+
+        setErrorHandler(myCallback);
+        handleError(errorMsg);
+
+        expect(myCallback).toHaveBeenCalledTimes(1);
+        expect(myCallback).toHaveBeenCalledWith(errorMsg);
+    });
+});

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -9,14 +9,15 @@ describe('Error', () => {
     });
 
     it('runs the default error handler correctly if no handler has been set', () => {
-        /* eslint-disable no-console */
-        console.error = jest.fn();
+        global.console = { error: jest.fn() };
 
         handleError(errorMsg);
 
         expect(console.error).toHaveBeenCalledTimes(1);
         expect(console.error).toHaveBeenCalledWith(errorMsg);
-        /* eslint-enable no-console */
+
+        global.console.error.mockClear();
+        delete global.console;
     });
 
     it('runs the error handler correctly after one has been set', () => {

--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -13,7 +13,9 @@ describe('Error', () => {
 
         handleError(errorMsg);
 
+        // eslint-disable-next-line no-console
         expect(console.error).toHaveBeenCalledTimes(1);
+        // eslint-disable-next-line no-console
         expect(console.error).toHaveBeenCalledWith(errorMsg);
 
         global.console.error.mockClear();

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,15 @@
+type onErrorFn = (error: string) => void;
+
+let onError: onErrorFn;
+
+const setErrorHandler = (newHandler: onErrorFn) => {
+    onError = newHandler;
+};
+
+const handleError = (error: string) => {
+    if (onError) {
+        onError(error);
+    }
+};
+
+export { setErrorHandler, handleError };

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,7 @@
 type onErrorFn = (error: string) => void;
 
-let onError: onErrorFn;
+// eslint-disable-next-line no-console
+let onError: onErrorFn = error => console.error(error);
 
 const setErrorHandler = (newHandler: onErrorFn) => {
     onError = newHandler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { onGuConsentNotification, onIabConsentNotification } from './core';
+export { setErrorHandler } from './error';
 export { canShow } from './cmp-ui';

--- a/src/logs.test.ts
+++ b/src/logs.test.ts
@@ -15,9 +15,6 @@ jest.mock('./error', () => ({
     handleError: jest.fn(),
 }));
 
-const mockThenBlock = jest.fn();
-const mockCatchBlock = jest.fn();
-
 describe('Logs', () => {
     const guState = {};
     const iabString = 'g0BbleDyg0_0k!';
@@ -54,16 +51,17 @@ describe('Logs', () => {
             readBwidCookie.mockReturnValue(fakeBwid);
             isProd.mockReturnValue(true);
 
-            return postConsentState(
-                guState,
-                iabString,
-                pAdvertisingState,
-                source,
-                variant,
+            return expect(
+                postConsentState(
+                    guState,
+                    iabString,
+                    pAdvertisingState,
+                    source,
+                    variant,
+                ),
             )
-                .catch(mockCatchBlock)
-                .finally(() => {
-                    expect(mockCatchBlock).not.toBeCalled();
+                .resolves.toBeUndefined()
+                .then(() => {
                     expect(global.fetch).toHaveBeenCalledTimes(1);
                     expect(global.fetch).toHaveBeenCalledWith(
                         _.CMP_LOGS_PROD_URL,
@@ -87,16 +85,17 @@ describe('Logs', () => {
         it('when not on PROD and bwid cookie is available.', () => {
             readBwidCookie.mockReturnValue(fakeBwid);
 
-            return postConsentState(
-                guState,
-                iabString,
-                pAdvertisingState,
-                source,
-                variant,
+            return expect(
+                postConsentState(
+                    guState,
+                    iabString,
+                    pAdvertisingState,
+                    source,
+                    variant,
+                ),
             )
-                .catch(mockCatchBlock)
-                .finally(() => {
-                    expect(mockCatchBlock).not.toBeCalled();
+                .resolves.toBeUndefined()
+                .then(() => {
                     expect(global.fetch).toHaveBeenCalledTimes(1);
                     expect(global.fetch).toHaveBeenCalledWith(
                         _.CMP_LOGS_NOT_PROD_URL,
@@ -120,16 +119,17 @@ describe('Logs', () => {
         it('when not on PROD and bwid cookie is not available', () => {
             readBwidCookie.mockReturnValue(null);
 
-            return postConsentState(
-                guState,
-                iabString,
-                pAdvertisingState,
-                source,
-                variant,
+            return expect(
+                postConsentState(
+                    guState,
+                    iabString,
+                    pAdvertisingState,
+                    source,
+                    variant,
+                ),
             )
-                .catch(mockCatchBlock)
-                .finally(() => {
-                    expect(mockCatchBlock).not.toBeCalled();
+                .resolves.toBeUndefined()
+                .then(() => {
                     expect(global.fetch).toHaveBeenCalledTimes(1);
                     expect(global.fetch).toHaveBeenCalledWith(
                         _.CMP_LOGS_NOT_PROD_URL,
@@ -154,19 +154,17 @@ describe('Logs', () => {
     describe('throws an error and returns a rejected Promise', () => {
         it('when on PROD and bwid cookies is not available', () => {
             isProd.mockReturnValue(true);
-            return postConsentState(
-                guState,
-                iabString,
-                pAdvertisingState,
-                source,
-                variant,
+            return expect(
+                postConsentState(
+                    guState,
+                    iabString,
+                    pAdvertisingState,
+                    source,
+                    variant,
+                ),
             )
-                .then(mockThenBlock)
-                .catch(() => {
-                    expect.anything();
-                })
-                .finally(() => {
-                    expect(mockThenBlock).not.toBeCalled();
+                .rejects.toBeUndefined()
+                .then(() => {
                     expect(handleError).toHaveBeenCalledTimes(1);
                     expect(handleError).toHaveBeenCalledWith(
                         'Error getting browserID in PROD',
@@ -185,17 +183,17 @@ describe('Logs', () => {
                 .fn()
                 .mockImplementation(() => Promise.resolve(notOkResponse));
 
-            return postConsentState(
-                guState,
-                iabString,
-                pAdvertisingState,
-                source,
-                variant,
+            return expect(
+                postConsentState(
+                    guState,
+                    iabString,
+                    pAdvertisingState,
+                    source,
+                    variant,
+                ),
             )
-                .then(mockThenBlock)
-                .catch(() => {})
-                .finally(() => {
-                    expect(mockThenBlock).not.toBeCalled();
+                .rejects.toBeUndefined()
+                .then(() => {
                     expect(global.fetch).toHaveBeenCalledTimes(1);
                     expect(handleError).toHaveBeenCalledTimes(1);
                     expect(handleError).toHaveBeenCalledWith(

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -25,7 +25,7 @@ export const postConsentState = (
     pAdvertisingState: boolean,
     source: string,
     variant?: string,
-) => {
+): Promise<void> => {
     const CMP_LOGS_URL = isProd() ? CMP_LOGS_PROD_URL : CMP_LOGS_NOT_PROD_URL;
 
     const browserID = readBwidCookie() || DUMMY_BROWSER_ID;

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -83,7 +83,6 @@ const okResponse = {
     ok: true,
     json: () => fakeVendorList,
 };
-
 const notOkResponse = {
     ok: false,
     status: 500,

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -346,7 +346,7 @@ describe('Store', () => {
                 .mockImplementation(() => Promise.resolve(notOkResponse));
 
             return expect(getVendorList())
-                .resolves.toBeUndefined()
+                .rejects.toBeUndefined()
                 .then(() => {
                     expect(handleError).toHaveBeenCalledTimes(1);
                     expect(handleError).toHaveBeenCalledWith(

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -201,7 +201,8 @@ describe('Store', () => {
         it('triggers StateChange handlers correctly', () => {
             registerStateChangeHandler(myCallBack);
 
-            return setConsentState(guDefaultState, iabDefaultState)
+            return expect(setConsentState(guDefaultState, iabDefaultState))
+                .resolves.toBeUndefined()
                 .then(() => {
                     return setConsentState(guMixedState, iabTrueState);
                 })
@@ -224,14 +225,16 @@ describe('Store', () => {
                 return parseInt(purposeId, 10);
             });
 
-            return setConsentState(guMixedState, iabTrueState).then(() => {
-                expect(
-                    ConsentString.prototype.setPurposesAllowed,
-                ).toHaveBeenCalledTimes(1);
-                expect(
-                    ConsentString.prototype.setPurposesAllowed,
-                ).toHaveBeenCalledWith(allowedPurposes);
-            });
+            return expect(setConsentState(guMixedState, iabTrueState))
+                .resolves.toBeUndefined()
+                .then(() => {
+                    expect(
+                        ConsentString.prototype.setPurposesAllowed,
+                    ).toHaveBeenCalledTimes(1);
+                    expect(
+                        ConsentString.prototype.setPurposesAllowed,
+                    ).toHaveBeenCalledWith(allowedPurposes);
+                });
         });
 
         it('calls setVendorsAllowed correctly', () => {
@@ -239,90 +242,102 @@ describe('Store', () => {
                 vendor => vendor.id,
             );
 
-            return setConsentState(guMixedState, iabTrueState).then(() => {
-                expect(
-                    ConsentString.prototype.setVendorsAllowed,
-                ).toHaveBeenCalledTimes(1);
-                expect(
-                    ConsentString.prototype.setVendorsAllowed,
-                ).toHaveBeenCalledWith(allowedVendors);
-            });
+            return expect(setConsentState(guMixedState, iabTrueState))
+                .resolves.toBeUndefined()
+                .then(() => {
+                    expect(
+                        ConsentString.prototype.setVendorsAllowed,
+                    ).toHaveBeenCalledTimes(1);
+                    expect(
+                        ConsentString.prototype.setVendorsAllowed,
+                    ).toHaveBeenCalledWith(allowedVendors);
+                });
         });
 
         it('calls writeStateCookies correctly', () => {
-            return setConsentState(guMixedState, iabTrueState).then(() => {
-                expect(writeStateCookies).toHaveBeenCalledTimes(1);
-                expect(writeStateCookies).toHaveBeenLastCalledWith(
-                    guMixedState,
-                    fakeIabString,
-                    true,
-                );
-            });
+            return expect(setConsentState(guMixedState, iabTrueState))
+                .resolves.toBeUndefined()
+                .then(() => {
+                    expect(writeStateCookies).toHaveBeenCalledTimes(1);
+                    expect(writeStateCookies).toHaveBeenLastCalledWith(
+                        guMixedState,
+                        fakeIabString,
+                        true,
+                    );
+                });
         });
 
         describe('calls postConsentState correctly', () => {
             it('with default variant', () => {
-                return setConsentState(guMixedState, iabTrueState).then(() => {
-                    expect(postConsentState).toHaveBeenCalledTimes(1);
-                    expect(postConsentState).toHaveBeenLastCalledWith(
-                        guMixedState,
-                        fakeIabString,
-                        true,
-                        _.DEFAULT_SOURCE,
-                    );
-                });
+                return expect(setConsentState(guMixedState, iabTrueState))
+                    .resolves.toBeUndefined()
+                    .then(() => {
+                        expect(postConsentState).toHaveBeenCalledTimes(1);
+                        expect(postConsentState).toHaveBeenLastCalledWith(
+                            guMixedState,
+                            fakeIabString,
+                            true,
+                            _.DEFAULT_SOURCE,
+                        );
+                    });
             });
 
             it('after setting source', () => {
                 const sourceStr = 'test source';
                 setSource(sourceStr);
 
-                return setConsentState(guMixedState, iabTrueState).then(() => {
-                    expect(postConsentState).toHaveBeenCalledTimes(1);
-                    expect(postConsentState).toHaveBeenLastCalledWith(
-                        guMixedState,
-                        fakeIabString,
-                        true,
-                        sourceStr,
-                    );
-                });
+                return expect(setConsentState(guMixedState, iabTrueState))
+                    .resolves.toBeUndefined()
+                    .then(() => {
+                        expect(postConsentState).toHaveBeenCalledTimes(1);
+                        expect(postConsentState).toHaveBeenLastCalledWith(
+                            guMixedState,
+                            fakeIabString,
+                            true,
+                            sourceStr,
+                        );
+                    });
             });
 
             it('after setting variant', () => {
                 const variantStr = 'test variant';
                 setVariant(variantStr);
-                return setConsentState(guMixedState, iabTrueState).then(() => {
-                    expect(postConsentState).toHaveBeenCalledTimes(1);
-                    expect(postConsentState).toHaveBeenLastCalledWith(
-                        guMixedState,
-                        fakeIabString,
-                        true,
-                        _.DEFAULT_SOURCE,
-                        variantStr,
-                    );
-                });
+                return expect(setConsentState(guMixedState, iabTrueState))
+                    .resolves.toBeUndefined()
+                    .then(() => {
+                        expect(postConsentState).toHaveBeenCalledTimes(1);
+                        expect(postConsentState).toHaveBeenLastCalledWith(
+                            guMixedState,
+                            fakeIabString,
+                            true,
+                            _.DEFAULT_SOURCE,
+                            variantStr,
+                        );
+                    });
             });
         });
     });
 
     describe('getVendorList', () => {
         it('fetches the vendor list from the correct URL when not in PROD', () => {
-            return getVendorList().then(result => {
-                expect(result).toMatchObject(fakeVendorList);
-                expect(global.fetch).toHaveBeenCalledWith(
-                    _.IAB_VENDOR_LIST_NOT_PROD_URL,
-                );
-            });
+            return expect(getVendorList())
+                .resolves.toMatchObject(fakeVendorList)
+                .then(() => {
+                    expect(global.fetch).toHaveBeenCalledWith(
+                        _.IAB_VENDOR_LIST_NOT_PROD_URL,
+                    );
+                });
         });
 
         it('fetches the vendor list from the correct URL when in PROD', () => {
             isProd.mockReturnValue(true);
-            return getVendorList().then(result => {
-                expect(result).toMatchObject(fakeVendorList);
-                expect(global.fetch).toHaveBeenCalledWith(
-                    _.IAB_VENDOR_LIST_PROD_URL,
-                );
-            });
+            return expect(getVendorList())
+                .resolves.toMatchObject(fakeVendorList)
+                .then(() => {
+                    expect(global.fetch).toHaveBeenCalledWith(
+                        _.IAB_VENDOR_LIST_PROD_URL,
+                    );
+                });
         });
 
         it('reports an error when the reply from fetch is an error code ', () => {
@@ -330,12 +345,14 @@ describe('Store', () => {
                 .fn()
                 .mockImplementation(() => Promise.resolve(notOkResponse));
 
-            return getVendorList().then(() => {
-                expect(handleError).toHaveBeenCalledTimes(1);
-                expect(handleError).toHaveBeenCalledWith(
-                    `Error fetching vendor list: Error: ${notOkResponse.status} | ${notOkResponse.statusText}`,
-                );
-            });
+            return expect(getVendorList())
+                .resolves.toBeUndefined()
+                .then(() => {
+                    expect(handleError).toHaveBeenCalledTimes(1);
+                    expect(handleError).toHaveBeenCalledWith(
+                        `Error fetching vendor list: Error: ${notOkResponse.status} | ${notOkResponse.statusText}`,
+                    );
+                });
         });
     });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,7 @@ const init = (): void => {
             })
             .catch(error => {
                 handleError(`Error fetching vendor list: ${error}`);
+                return Promise.reject();
             });
 
         guState = getGuStateFromCookie();

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ import {
 import { readIabCookie, readLegacyCookie, writeStateCookies } from './cookies';
 import { GU_PURPOSE_LIST, isProd } from './config';
 import { postConsentState } from './logs';
+import { handleError } from './error';
 
 type onStateChangeFn = (
     guState: GuPurposeState,
@@ -48,8 +49,7 @@ const init = (): void => {
                 throw new Error(`${response.status} | ${response.statusText}`);
             })
             .catch(error => {
-                // eslint-disable-next-line no-console
-                console.log('Error fetching vendor list: ', error);
+                handleError(`Error fetching vendor list: ${error}`);
             });
 
         guState = getGuStateFromCookie();


### PR DESCRIPTION
This PR executes phase six of the CMP restructure, which includes:
- Add error handling
- Include `setErrorHandler` as a package export
- Add/update unit testing for affected modules

Notes:
- Updated functions that returns a promise to reject said promise on cases where the request failed.
- Improved how we test promise resolving/rejection.