### PR TITLE
Call state change handlers only when consent is not the same

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -90,8 +90,8 @@ const notOkResponse = {
 };
 
 const guDefaultState = { functional: true, performance: true };
-const iabDefaultState = { 1: null, 2: null, 3: null, 4: null, 5: null };
 const guMixedState = { functional: true, performance: false };
+const iabDefaultState = { 1: null, 2: null, 3: null, 4: null, 5: null };
 const iabTrueState = { 1: true, 2: true, 3: true, 4: true, 5: true };
 const legacyTrueCookie = '1.54321';
 const fakeIabString = 'UH IH OH HA HA';
@@ -198,24 +198,35 @@ describe('Store', () => {
     });
 
     describe('setConsentState', () => {
-        it('triggers StateChange handlers correctly', () => {
+        it('does not trigger StateChange handlers when the consent state is the same', () => {
             registerStateChangeHandler(myCallBack);
 
             return expect(setConsentState(guDefaultState, iabDefaultState))
                 .resolves.toBeUndefined()
                 .then(() => {
-                    return setConsentState(guMixedState, iabTrueState);
+                    expect(myCallBack).not.toHaveBeenCalled();
+                });
+        });
+
+        it('triggers StateChange handlers correctly when the new consent state is not the same', () => {
+            registerStateChangeHandler(myCallBack);
+
+            return expect(setConsentState(guMixedState, iabTrueState))
+                .resolves.toBeUndefined()
+                .then(() => {
+                    return setConsentState(guDefaultState, iabDefaultState);
                 })
                 .then(() => {
                     expect(myCallBack).toHaveBeenCalledTimes(2);
+
                     expect(myCallBack).toHaveBeenNthCalledWith(
                         1,
-                        guDefaultState,
-                        iabDefaultState,
-                    );
-                    expect(myCallBack).toHaveBeenLastCalledWith(
                         guMixedState,
                         iabTrueState,
+                    );
+                    expect(myCallBack).toHaveBeenLastCalledWith(
+                        guDefaultState,
+                        iabDefaultState,
                     );
                 });
         });

--- a/src/store.ts
+++ b/src/store.ts
@@ -133,9 +133,7 @@ const setConsentState = (
 ): Promise<void> => {
     init();
 
-    const stateChanged =
-        JSON.stringify(guState) !== JSON.stringify(newGuState) ||
-        JSON.stringify(iabState) !== JSON.stringify(newIabState);
+    const triggerCallbacks = stateChanged(newGuState, newIabState);
 
     guState = newGuState;
     iabState = newIabState;
@@ -177,7 +175,7 @@ const setConsentState = (
             }
         })
         .finally(() => {
-            if (stateChanged) {
+            if (triggerCallbacks) {
                 onStateChange.forEach((callback: onStateChangeFn): void => {
                     callback(guState, iabState);
                 });
@@ -193,6 +191,32 @@ const setSource = (newSource: string): void => {
 
 const setVariant = (newVariant: string): void => {
     variant = newVariant;
+};
+
+const stateChanged = (
+    guNew: GuPurposeState,
+    iabNew: IabPurposeState,
+): boolean => {
+    if (
+        Object.keys(guNew).length !== Object.keys(guState).length ||
+        Object.keys(iabNew).length !== Object.keys(iabState).length
+    ) {
+        return true;
+    }
+
+    return (
+        Object.keys(guNew).reduce(
+            (acc, key) => acc || guNew[key] !== guState[key],
+            false as boolean,
+        ) ||
+        Object.keys(iabNew).reduce(
+            (acc, key) => {
+                const keyAsNum = parseInt(key, 10);
+                return acc || iabNew[keyAsNum] !== iabState[keyAsNum];
+            },
+            false as boolean,
+        )
+    );
 };
 
 export {

--- a/src/store.ts
+++ b/src/store.ts
@@ -132,6 +132,11 @@ const setConsentState = (
     newIabState: IabPurposeState,
 ): Promise<void> => {
     init();
+
+    const stateChanged =
+        JSON.stringify(guState) !== JSON.stringify(newGuState) ||
+        JSON.stringify(iabState) !== JSON.stringify(newIabState);
+
     guState = newGuState;
     iabState = newIabState;
 
@@ -172,9 +177,11 @@ const setConsentState = (
             }
         })
         .finally(() => {
-            onStateChange.forEach((callback: onStateChangeFn): void => {
-                callback(guState, iabState);
-            });
+            if (stateChanged) {
+                onStateChange.forEach((callback: onStateChangeFn): void => {
+                    callback(guState, iabState);
+                });
+            }
 
             return Promise.resolve();
         });


### PR DESCRIPTION
Currently we trigger the `onStateChange` callbacks every time the state is set through `setConsentState()`. However the state being set might be the same as the current, in which case there's no use triggering the `onStateChange` callbacks. This is what this PR changes.