### PR TITLE
Unified build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,73 +1,74 @@
 {
-  "name": "@guardian/consent-management-platform",
-  "version": "1.1.0-beta.4",
-  "description": "Library of useful utilities for managing consent state across *.theguardian.com",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "scripts": {
-    "build": "yarn clean && tsc && rollup --config",
-    "clean": "rm -rf lib/*",
-    "test": "jest --config jestconfig.json",
-    "lint": "eslint src/**/*.ts src/**/*.tsx",
-    "tsc": "tsc --noEmit",
-    "validate": "yarn tsc && yarn lint && yarn test",
-    "fix": "yarn validate --fix",
-    "prepublishOnly": "yarn validate && yarn build"
-  },
-  "husky": {
-    "hooks": {
-      "pre-push": "yarn validate"
-    }
-  },
-  "repository": "https://github.com/guardian/consent-management-platform.git",
-  "homepage": "https://github.com/guardian/consent-management-platform.git",
-  "author": "George Haberis <george.haberis@guardian.co.uk>",
-  "contributors": [
-    "Ricardo Costa <ricardo.costa@guardian.co.uk>"
-  ],
-  "license": "Apache-2.0",
-  "dependencies": {
-    "@guardian/src-foundations": "^0.2.3",
-    "consent-string": "^1.5.1",
-    "js-cookie": "^2.2.1",
-    "whatwg-fetch": "^3.0.0"
-  },
-  "peerDependencies": {
-    "@emotion/core": "^10.0.21",
-    "react": "^16.10.2"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.6.4",
-    "@babel/plugin-proposal-class-properties": "^7.5.5",
-    "@babel/preset-env": "^7.6.3",
-    "@babel/preset-react": "^7.6.3",
-    "@babel/preset-typescript": "^7.6.0",
-    "@emotion/babel-preset-css-prop": "^10.0.17",
-    "@emotion/core": "^10.0.21",
-    "@types/jest": "^24.0.16",
-    "@types/js-cookie": "^2.2.2",
-    "@types/react": "^16.9.9",
-    "@typescript-eslint/eslint-plugin": "^2.1.0",
-    "@typescript-eslint/parser": "^1.13.0",
-    "eslint": "^6.3.0",
-    "eslint-config-airbnb-typescript": "^4.0.1",
-    "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jest": "^22.14.1",
-    "eslint-plugin-prettier": "^3.1.0",
-    "eslint-plugin-react": "^7.16.0",
-    "husky": "^3.0.2",
-    "jest": "^24.8.0",
-    "prettier": "^1.18.2",
-    "react": "^16.10.2",
-    "rollup": "^1.24.0",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "ts-jest": "^24.0.2",
-    "typescript": "^3.5.3"
-  },
-  "files": [
-    "lib/**/*"
-  ]
+    "name": "@guardian/consent-management-platform",
+    "version": "2.0.0",
+    "description": "Library of useful utilities for managing consent state across *.theguardian.com",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "scripts": {
+        "build": "yarn validate && yarn clean && rollup --config",
+        "clean": "rm -rf lib/*",
+        "test": "jest --config jestconfig.json",
+        "lint": "eslint src/**/*.ts src/**/*.tsx",
+        "tsc": "tsc --noEmit",
+        "validate": "yarn tsc && yarn lint && yarn test",
+        "fix": "yarn validate --fix",
+        "prepublishOnly": "yarn build"
+    },
+    "husky": {
+        "hooks": {
+            "pre-push": "yarn validate"
+        }
+    },
+    "repository": "https://github.com/guardian/consent-management-platform.git",
+    "homepage": "https://github.com/guardian/consent-management-platform.git",
+    "author": "George Haberis <george.haberis@guardian.co.uk>",
+    "contributors": [
+        "Ricardo Costa <ricardo.costa@guardian.co.uk>"
+    ],
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@guardian/src-foundations": "^0.2.3",
+        "consent-string": "^1.5.1",
+        "js-cookie": "^2.2.1",
+        "whatwg-fetch": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@emotion/core": "^10.0.21",
+        "react": "^16.10.2"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.6.4",
+        "@babel/plugin-proposal-class-properties": "^7.5.5",
+        "@babel/preset-env": "^7.6.3",
+        "@babel/preset-react": "^7.6.3",
+        "@babel/preset-typescript": "^7.6.0",
+        "@emotion/babel-preset-css-prop": "^10.0.17",
+        "@emotion/core": "^10.0.21",
+        "@types/jest": "^24.0.16",
+        "@types/js-cookie": "^2.2.2",
+        "@types/react": "^16.9.9",
+        "@typescript-eslint/eslint-plugin": "^2.1.0",
+        "@typescript-eslint/parser": "^1.13.0",
+        "eslint": "^6.3.0",
+        "eslint-config-airbnb-typescript": "^4.0.1",
+        "eslint-config-prettier": "^6.0.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-jest": "^22.14.1",
+        "eslint-plugin-prettier": "^3.1.0",
+        "eslint-plugin-react": "^7.16.0",
+        "husky": "^3.0.2",
+        "jest": "^24.8.0",
+        "prettier": "^1.18.2",
+        "react": "^16.10.2",
+        "rollup": "^1.24.0",
+        "rollup-plugin-babel": "^4.3.3",
+        "rollup-plugin-commonjs": "^10.1.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-typescript2": "^0.25.2",
+        "ts-jest": "^24.0.2",
+        "typescript": "^3.7.2"
+    },
+    "files": [
+        "lib/**/*"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-typescript2": "^0.25.2",
         "ts-jest": "^24.0.2",
-        "typescript": "^3.7.2"
+        "typescript": "~3.5.3"
     },
     "files": [
         "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
         "build": "yarn validate && yarn build-only",
         "build-only": "yarn clean && rollup --config && yarn declaration",
         "clean": "rm -rf lib/*",
-        "test": "jest --config jestconfig.json",
-        "lint": "eslint src/**/*.ts src/**/*.tsx",
-        "tsc": "tsc --noEmit",
-        "validate": "yarn tsc && yarn lint && yarn test",
-        "fix": "yarn validate --fix",
         "declaration": "tsc --emitDeclarationOnly -d -m commonjs && mv ./lib/component/ConsentManagementPlatform.d.ts ./lib && sed -i '' 's/\\.\\././g' ./lib/ConsentManagementPlatform.d.ts && rm -rf ./lib/component",
-        "prepublishOnly": "yarn build"
+        "fix": "yarn validate --fix",
+        "lint": "eslint src/**/*.ts src/**/*.tsx",
+        "prepublishOnly": "yarn build",
+        "test": "jest --config jestconfig.json",
+        "tsc": "tsc --noEmit",
+        "validate": "yarn tsc && yarn lint && yarn test"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
-        "build": "yarn validate && yarn clean && rollup --config && yarn declaration",
+        "build": "yarn validate && yarn build-only",
+        "build-only": "yarn clean && rollup --config && yarn declaration",
         "clean": "rm -rf lib/*",
         "test": "jest --config jestconfig.json",
         "lint": "eslint src/**/*.ts src/**/*.tsx",
         "tsc": "tsc --noEmit",
         "validate": "yarn tsc && yarn lint && yarn test",
         "fix": "yarn validate --fix",
-        "declaration": "tsc --emitDeclarationOnly -t es5 -m commonjs --lib 'dom, es7' -d --outDir ./lib  --strict true --jsx preserve && mv ./lib/component/ConsentManagementPlatform.d.ts ./lib && sed -i '' 's/\\.\\././g' ./lib/ConsentManagementPlatform.d.ts && rm -rf ./lib/component",
+        "declaration": "tsc --emitDeclarationOnly -d -m commonjs && mv ./lib/component/ConsentManagementPlatform.d.ts ./lib && sed -i '' 's/\\.\\././g' ./lib/ConsentManagementPlatform.d.ts && rm -rf ./lib/component",
         "prepublishOnly": "yarn build"
     },
     "husky": {

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "scripts": {
-        "build": "yarn validate && yarn clean && rollup --config",
+        "build": "yarn validate && yarn clean && rollup --config && yarn declaration",
         "clean": "rm -rf lib/*",
         "test": "jest --config jestconfig.json",
         "lint": "eslint src/**/*.ts src/**/*.tsx",
         "tsc": "tsc --noEmit",
         "validate": "yarn tsc && yarn lint && yarn test",
         "fix": "yarn validate --fix",
+        "declaration": "tsc --emitDeclarationOnly -t es5 -m commonjs --lib 'dom, es7' -d --outDir ./lib  --strict true --jsx preserve && mv ./lib/component/ConsentManagementPlatform.d.ts ./lib && sed -i '' 's/\\.\\././g' ./lib/ConsentManagementPlatform.d.ts && rm -rf ./lib/component",
         "prepublishOnly": "yarn build"
     },
     "husky": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,17 +1,27 @@
 import babel from 'rollup-plugin-babel';
-import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import typescript from 'rollup-plugin-typescript2';
 
 const extensions = ['.ts', '.tsx'];
 
 module.exports = {
-    input: 'src/component/ConsentManagementPlatform.tsx',
+    input: ['src/index.ts', 'src/component/ConsentManagementPlatform.tsx'],
     output: [
         {
-            file: 'lib/ConsentManagementPlatform.js',
+            dir: 'lib',
+            format: 'cjs',
+        },
+        {
+            dir: 'lib',
             format: 'cjs',
         },
     ],
     external: ['react', '@emotion/core'],
-    plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+    plugins: [
+        typescript(),
+        babel({ extensions }),
+        resolve({ extensions }),
+        commonjs(),
+    ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,9 @@
 {
     "compilerOptions": {
-        "target": "es5", // compile to es5 since to build a package with browser compatibility.
-        "module": "commonjs",
-        "lib": ["dom", "es7"],
-        "declaration": true, // should export typescript definitions.
-        "outDir": "./lib",
+        // "declaration": true, // should export typescript definitions.
         "strict": true,
         "jsx": "preserve",
+        "noImplicitAny": true,
         "esModuleInterop": true
     },
     "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,17 @@
         // "declaration": true, // should export typescript definitions.
         "strict": true,
         "jsx": "preserve",
-        "noImplicitAny": true,
         "esModuleInterop": true
+
+        // "target": "es5", // compile to es5 since to build a package with browser compatibility.
+        // "module": "commonjs",
+        // "lib": ["dom", "es7"],
+        // "declaration": true, // should export typescript definitions.
+        // "outDir": "./lib",
+        // "strict": true,
+        // "jsx": "preserve"
+
+        // -t es5 -m commonjs --lib "dom, es7" -d --outDir ./lib  --strict true --jsx "preserve"
     },
     "include": ["src/**/*.ts", "src/**/*.tsx"],
     "exclude": ["node_modules", "src/**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,11 @@
 {
     "compilerOptions": {
-        // "declaration": true, // should export typescript definitions.
+        "target": "es5", // compile to es5 since to build a package with browser compatibility.
+        "lib": ["dom", "es7"],
+        "outDir": "./lib",
         "strict": true,
         "jsx": "preserve",
         "esModuleInterop": true
-
-        // "target": "es5", // compile to es5 since to build a package with browser compatibility.
-        // "module": "commonjs",
-        // "lib": ["dom", "es7"],
-        // "declaration": true, // should export typescript definitions.
-        // "outDir": "./lib",
-        // "strict": true,
-        // "jsx": "preserve"
-
-        // -t es5 -m commonjs --lib "dom, es7" -d --outDir ./lib  --strict true --jsx "preserve"
     },
     "include": ["src/**/*.ts", "src/**/*.tsx"],
     "exclude": ["node_modules", "src/**/*.test.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5483,10 +5483,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,6 +1789,11 @@ commander@~2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -2487,6 +2492,15 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-cache-dir@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.1.0.tgz#9935894999debef4cf9f677fdf646d002c4cdecb"
+  integrity sha512-zw+EFiNBNPgI2NTrKkDd1xd7q0cs6wr/iWnr/oUkI0yF9K9GqQ+riIt4aiyFaaqpaWbxPrJXHI+QvmNUQbX+0Q==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.0"
+    pkg-dir "^4.1.0"
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -2553,6 +2567,15 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
+
+fs-extra@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.5:
   version "1.2.6"
@@ -2660,6 +2683,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3588,6 +3616,13 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3744,6 +3779,13 @@ make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
 
 make-error@1.x:
   version "1.3.5"
@@ -4406,7 +4448,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -4770,17 +4812,17 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
+resolve@1.12.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.5.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.5.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -4833,6 +4875,24 @@ rollup-plugin-node-resolve@^5.2.0:
     is-module "^1.0.0"
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-typescript2@^0.25.2:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.25.2.tgz#1a165df08560902da45b355413464caca1765d3a"
+  integrity sha512-+tpZj/ZIf2lwjyjX6xEW1S5Y38/21TB3p6poLodISIia8owMMfIKuFFnWcESE4FPBHkR8XPKqjY0PH9IUJJK+Q==
+  dependencies:
+    find-cache-dir "^3.0.0"
+    fs-extra "8.1.0"
+    resolve "1.12.0"
+    rollup-pluginutils "2.8.1"
+    tslib "1.10.0"
+
+rollup-pluginutils@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup-pluginutils@^2.8.1:
   version "2.8.2"
@@ -5387,7 +5447,7 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -5423,10 +5483,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"
@@ -5468,6 +5528,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Current state
We currently have 2 separate build processes:
- One to build the CMP system that uses tsc
- One to build the CMP UI that uses rollup to bundle.

## The problem
Besides being bad practice to have two separate build processes this is causing unwanted effects where 2 different instances of `store.ts` are created as opposed to only one that is shared between the core and the ui parts of the library.

## The goal
We want to avoid importing the UI components unless the UI needs to be shown, which means having 2 bundles (one for the system and one for UI). These two bundles should use the same instance of the `store.ts` code (or whatever it transpiles to).

## The outcome
This PR makes changes so only a single build process exists. The new process uses rollup to create 2 bundles. As a side effect a common bundle is created that contains the transpiled `store.ts` code that is common to the two bundles.
It also adds a `yarn validate` step to `yarn build` to make sure we're not building something with errors.

**Note**: ~~Because rollup does not bundle declaration files and we now out 2 bundles a file conflict occurs where the `.d.ts` files are generated twice, which fails the build. For this reason the exporting of declaration files was commented out and will be fixed in a later PR.~~ Declaration files are produced by running `tsc --emitDeclarationOnly` and then moving files to the correct place (namely `ConsentManagementPlatform.d.ts`). Unfortunately we can not use `tsconfig.json` for our settings in this case because we need that file for the rollup `tsc` build config, which is slightly different from our declaration config, so the parameters have to be supplied in the command line. This solution isn't the most elegant, but it does work.