### PR TITLE
Fixes scrolling accessibility issue

### DIFF
--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -203,6 +203,13 @@ class Modal extends Component<Props, State> {
         window.addEventListener('resize', () => {
             this.hideScrollbar();
         });
+
+        // This enables scrolling the modal using arrow keys as well
+        // as tabing through the items as soon as the modal is shown
+        const scrollableElem = document.getElementById(SCROLLABLE_ID);
+        if (scrollableElem) {
+            (scrollableElem as HTMLElement).focus();
+        }
     }
 
     public render(): React.ReactNode {
@@ -229,6 +236,7 @@ class Modal extends Component<Props, State> {
                                 <div
                                     id={SCROLLABLE_ID}
                                     css={scrollableAreaStyles(scrollbarWidth)}
+                                    tabIndex={-1}
                                 >
                                     <div
                                         css={copyContainerStyles(headlineSerif)}


### PR DESCRIPTION
There is an accessibility issue on the modal for users without a scroll wheel. Users would have to click somewhere in the modal before being able to use the arrows keys to scroll. This PR forces the browser to focus on scrollable element of the modal immediately allowing the user to scroll the modal and also using tab to navigate it.