### PR TITLE
Introduce FontsContext (CMP restructure)

### DIFF
--- a/src/component/CmpCollapsible.tsx
+++ b/src/component/CmpCollapsible.tsx
@@ -3,7 +3,8 @@ import { palette } from '@guardian/src-foundations';
 import React, { Component } from 'react';
 import { CollapseItemButton } from './CollapseItemButton';
 import { OnOffRadio } from './OnOffRadio';
-import { ItemState } from '../types';
+import { ItemState, FontsContextInterface } from '../types';
+import { FontsContext } from './FontsContext';
 
 const titleTabStyles = css`
     display: flex;
@@ -15,22 +16,20 @@ const titleContainerStyles = css`
     flex: 1;
 `;
 
-const titleStyles = (collapsed: boolean) => css`
-    font-family: 'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial,
-        Lucida Grande, sans-serif;
+const titleStyles = (collapsed: boolean, bodySans: string) => css`
+    font-family: ${bodySans};
     font-size: 20px;
     line-height: 22px;
     font-weight: 700;
     color: ${collapsed ? palette.yellow.dark : palette.neutral[100]};
 `;
 
-const panelStyles = (collapsed: boolean) => css`
+const panelStyles = (collapsed: boolean, bodySans: string) => css`
     display: ${collapsed ? 'block' : 'none'};
     padding-left: 20px;
 
     p {
-        font-family: 'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial,
-            Lucida Grande, sans-serif;
+        font-family: ${bodySans};
         fontsize: 17px;
         lineheight: 24px;
     }
@@ -61,32 +60,40 @@ export class CmpCollapsible extends Component<Props, State> {
         const { title, value, children, updateItem, showError } = this.props;
 
         return (
-            <>
-                <div css={titleTabStyles}>
-                    <div
-                        css={css`
-                            flex-grow: 1;
-                            display: flex;
-                        `}
-                        onClick={() => {
-                            this.toggleCollapsed();
-                        }}
-                    >
-                        <CollapseItemButton collapsed={collapsed} />
-                        <div css={titleContainerStyles}>
-                            <div css={titleStyles(collapsed)}>{title}</div>
+            <FontsContext.Consumer>
+                {({ bodySans }: FontsContextInterface) => (
+                    <>
+                        <div css={titleTabStyles}>
+                            <div
+                                css={css`
+                                    flex-grow: 1;
+                                    display: flex;
+                                `}
+                                onClick={() => {
+                                    this.toggleCollapsed();
+                                }}
+                            >
+                                <CollapseItemButton collapsed={collapsed} />
+                                <div css={titleContainerStyles}>
+                                    <div css={titleStyles(collapsed, bodySans)}>
+                                        {title}
+                                    </div>
+                                </div>
+                            </div>
+                            {value !== undefined && (
+                                <OnOffRadio
+                                    selectedValue={value}
+                                    onChangeHandler={updateItem}
+                                    showError={showError}
+                                />
+                            )}
                         </div>
-                    </div>
-                    {value !== undefined && (
-                        <OnOffRadio
-                            selectedValue={value}
-                            onChangeHandler={updateItem}
-                            showError={showError}
-                        />
-                    )}
-                </div>
-                <div css={panelStyles(collapsed)}>{children}</div>
-            </>
+                        <div css={panelStyles(collapsed, bodySans)}>
+                            {children}
+                        </div>
+                    </>
+                )}
+            </FontsContext.Consumer>
         );
     }
 

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -31,6 +31,13 @@ const overlayStyles = css`
         transition-duration: ${TRANSITION_TIME / 2}ms;
         will-change: background-color;
     }
+    box-sizing: border-box;
+
+    *,
+    *:before,
+    *:after {
+        box-sizing: inherit;
+    }
 `;
 
 const activeOverlayStyles = css`

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -3,8 +3,14 @@ import { css } from '@emotion/core';
 import { mobileLandscape, palette, space } from '@guardian/src-foundations';
 import { Logo } from './svgs/Logo';
 import { ConsentPreferencesDashboard } from './ConsentPreferencesDashboard';
-import { SCROLLABLE_ID, CONTENT_ID } from './utils/config';
+import { FontsContext } from './FontsContext';
+import {
+    SCROLLABLE_ID,
+    CONTENT_ID,
+    DEFAULT_FONT_FAMILIES,
+} from './utils/config';
 import { setSource, setVariant } from '../store';
+import { FontsContextInterface } from '../types';
 
 const TRANSITION_TIME = 1000;
 
@@ -130,8 +136,8 @@ interface Props {
     onClose: () => void;
     source?: string;
     variant?: string;
+    fontFamilies?: FontsContextInterface;
 }
-
 class ConsentManagementPlatform extends Component<Props, State> {
     scrollableRef: React.RefObject<HTMLDivElement>;
 
@@ -164,64 +170,70 @@ class ConsentManagementPlatform extends Component<Props, State> {
         }
 
         return (
-            <div
-                css={css`
-                    ${overlayStyles};
-                    ${active ? activeOverlayStyles : ''};
-                    ${visible ? showOverlayStyles : ''};
-                `}
+            <FontsContext.Provider
+                value={this.props.fontFamilies || DEFAULT_FONT_FAMILIES}
             >
                 <div
                     css={css`
-                        ${scrollableStyles};
-                        ${visible ? showScrollableStyles(scrollableWidth) : ''};
+                        ${overlayStyles};
+                        ${active ? activeOverlayStyles : ''};
+                        ${visible ? showOverlayStyles : ''};
                     `}
-                    id={SCROLLABLE_ID}
-                    ref={this.scrollableRef}
                 >
-                    <div css={headerStyles}>
-                        <div css={logoContainer}>
-                            <Logo css={logoStyles} />
+                    <div
+                        css={css`
+                            ${scrollableStyles};
+                            ${visible
+                                ? showScrollableStyles(scrollableWidth)
+                                : ''};
+                        `}
+                        id={SCROLLABLE_ID}
+                        ref={this.scrollableRef}
+                    >
+                        <div css={headerStyles}>
+                            <div css={logoContainer}>
+                                <Logo css={logoStyles} />
+                            </div>
+                        </div>
+                        <div css={contentStyles} id={CONTENT_ID}>
+                            <ConsentPreferencesDashboard
+                                showCmp={() => {
+                                    this.setState(
+                                        {
+                                            active: true,
+                                        },
+                                        () => {
+                                            this.setState({
+                                                visible: true,
+                                            });
+                                        },
+                                    );
+                                }}
+                                hideCmp={() => {
+                                    this.setState(
+                                        {
+                                            visible: false,
+                                        },
+                                        () => {
+                                            // delay by TRANSITION_TIME before deactivating
+                                            setTimeout(() => {
+                                                this.setState(
+                                                    {
+                                                        active: false,
+                                                    },
+                                                    () => {
+                                                        this.props.onClose();
+                                                    },
+                                                );
+                                            }, TRANSITION_TIME);
+                                        },
+                                    );
+                                }}
+                            />
                         </div>
                     </div>
-                    <div css={contentStyles} id={CONTENT_ID}>
-                        <ConsentPreferencesDashboard
-                            showCmp={() => {
-                                this.setState(
-                                    {
-                                        active: true,
-                                    },
-                                    () => {
-                                        this.setState({
-                                            visible: true,
-                                        });
-                                    },
-                                );
-                            }}
-                            hideCmp={() => {
-                                this.setState(
-                                    {
-                                        visible: false,
-                                    },
-                                    () => {
-                                        // delay by TRANSITION_TIME before deactivating
-                                        setTimeout(() => {
-                                            this.setState(
-                                                {
-                                                    active: false,
-                                                },
-                                                () => {
-                                                    this.props.onClose();
-                                                },
-                                            );
-                                        }, TRANSITION_TIME);
-                                    },
-                                );
-                            }}
-                        />
-                    </div>
                 </div>
-            </div>
+            </FontsContext.Provider>
         );
     }
 }

--- a/src/component/ConsentPreferencesDashboard.tsx
+++ b/src/component/ConsentPreferencesDashboard.tsx
@@ -14,7 +14,12 @@ import { CmpListItem } from './CmpListItem';
 import { Vendors } from './Vendors';
 import { Features } from './Features';
 import { ArrowIcon } from './svgs/ArrowIcon';
-import { getConsentState, setConsentState, getVendorList } from '../store';
+import {
+    getConsentState,
+    setConsentState,
+    getVendorList,
+    getVariant,
+} from '../store';
 import { SCROLLABLE_ID, CONTENT_ID, PURPOSES_ID } from './utils/config';
 import {
     IabFeature,
@@ -23,14 +28,16 @@ import {
     IabVendor,
     IabVendorList,
     ParsedIabVendorList,
+    FontsContextInterface,
 } from '../types';
+import { FontsContext } from './FontsContext';
 
 const privacyPolicyURL = 'https://www.theguardian.com/info/privacy';
 const cookiePolicyURL = 'https://www.theguardian.com/info/cookies';
 const smallSpace = space[2]; // 12px
 const mediumSpace = smallSpace + smallSpace / 3; // 16px
 
-const formStyles = css`
+const formStyles = (headlineSerif: string, bodySerif: string) => css`
     color: ${palette.neutral[100]};
     padding: ${smallSpace}px ${smallSpace}px 0 ${smallSpace}px;
 
@@ -42,7 +49,7 @@ const formStyles = css`
         font-size: 20px;
         line-height: 24px;
         font-weight: 700;
-        font-family: 'Guardian Egyptian Web', Georgia, serif;
+        font-family: ${headlineSerif};
         margin-bottom: 12px;
     }
 
@@ -50,7 +57,7 @@ const formStyles = css`
         margin-bottom: 16px;
         font-size: 17px;
         line-height: 24px;
-        font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+        font-family: ${bodySerif};
     }
 
     a,
@@ -120,7 +127,7 @@ const topButtonContainerStyles = css`
     }
 `;
 
-const buttonStyles = css`
+const buttonStyles = (bodySans: string) => css`
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
@@ -128,8 +135,7 @@ const buttonStyles = css`
     text-decoration: none;
     font-size: 16px;
     line-height: 22px;
-    font-family: 'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial,
-        Lucida Grande, sans-serif;
+    font-family: ${bodySans};
     font-weight: 700;
     box-sizing: border-box;
     border: none;
@@ -187,7 +193,7 @@ const blueButtonStyles = css`
     }
 `;
 
-const bottomButtonContainerStyles = css`
+const bottomButtonContainerStyles = (bodySerif: string) => css`
     padding: ${smallSpace / 2}px ${smallSpace}px ${smallSpace}px ${smallSpace}px;
     margin-bottom: 12px;
     ${mobileLandscape} {
@@ -197,12 +203,12 @@ const bottomButtonContainerStyles = css`
     p {
         font-size: 15px;
         line-height: 20px;
-        font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+        font-family: ${bodySerif};
         font-weight: 700;
     }
 `;
 
-const validationErrorStyles = css`
+const validationErrorStyles = (bodySerif: string) => css`
     display: block;
     background-color: ${palette.news.bright};
     padding: ${smallSpace / 2}px ${smallSpace}px;
@@ -217,7 +223,7 @@ const validationErrorStyles = css`
     p {
         font-size: 15px;
         line-height: 20px;
-        font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+        font-family: ${bodySerif};
         font-weight: 700;
         margin: 0;
     }
@@ -263,159 +269,185 @@ export class ConsentPreferencesDashboard extends Component<Props, State> {
         const firstIabPurposeList = iabPurposesList.slice(0, 3);
         const secondIabPurposeList = iabPurposesList.slice(3);
         const { iabNullResponses } = this.state;
+        const showCancel = getVariant() !== 'CmpUiNonDismissable-variant';
 
         return (
-            <>
-                <img
-                    src="https://manage.theguardian.com/static/images/consent-graphic.png"
-                    css={css`
-                        width: 100%;
-                    `}
-                />
-                <form css={formStyles}>
-                    <h1>
-                        Please review and manage your data and privacy settings
-                        below.
-                    </h1>
-                    <p>
-                        When you visit this site, we&apos;d like to use cookies
-                        and identifiers to understand things like which pages
-                        you&apos;ve visited and how long you&apos;ve spent with
-                        us. It helps us improve our service to you.{' '}
-                    </p>
-                    <p>
-                        Our advertising partners would like to do the same – so
-                        the adverts are more relevant, and we make more money to
-                        invest in Guardian journalism. By using this site, you
-                        agree to our{' '}
-                        <a
-                            href={privacyPolicyURL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            privacy
-                        </a>{' '}
-                        and{' '}
-                        <a
-                            href={cookiePolicyURL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            cookie
-                        </a>{' '}
-                        policies
-                    </p>
-                    <div
-                        css={css`
-                            ${buttonContainerStyles};
-                            ${topButtonContainerStyles};
-                        `}
-                    >
-                        <button
-                            type="button"
-                            onClick={() => {
-                                scrollToPurposes();
-                            }}
+            <FontsContext.Consumer>
+                {({
+                    headlineSerif,
+                    bodySerif,
+                    bodySans,
+                }: FontsContextInterface) => (
+                    <>
+                        <img
+                            src="https://manage.theguardian.com/static/images/consent-graphic.png"
                             css={css`
-                                ${buttonStyles};
-                                ${blueButtonStyles};
+                                width: 100%;
                             `}
-                        >
-                            Options
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => {
-                                this.enableAllAndClose();
-                            }}
-                            css={css`
-                                ${buttonStyles};
-                                ${yellowButtonStyles};
-                            `}
-                        >
-                            Enable all and close
-                            <ArrowIcon />
-                        </button>
-                    </div>
-                    <div css={purposesContainerStyles} id={PURPOSES_ID}>
-                        <ul css={cmpListStyles}>{firstIabPurposeList}</ul>
-                        {/*
+                        />
+                        <form css={formStyles(headlineSerif, bodySerif)}>
+                            <h1>
+                                Please review and manage your data and privacy
+                                settings below.
+                            </h1>
+                            <p>
+                                When you visit this site, we&apos;d like to use
+                                cookies and identifiers to understand things
+                                like which pages you&apos;ve visited and how
+                                long you&apos;ve spent with us. It helps us
+                                improve our service to you.{' '}
+                            </p>
+                            <p>
+                                Our advertising partners would like to do the
+                                same – so the adverts are more relevant, and we
+                                make more money to invest in Guardian
+                                journalism. By using this site, you agree to our{' '}
+                                <a
+                                    href={privacyPolicyURL}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    privacy
+                                </a>{' '}
+                                and{' '}
+                                <a
+                                    href={cookiePolicyURL}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    cookie
+                                </a>{' '}
+                                policies
+                            </p>
+                            <div
+                                css={css`
+                                    ${buttonContainerStyles};
+                                    ${topButtonContainerStyles};
+                                `}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        scrollToPurposes();
+                                    }}
+                                    css={css`
+                                        ${buttonStyles(bodySans)};
+                                        ${blueButtonStyles};
+                                    `}
+                                >
+                                    Options
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        this.enableAllAndClose();
+                                    }}
+                                    css={css`
+                                        ${buttonStyles(bodySans)};
+                                        ${yellowButtonStyles};
+                                    `}
+                                >
+                                    Enable all and close
+                                    <ArrowIcon />
+                                </button>
+                            </div>
+                            <div css={purposesContainerStyles} id={PURPOSES_ID}>
+                                <ul css={cmpListStyles}>
+                                    {firstIabPurposeList}
+                                </ul>
+                                {/*
                             renderIabPurposeItems,
                             renderVendorItems and renderFeatureItems
                             should be in single <ul> once renderGuPurposeItems
                             is restored.
                         */}
-                        <div>
-                            <ul css={cmpListStyles}>{secondIabPurposeList}</ul>
-                            {this.iabVendorList && (
-                                <Vendors vendors={this.iabVendorList.vendors} />
-                            )}
-                            {this.iabVendorList && (
-                                <Features
-                                    features={this.iabVendorList.features}
-                                />
-                            )}
-                            <div
-                                css={css`
-                                    ${buttonContainerStyles};
-                                    ${bottomButtonContainerStyles};
-                                `}
-                            >
-                                {!!(
-                                    iabNullResponses && iabNullResponses.length
-                                ) && (
+                                <div>
+                                    <ul css={cmpListStyles}>
+                                        {secondIabPurposeList}
+                                    </ul>
+                                    {this.iabVendorList && (
+                                        <Vendors
+                                            vendors={this.iabVendorList.vendors}
+                                        />
+                                    )}
+                                    {this.iabVendorList && (
+                                        <Features
+                                            features={
+                                                this.iabVendorList.features
+                                            }
+                                        />
+                                    )}
                                     <div
-                                        role="alert"
-                                        css={validationErrorStyles}
+                                        css={css`
+                                            ${buttonContainerStyles};
+                                            ${bottomButtonContainerStyles(
+                                                bodySerif,
+                                            )};
+                                        `}
                                     >
+                                        {!!(
+                                            iabNullResponses &&
+                                            iabNullResponses.length
+                                        ) && (
+                                            <div
+                                                role="alert"
+                                                css={validationErrorStyles(
+                                                    bodySerif,
+                                                )}
+                                            >
+                                                <p>
+                                                    Please set all privacy
+                                                    options to continue.
+                                                </p>
+                                            </div>
+                                        )}
                                         <p>
-                                            Please set all privacy options to
-                                            continue.
+                                            You can change the above settings
+                                            for this browser at any time by
+                                            accessing our{' '}
+                                            <a
+                                                href={privacyPolicyURL}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
+                                                privacy policy
+                                            </a>
+                                            .
                                         </p>
+                                        {showCancel && (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    this.close();
+                                                }}
+                                                css={css`
+                                                    ${buttonStyles(bodySans)};
+                                                    ${blueButtonStyles};
+                                                `}
+                                            >
+                                                Cancel
+                                            </button>
+                                        )}
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                this.saveAndClose();
+                                            }}
+                                            css={css`
+                                                ${buttonStyles(bodySans)};
+                                                ${yellowButtonStyles};
+                                            `}
+                                        >
+                                            <span>Save and continue</span>
+                                            <ArrowIcon />
+                                        </button>
                                     </div>
-                                )}
-                                <p>
-                                    You can change the above settings for this
-                                    browser at any time by accessing our{' '}
-                                    <a
-                                        href={privacyPolicyURL}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        privacy policy
-                                    </a>
-                                    .
-                                </p>
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        this.close();
-                                    }}
-                                    css={css`
-                                        ${buttonStyles};
-                                        ${blueButtonStyles};
-                                    `}
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        this.saveAndClose();
-                                    }}
-                                    css={css`
-                                        ${buttonStyles};
-                                        ${yellowButtonStyles};
-                                    `}
-                                >
-                                    <span>Save and continue</span>
-                                    <ArrowIcon />
-                                </button>
+                                </div>
                             </div>
-                        </div>
-                    </div>
-                </form>
-            </>
+                        </form>
+                    </>
+                )}
+            </FontsContext.Consumer>
         );
     }
 

--- a/src/component/FontsContext.tsx
+++ b/src/component/FontsContext.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { DEFAULT_FONT_FAMILIES } from './utils/config';
+import { FontsContextInterface } from '../types';
+
+export const FontsContext = React.createContext<FontsContextInterface>(
+    DEFAULT_FONT_FAMILIES,
+);

--- a/src/component/OnOffRadio.tsx
+++ b/src/component/OnOffRadio.tsx
@@ -7,7 +7,8 @@ import {
     transitions,
 } from '@guardian/src-foundations';
 import React, { Component } from 'react';
-import { ItemState } from '../types';
+import { ItemState, FontsContextInterface } from '../types';
+import { FontsContext } from './FontsContext';
 
 let idCounter = 0;
 
@@ -90,10 +91,9 @@ const radioLabelStyles = (disabled: boolean) => css`
         }
     }
 `;
-const radioLabelTextStyles = (disabled: boolean) => css`
+const radioLabelTextStyles = (disabled: boolean, bodySans: string) => css`
     position: relative;
-    font-family: 'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial,
-        Lucida Grande, sans-serif;
+    font-family: ${bodySans};
     font-size: 17px;
     color: ${disabled ? palette.brand.pastel : palette.neutral[100]};
 `;
@@ -124,50 +124,62 @@ export class OnOffRadio extends Component<Props, {}> {
             : {};
 
         return (
-            <div css={radioContainerStyles}>
-                <label css={radioLabelStyles(disabled)}>
-                    <input
-                        id={offId}
-                        name={id}
-                        type="radio"
-                        value="off"
-                        onChange={(
-                            evt: React.ChangeEvent<HTMLInputElement>,
-                        ) => {
-                            this.updateValue(evt);
-                        }}
-                        defaultChecked={selectedValue === false}
-                        css={css`
-                            ${radioInputStyles};
-                            ${showError ? errorStyles : ''};
-                        `}
-                        disabled={disabled}
-                        {...validationProps}
-                    />
-                    <span css={radioLabelTextStyles(disabled)}>Off</span>
-                </label>
-                <label css={radioLabelStyles(disabled)}>
-                    <input
-                        id={onId}
-                        name={id}
-                        type="radio"
-                        value="on"
-                        onChange={(
-                            evt: React.ChangeEvent<HTMLInputElement>,
-                        ) => {
-                            this.updateValue(evt);
-                        }}
-                        defaultChecked={selectedValue === true}
-                        css={css`
-                            ${radioInputStyles};
-                            ${showError ? errorStyles : ''};
-                        `}
-                        disabled={disabled}
-                        {...validationProps}
-                    />
-                    <span css={radioLabelTextStyles(disabled)}>On</span>
-                </label>
-            </div>
+            <FontsContext.Consumer>
+                {({ bodySans }: FontsContextInterface) => (
+                    <div css={radioContainerStyles}>
+                        <label css={radioLabelStyles(disabled)}>
+                            <input
+                                id={offId}
+                                name={id}
+                                type="radio"
+                                value="off"
+                                onChange={(
+                                    evt: React.ChangeEvent<HTMLInputElement>,
+                                ) => {
+                                    this.updateValue(evt);
+                                }}
+                                defaultChecked={selectedValue === false}
+                                css={css`
+                                    ${radioInputStyles};
+                                    ${showError ? errorStyles : ''};
+                                `}
+                                disabled={disabled}
+                                {...validationProps}
+                            />
+                            <span
+                                css={radioLabelTextStyles(disabled, bodySans)}
+                            >
+                                Off
+                            </span>
+                        </label>
+                        <label css={radioLabelStyles(disabled)}>
+                            <input
+                                id={onId}
+                                name={id}
+                                type="radio"
+                                value="on"
+                                onChange={(
+                                    evt: React.ChangeEvent<HTMLInputElement>,
+                                ) => {
+                                    this.updateValue(evt);
+                                }}
+                                defaultChecked={selectedValue === true}
+                                css={css`
+                                    ${radioInputStyles};
+                                    ${showError ? errorStyles : ''};
+                                `}
+                                disabled={disabled}
+                                {...validationProps}
+                            />
+                            <span
+                                css={radioLabelTextStyles(disabled, bodySans)}
+                            >
+                                On
+                            </span>
+                        </label>
+                    </div>
+                )}
+            </FontsContext.Consumer>
         );
     }
 

--- a/src/component/utils/config.ts
+++ b/src/component/utils/config.ts
@@ -1,3 +1,13 @@
 export const SCROLLABLE_ID = 'cmpScrollable';
 export const CONTENT_ID = 'cmpContent';
 export const PURPOSES_ID = 'cmpPurposes';
+export const DEFAULT_FONT_FAMILIES: {
+    headlineSerif: string;
+    bodySerif: string;
+    bodySans: string;
+} = {
+    headlineSerif: "'Guardian Egyptian Web', Georgia, serif",
+    bodySerif: "'Guardian Text Egyptian Web', Georgia, serif",
+    bodySans:
+        "'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
+};

--- a/src/component/utils/config.ts
+++ b/src/component/utils/config.ts
@@ -1,13 +1,11 @@
+import { FontsContextInterface } from '../../types';
+
 export const SCROLLABLE_ID = 'cmpScrollable';
 export const CONTENT_ID = 'cmpContent';
 export const PURPOSES_ID = 'cmpPurposes';
-export const DEFAULT_FONT_FAMILIES: {
-    headlineSerif: string;
-    bodySerif: string;
-    bodySans: string;
-} = {
-    headlineSerif: "'Guardian Egyptian Web', Georgia, serif",
-    bodySerif: "'Guardian Text Egyptian Web', Georgia, serif",
+export const DEFAULT_FONT_FAMILIES: FontsContextInterface = {
+    headlineSerif: 'GH Guardian Headline, Georgia, serif',
+    bodySerif: 'GuardianTextEgyptian, Georgia, serif',
     bodySans:
-        "'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
+        'GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,9 @@ export interface ParsedIabVendorList extends IabVendorList {
 export interface ParsedIabVendor extends IabVendor {
     description: React.ReactNode;
 }
+
+export interface FontsContextInterface {
+    headlineSerif: string;
+    bodySerif: string;
+    bodySans: string;
+}


### PR DESCRIPTION
Currently the `font-family` names we use in the CSS-in-JS for the CMP UI component are hardcoded to be the same as the `font-family` names used on `frontend`. 

Unfortunately, although the font files on `frontend` are up to date the `font-family` names it uses are the out of date legacy `font-family` names. For example...

Legacy headline font-family: `Guardian Egyptian Web, Georgia, serif`
Up to date headline font-family: `GH Guardian Headline, Georgia, serif` 

Other platforms on which the new CMP UI will run (dotcom-rendering for example) use the up to date files AND the up to date `font-family` names too.

This PR updates the `<ConsentManagementPlatform>` component to take a new prop `fontFamilies`. This optional prop looks like:

```js
<ConsentManagementPlatform fontFamilies={{
  headlineSerif: "GH Guardian Headline, Georgia, serif",
  bodySerif: "GuardianTextEgyptian, Georgia, serif",
  bodySans: "GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
}} />
```

This prop allows consumers of the `<ConsentManagementPlatform>` component to pass in the correct `font-family` names in use for their platform.

In the `<ConsentManagementPlatform>` component I've created a new React [context](https://reactjs.org/docs/context.html)  called `<FontsContext>`. 

> Context provides a way to pass data through the component tree without having to pass props down manually at every level.

I'm using context so we don't have to pass the `fontFamilies` prop down the component tree to every component that needs to use font styles. Below is an example of how a component that needs to use font styles can "consume" the context:

```js
<FontsContext.Consumer>
  {({ headlineSerif }) => (
    <h1 css={css`font-family: ${headlineSerif}`}>Hello World</h1>
  )}
</FontsContext.Consumer>
```

As mentioned earlier the fontFamilies property passed to  `<ConsentManagementPlatform>` is optional, if nothing is passed the context will use the `DEFAULT_FONT_FAMILIES`, which are the latest `font-family` names. 

**In time hopefully all platforms will use the same `font-family` names and we can remove this requirement to support multiple `font-family` names for the same font file!**
