### PR TITLE
update getVendorList to use IAB vendor list endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -173,11 +173,10 @@ describe('Store', () => {
         });
     });
 
-    describe('reads cookies and fetches vendor list exactly once', () => {
+    describe('reads cookies exactly once', () => {
         afterEach(() => {
             expect(readIabCookie).toHaveBeenCalledTimes(1);
             expect(readLegacyCookie).toHaveBeenCalledTimes(1);
-            expect(global.fetch).toHaveBeenCalledTimes(1);
         });
 
         it('when registerStateChangeHandler is called first', () => {
@@ -372,6 +371,16 @@ describe('Store', () => {
                     expect(handleError).toHaveBeenCalledWith(
                         `Error fetching vendor list: Error: ${notOkResponse.status} | ${notOkResponse.statusText}`,
                     );
+                });
+        });
+
+        it('fetches vendor list exactly once', () => {
+            return expect(getVendorList())
+                .resolves.toMatchObject(fakeVendorList)
+                .then(() => {
+                    return getVendorList().then(() => {
+                        expect(global.fetch).toHaveBeenCalledTimes(1);
+                    });
                 });
         });
     });


### PR DESCRIPTION
This PR has 2 changes:

1. Temporarily `getVendorList` will use IAB vendor list endpoint instead of our own internal end point whilst we resolve caching issues.
2. Only fetch the vendorList when it's required. Previously we were always fetching the vendor list from `store.init`, even if `store.getVendorList` was never called. this was an enhancement to ensure the vendor list was available as early as possible, but in reality it means we're making many unnecessary request for the vendor list.