### PR TITLE
ShouldShow repermissioning code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The library exports The Guardian's CMP as a React component that can easily be i
 
 #### shouldShow
 
-The `shouldShow` function returns a boolean, it will be `true` if the user does not have the appropriate consent cookies saved and `false` if they do.
+The `shouldShow` function returns a boolean, it will be `true` if the user does not have the appropriate consent cookies saved and `false` if they do. It takes an optional boolean `shouldRepermission`. If this is set to true it will only check for the existence of the IAB cookie, otherwise it will check for both IAB and GU_TK cookies.
 
 **Example:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/cmp-ui.test.ts
+++ b/src/cmp-ui.test.ts
@@ -2,14 +2,17 @@ import { shouldShow } from './cmp-ui';
 import {
     // readGuCookie as _readGuCookie,
     readIabCookie as _readIabCookie,
+    readLegacyCookie as _readLegacyCookie,
 } from './cookies';
 
 // const readGuCookie = _readGuCookie;
 const readIabCookie = _readIabCookie;
+const readLegacyCookie = _readLegacyCookie;
 
 jest.mock('./cookies', () => ({
     // readGuCookie: jest.fn(),
     readIabCookie: jest.fn(),
+    readLegacyCookie: jest.fn(),
 }));
 
 describe('cmp-ui', () => {
@@ -18,14 +21,49 @@ describe('cmp-ui', () => {
     });
 
     describe('shouldShow', () => {
-        it('shouldShow returns true if readIabCookie returns null', () => {
-            readIabCookie.mockReturnValue(null);
-            expect(shouldShow()).toBe(true);
+        describe('with shouldRepermission set to true', () => {
+            it('shouldShow returns true if readIabCookie and readyLegacyCookie both return null', () => {
+                readIabCookie.mockReturnValue(null);
+                readLegacyCookie.mockReturnValue(null);
+                expect(shouldShow(true)).toBe(true);
+            });
+            it('shouldShow returns false if readIabCookie returns a truthy value and readLegacyCookie returns null', () => {
+                readIabCookie.mockReturnValue('foo');
+                readLegacyCookie.mockReturnValue(null);
+                expect(shouldShow(true)).toBe(false);
+            });
+            it('shouldShow returns true if readIabCookie returns null and readLegacyCookie returns a truthy value', () => {
+                readIabCookie.mockReturnValue(null);
+                readLegacyCookie.mockReturnValue('foo');
+                expect(shouldShow(true)).toBe(true);
+            });
+            it('shouldShow returns false if readIabCookie and readLegacyCookie both return a truthy value', () => {
+                readIabCookie.mockReturnValue('foo');
+                readLegacyCookie.mockReturnValue('foo');
+                expect(shouldShow(true)).toBe(false);
+            });
         });
-
-        it('shouldShow returns false if readIabCookie returns truthy value', () => {
-            readIabCookie.mockReturnValue('foo');
-            expect(shouldShow()).toBe(false);
+        describe('with shouldRepermission set to false', () => {
+            it('shouldShow returns true if readIabCookie and readyLegacyCookie both return null', () => {
+                readIabCookie.mockReturnValue(null);
+                readLegacyCookie.mockReturnValue(null);
+                expect(shouldShow(false)).toBe(true);
+            });
+            it('shouldShow returns false if readIabCookie returns a truthy value and readLegacyCookie returns null', () => {
+                readIabCookie.mockReturnValue('foo');
+                readLegacyCookie.mockReturnValue(null);
+                expect(shouldShow(false)).toBe(false);
+            });
+            it('shouldShow returns false if readIabCookie returns null and readLegacyCookie returns a truthy value', () => {
+                readIabCookie.mockReturnValue(null);
+                readLegacyCookie.mockReturnValue('foo');
+                expect(shouldShow(false)).toBe(false);
+            });
+            it('shouldShow returns false if readIabCookie and readLegacyCookie both return a truthy value', () => {
+                readIabCookie.mockReturnValue('foo');
+                readLegacyCookie.mockReturnValue('foo');
+                expect(shouldShow(false)).toBe(false);
+            });
         });
 
         // TODO: Restore tests below once we start saving GU cookie

--- a/src/cmp-ui.ts
+++ b/src/cmp-ui.ts
@@ -1,3 +1,9 @@
-import { readIabCookie } from './cookies';
+import { readIabCookie, readLegacyCookie } from './cookies';
 
-export const shouldShow = (): boolean => !readIabCookie(); // TODO: Restore readGuCookie check once we start saving GU cookie
+export const shouldShow = (shouldRepermission = false): boolean => {
+    if (shouldRepermission) {
+        return !readIabCookie(); // TODO: Restore readGuCookie check once we start saving GU cookie
+    }
+
+    return !readIabCookie() && !readLegacyCookie();
+};

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -68,31 +68,6 @@ describe('Cookies', () => {
         });
         // TODO: update test when PECR purposes introduced
         it('all states provided', () => {
-            writeStateCookies(guConsentState, iabConsentString, true);
-
-            // expect(Cookies.set).toHaveBeenCalledTimes(3);
-            expect(Cookies.set).toHaveBeenCalledTimes(2);
-            expect(Cookies.set).toHaveBeenNthCalledWith(
-                1,
-                LEGACY_COOKIE_NAME,
-                `1.${fakeNow}`,
-                cookieOptions,
-            );
-            // expect(Cookies.set).toHaveBeenNthCalledWith(
-            //     2,
-            //     GU_COOKIE_NAME,
-            //     guCookie,
-            //     cookieOptions,
-            // );
-            expect(Cookies.set).toHaveBeenLastCalledWith(
-                IAB_COOKIE_NAME,
-                iabConsentString,
-                cookieOptions,
-            );
-        });
-
-        // TODO: update test when PECR purposes introduced
-        it('legacyState is not provided', () => {
             writeStateCookies(guConsentState, iabConsentString);
 
             // expect(Cookies.set).toHaveBeenCalledTimes(2);
@@ -109,6 +84,7 @@ describe('Cookies', () => {
                 cookieOptions,
             );
         });
+
         it('guState is not provided', () => {
             writeStateCookies({}, iabConsentString);
 
@@ -142,28 +118,6 @@ describe('Cookies', () => {
                 1,
                 IAB_COOKIE_NAME,
                 iabConsentString,
-                cookieOptions,
-            );
-        });
-
-        it('legacy cookie to true', () => {
-            writeStateCookies(guConsentState, iabConsentString, true);
-
-            expect(Cookies.set).toHaveBeenNthCalledWith(
-                1,
-                LEGACY_COOKIE_NAME,
-                `1.${fakeNow}`,
-                cookieOptions,
-            );
-        });
-
-        it('legacy cookie to false', () => {
-            writeStateCookies(guConsentState, iabConsentString, false);
-
-            expect(Cookies.set).toHaveBeenNthCalledWith(
-                1,
-                LEGACY_COOKIE_NAME,
-                `0.${fakeNow}`,
                 cookieOptions,
             );
         });

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -74,17 +74,10 @@ const writeGuCookie = (guState: GuPurposeState): void => {
 const writeIabCookie = (iabString: string): void =>
     addCookie(IAB_COOKIE_NAME, iabString);
 
-const writeLegacyCookie = (state: boolean): void =>
-    addCookie(LEGACY_COOKIE_NAME, [state ? '1' : '0', Date.now()].join('.'));
-
 const writeStateCookies = (
     guState: GuPurposeState,
     iabString: string,
-    legacyState?: boolean,
 ): void => {
-    if (typeof legacyState !== 'undefined') {
-        writeLegacyCookie(legacyState);
-    }
     if (Object.keys(guState).length > 0) {
         writeGuCookie(guState);
     }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -281,7 +281,6 @@ describe('Store', () => {
                     expect(writeStateCookies).toHaveBeenLastCalledWith(
                         guMixedState,
                         fakeIabString,
-                        true,
                     );
                 });
         });

--- a/src/store.ts
+++ b/src/store.ts
@@ -185,7 +185,7 @@ const setConsentState = (
             const iabStr = consentData.getConsentString();
             const pAdvertisingState = allowedPurposes.length === 5;
 
-            writeStateCookies(guState, iabStr, pAdvertisingState);
+            writeStateCookies(guState, iabStr);
             if (variant) {
                 postConsentState(
                     guState,


### PR DESCRIPTION
ShouldShow now differentiates between re-permissiong  and non re-permissioning conditions to allow frontend to have a test running at with one behaviour and roll out to rest of the audience with the other. Updated unit tests and documentation to reflect changes.
Also removed logic related to saving legacy cookie.