### PR TITLE
Fix cookies not saving in viewer.gutools.co.uk

### DIFF
--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -38,6 +38,11 @@ describe('Cookies', () => {
         domain: '.theguardian.com',
         expires: COOKIE_MAX_AGE,
     };
+    const previewCookieOptions = {
+        domain: '.gutools.co.uk',
+        expires: COOKIE_MAX_AGE,
+    };
+
     const iabConsentString = 'heL10W0rLd';
     const fakeNow = '12345';
 
@@ -45,14 +50,21 @@ describe('Cookies', () => {
         global.Date = {
             now: () => fakeNow,
         };
-        Object.defineProperty(document, 'domain', {
-            value: 'www.theguardian.com',
-        });
     });
 
     afterAll(() => {
         global.Date = OriginalDate;
         expect(Date.now()).not.toMatch(fakeNow);
+    });
+
+    beforeEach(() => {
+        global.guardian = {
+            config: { page: { isPreview: false } },
+        };
+        Object.defineProperty(document, 'domain', {
+            value: 'www.theguardian.com',
+            configurable: true,
+        });
     });
 
     afterEach(() => {
@@ -63,9 +75,7 @@ describe('Cookies', () => {
         beforeAll(() => {
             Cookies.set.mockImplementation(() => undefined);
         });
-        afterEach(() => {
-            jest.resetAllMocks();
-        });
+
         // TODO: update test when PECR purposes introduced
         it('all states provided', () => {
             writeStateCookies(guConsentState, iabConsentString);
@@ -93,6 +103,33 @@ describe('Cookies', () => {
                 IAB_COOKIE_NAME,
                 iabConsentString,
                 cookieOptions,
+            );
+        });
+
+        // TODO: update test when PECR purposes introduced
+        it('is in preview', () => {
+            Object.defineProperty(document, 'domain', {
+                value: 'viewer.gutools.co.uk',
+                configurable: true,
+            });
+            global.guardian = {
+                config: { page: { isPreview: true } },
+            };
+
+            writeStateCookies(guConsentState, iabConsentString);
+
+            // expect(Cookies.set).toHaveBeenCalledTimes(2);
+            expect(Cookies.set).toHaveBeenCalledTimes(1);
+            // expect(Cookies.set).toHaveBeenNthCalledWith(
+            //     1,
+            //     GU_COOKIE_NAME,
+            //     guCookie,
+            //     previewCookieOptions,
+            // );
+            expect(Cookies.set).toHaveBeenLastCalledWith(
+                IAB_COOKIE_NAME,
+                iabConsentString,
+                previewCookieOptions,
             );
         });
     });

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -58,9 +58,6 @@ describe('Cookies', () => {
     });
 
     beforeEach(() => {
-        global.guardian = {
-            config: { page: { isPreview: false } },
-        };
         Object.defineProperty(document, 'domain', {
             value: 'www.theguardian.com',
             configurable: true,
@@ -112,9 +109,6 @@ describe('Cookies', () => {
                 value: 'viewer.gutools.co.uk',
                 configurable: true,
             });
-            global.guardian = {
-                config: { page: { isPreview: true } },
-            };
 
             writeStateCookies(guConsentState, iabConsentString);
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -2,6 +2,12 @@
 import Cookies from 'js-cookie';
 import { GuCookie, GuPurposeState } from './types';
 
+declare global {
+    interface Window {
+        guardian?: { config?: { page?: { isPreview?: boolean } } };
+    }
+}
+
 const GU_COOKIE_NAME = 'guconsent';
 const IAB_COOKIE_NAME = 'euconsent';
 const LEGACY_COOKIE_NAME = 'GU_TK';
@@ -12,9 +18,11 @@ const COOKIE_MAX_AGE = 395; // 13 months
 const getShortDomain = (): string => {
     const domain = document.domain || '';
 
+    const slice = domain.endsWith('co.uk') ? -3 : -2;
+
     return domain === 'localhost'
         ? domain
-        : ['', ...domain.split('.').slice(-2)].join('.');
+        : ['', ...domain.split('.').slice(slice)].join('.');
 };
 
 const getDomainAttribute = (): string => {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -2,12 +2,6 @@
 import Cookies from 'js-cookie';
 import { GuCookie, GuPurposeState } from './types';
 
-declare global {
-    interface Window {
-        guardian?: { config?: { page?: { isPreview?: boolean } } };
-    }
-}
-
 const GU_COOKIE_NAME = 'guconsent';
 const IAB_COOKIE_NAME = 'euconsent';
 const LEGACY_COOKIE_NAME = 'GU_TK';


### PR DESCRIPTION
Fixes a bug where cookies were not being saved when accessing viewer.gutools.co.uk.

This was happening because we never accounted for domains using a second level domain such as `viewer.gutools.co.uk`. So when slicing the full domain to remove subdomains we were getting `.co.uk` and setting it as the cookie domain, which the browser ignored.