### PR TITLE
Fix iOS 10 modal scrollable bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/CmpCollapsible.tsx
+++ b/src/component/CmpCollapsible.tsx
@@ -62,6 +62,7 @@ export class CmpCollapsible extends Component<Props, State> {
                                 css={css`
                                     flex-grow: 1;
                                     display: flex;
+                                    min-height: 25px;
                                 `}
                                 onClick={() => {
                                     this.toggleCollapsed();

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -100,7 +100,6 @@ const copyContainerStyles = (headlineSerif: string) => css`
 
 const scrollableAreaStyles = (scrollbarWidth: number) => css`
     width: 100%;
-    height: 100%;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
     padding-right: ${scrollbarWidth}px; /* Increase/decrease this value for cross-browser compatibility */
@@ -111,8 +110,8 @@ const scrollableContainerStyles = (scrollbarWidth: number) => css`
     background-color: ${palette.neutral[100]};
     margin-right: -${scrollbarWidth}px;
     overflow: hidden;
-    max-height: 100%; /* For scrolling purposes */
-    height: 450px; /* For scrolling purposes */
+    display: flex;
+    flex-direction: column;
 `;
 
 const buttonContainerStyles = (bodySerif: string) => css`


### PR DESCRIPTION
On iOS 10 devices (iPhone or iPad) the modal in the CMP UI is not entirely scrollable, users report being unable to scroll to the "Measurement" on/off radio buttons and the "Vendors" and "Features" lists without the scroll bouncing back to it's original position. I can verify this bug was reproducible on Browserstack.

The issue was caused by the "scrollable" div not rendering at the expected height, this PR fixes that by using a different technique to set the height of this element. 

This has been tested non Browserstack against a range of devices/browsers on desktop/mobile/tablet.

**Bug on iOS 10 iPhone...**

![ios-10-buggy](https://user-images.githubusercontent.com/1590704/73548888-7978b580-4439-11ea-8ea0-d98c26e4067c.gif)

**Fixed on iOS 10 iPhone...**

![ios-10-fix](https://user-images.githubusercontent.com/1590704/73548705-23a40d80-4439-11ea-8d31-0d23862aff9c.gif)

Trello card: https://trello.com/c/iDngBtE8/646-cmp-investigate-cmp-ios-1033-issues