### PR TITLE
Pixel Parity between frontend and dotcom-rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -65,6 +65,7 @@ const contentContainerStyles = (bodySerif: string) => css`
     margin: 0 ${gutterWidth / 2}px;
     max-width: ${gridWidth(9, 0)}px;
     height: 100%;
+    box-sizing: content-box;
 
     ${until.mobileLandscape} {
         display: flex;
@@ -105,6 +106,8 @@ const contentContainerStyles = (bodySerif: string) => css`
 
 const headlineStyles = (headlineSerif: string) => css`
     font-size: ${headlineSizes.small}rem;
+    font-weight: 700;
+    line-height: 1.5;
 
     ${from.leftCol} {
         font-size: ${headlineSizes.medium}rem;
@@ -113,7 +116,7 @@ const headlineStyles = (headlineSerif: string) => css`
     font-family: ${headlineSerif};
 `;
 
-const collapsibleButtonStyles = (show: boolean) => css`
+const collapsibleButtonStyles = (show: boolean, bodySerif: string) => css`
     border: 0;
     color: ${palette.neutral[100]};
     background-color: transparent;
@@ -122,6 +125,12 @@ const collapsibleButtonStyles = (show: boolean) => css`
     padding-left: 24px;
     margin-left: -4px;
     margin-bottom: ${show ? '8px' : 0};
+    ${body.medium()};
+    font-family: ${bodySerif};
+
+    :hover {
+        cursor: pointer;
+    }
 
     :focus {
         outline: none;
@@ -151,7 +160,7 @@ const collapsibleButtonStyles = (show: boolean) => css`
     }
 `;
 
-const collapsibleListStyles = (show: boolean) => css`
+const collapsibleListStyles = (show: boolean, bodySerif: string) => css`
     margin: 0;
     margin-bottom: ${show ? '8px' : 0};
     max-height: ${show ? '500px' : 0};
@@ -165,6 +174,8 @@ const collapsibleListStyles = (show: boolean) => css`
 
     li {
         padding-left: 4px;
+        ${body.medium()};
+        font-family: ${bodySerif};
     }
 
     li:before {
@@ -199,7 +210,9 @@ const buttonContainerStyles = css`
     }
 `;
 
-const mobileButtonStyles = css`
+const buttonStyles = (bodySans: string) => css`
+    font-family: ${bodySans};
+
     ${until.mobileMedium} {
         padding: 0 14px;
 
@@ -237,6 +250,10 @@ const mobileScrollable = css`
         padding-bottom: 12px;
         height: 100%;
         overflow-y: scroll;
+    }
+
+    p {
+        margin-bottom: 8px;
     }
 `;
 
@@ -276,7 +293,11 @@ class Banner extends Component<Props, State> {
 
         return (
             <FontsContext.Consumer>
-                {({ headlineSerif, bodySerif }: FontsContextInterface) => (
+                {({
+                    headlineSerif,
+                    bodySerif,
+                    bodySans,
+                }: FontsContextInterface) => (
                     <div css={bannerStyles}>
                         <div css={outerContainerStyles}>
                             <div css={roundelContainerStyles}>
@@ -312,7 +333,10 @@ class Banner extends Component<Props, State> {
                                         .
                                     </p>
                                     <button
-                                        css={collapsibleButtonStyles(showInfo)}
+                                        css={collapsibleButtonStyles(
+                                            showInfo,
+                                            bodySerif,
+                                        )}
                                         onClick={() => {
                                             this.setState({
                                                 showInfo: !showInfo,
@@ -328,7 +352,10 @@ class Banner extends Component<Props, State> {
                                     </button>
                                     <ul
                                         id={INFO_LIST_ID}
-                                        css={collapsibleListStyles(showInfo)}
+                                        css={collapsibleListStyles(
+                                            showInfo,
+                                            bodySerif,
+                                        )}
                                     >
                                         <li>
                                             Type of browser and its settings
@@ -353,6 +380,7 @@ class Banner extends Component<Props, State> {
                                     <button
                                         css={collapsibleButtonStyles(
                                             showPurposes,
+                                            bodySerif,
                                         )}
                                         onClick={() => {
                                             this.setState({
@@ -371,6 +399,7 @@ class Banner extends Component<Props, State> {
                                         id={PURPOSE_LIST_ID}
                                         css={collapsibleListStyles(
                                             showPurposes,
+                                            bodySerif,
                                         )}
                                     >
                                         {this.renderPurposeList()}
@@ -383,7 +412,7 @@ class Banner extends Component<Props, State> {
                                             size="default"
                                             icon={<SvgCheckmark />}
                                             iconSide="left"
-                                            css={mobileButtonStyles}
+                                            css={buttonStyles(bodySans)}
                                             onClick={() => {
                                                 const {
                                                     onEnableAllAndCloseClick,
@@ -397,7 +426,7 @@ class Banner extends Component<Props, State> {
                                         <Button
                                             priority="secondary"
                                             size="default"
-                                            css={mobileButtonStyles}
+                                            css={buttonStyles(bodySans)}
                                             onClick={() => {
                                                 onOptionsClick();
                                             }}

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -31,6 +31,7 @@ const bannerStyles = css`
     bottom: -1px;
     right: 0;
     z-index: 9999;
+    border-top: 1px solid ${palette.brand.pastel};
 
     ${until.mobileLandscape} {
         height: 320px;

--- a/src/component/CmpCollapsible.tsx
+++ b/src/component/CmpCollapsible.tsx
@@ -18,8 +18,9 @@ const panelStyles = (collapsed: boolean, bodySans: string) => css`
 
     p {
         font-family: ${bodySans};
-        fontsize: ${bodySizes.medium}rem;
-        lineheight: 1.5rem;
+        font-size: ${bodySizes.medium}rem;
+        line-height: 1.5rem;
+        margin-bottom: 8px;
     }
 `;
 

--- a/src/component/CollapseItemButton.tsx
+++ b/src/component/CollapseItemButton.tsx
@@ -41,6 +41,7 @@ const collapseItemButtonStyles = (collapsed: boolean, bodySans: string) => css`
         transform: ${collapsed ? 'rotate(-135deg)' : 'rotate(45deg)'};
         height: 6px;
         width: 6px;
+        box-sizing: content-box;
     }
     :focus,
     :hover {

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -70,13 +70,14 @@ const headerStyles = css`
 `;
 
 const primaryHeadlineStyles = (headlineSerif: string) => css`
+    font-family: ${headlineSerif};
     font-size: ${headlineSizes.xsmall}rem;
+    font-weight: 700;
+    line-height: 1.5;
 
     ${from.leftCol} {
         font-size: ${headlineSizes.small}rem;
     }
-
-    font-family: ${headlineSerif};
 `;
 
 const copyContainerStyles = (headlineSerif: string) => css`
@@ -136,6 +137,7 @@ const buttonContainerStyles = (bodySerif: string) => css`
         font-size: ${bodySizes.small}rem;
         line-height: 1.35rem;
         font-weight: 700;
+        margin-bottom: 8px;
     }
 
     button + button {
@@ -217,7 +219,11 @@ class Modal extends Component<Props, State> {
 
         return (
             <FontsContext.Consumer>
-                {({ headlineSerif, bodySerif }: FontsContextInterface) => (
+                {({
+                    headlineSerif,
+                    bodySerif,
+                    bodySans,
+                }: FontsContextInterface) => (
                     <>
                         <div css={overlayContainerStyles}></div>
                         <form css={modalStyles}>
@@ -240,7 +246,11 @@ class Modal extends Component<Props, State> {
                                     <div
                                         css={copyContainerStyles(headlineSerif)}
                                     >
-                                        <h2>
+                                        <h2
+                                            css={css`
+                                                font-weight: 700;
+                                            `}
+                                        >
                                             Please review and manage your data
                                             and privacy settings below.
                                         </h2>
@@ -310,6 +320,9 @@ class Modal extends Component<Props, State> {
                                             onClick={() => {
                                                 this.saveAndCloseClick();
                                             }}
+                                            css={css`
+                                                font-family: ${bodySans};
+                                            `}
                                         >
                                             Save and close
                                         </Button>
@@ -323,6 +336,9 @@ class Modal extends Component<Props, State> {
 
                                                 onCancelClick();
                                             }}
+                                            css={css`
+                                                font-family: ${bodySans};
+                                            `}
                                         >
                                             Cancel
                                         </Button>

--- a/src/component/OnOffRadio.tsx
+++ b/src/component/OnOffRadio.tsx
@@ -89,6 +89,7 @@ const radioLabelTextStyles = (disabled: boolean, bodySans: string) => css`
     font-family: ${bodySans};
     font-size: 17px;
     color: ${disabled ? palette.brand.pastel : palette.neutral[7]};
+    line-height: 1.5;
 `;
 
 interface Props {


### PR DESCRIPTION
Whilst integrating the CMP UI component into `dotcom-rendering` we found styles were applied compared to `frontend`, this is because `frontend` uses a different set of default css styles compared to `dotcom-rendering`. To overcome this problem we've had to explicitly declare style rules  where we'd previously implicitly inherited them from `frontend`'s defaults. This creates a pixel accurate version of the CMP UI across both versions of the site.