### PR TITLE
Polyfill fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -1,3 +1,4 @@
+import 'whatwg-fetch';
 import React, { Component } from 'react';
 import { FontsContext } from './FontsContext';
 import { DEFAULT_FONT_FAMILIES } from './utils/config';

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -40,6 +40,8 @@ interface Props {
 
 class ConsentManagementPlatform extends Component<Props, State> {
     constructor(props: Props) {
+        console.log('***');
+
         super(props);
 
         const { forceModal } = props;


### PR DESCRIPTION
This PR re-introduces the `whatwg-fetch` dependency into the `CMP` component - this is required for older browsers that don't support `window.fetch` (eg. IE11)