### PR TITLE
Fix parameter used when calling setConsentState

### DIFF
--- a/src/component/ConsentPreferencesDashboard.tsx
+++ b/src/component/ConsentPreferencesDashboard.tsx
@@ -526,7 +526,7 @@ export class ConsentPreferencesDashboard extends Component<Props, State> {
             return false;
         }
 
-        setConsentState({}, this.state.iabPurposes);
+        setConsentState({}, stateToSave.iabPurposes);
 
         return true;
     }


### PR DESCRIPTION
...as it was using the wrong one and making the script pass all Nulls when the user clicked 'Enable all and continue'