### PR TITLE
Move focus onto banner programmatically when it renders

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,13 @@
         "no-plusplus": 0,
         "no-use-before-define": 0,
         "object-literal-sort-keys": 0,
-        "prettier/prettier": 2
+        "prettier/prettier": 2,
+        "class-methods-use-this": [
+            2,
+            {
+                "exceptMethods": ["componentDidMount"]
+            }
+        ]
     },
     "overrides": [
         {

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -290,8 +290,10 @@ class Banner extends Component<Props, State> {
     }
 
     public componentDidMount(): void {
-        // This enables scrolling the modal using arrow keys as well
-        // as tabing through the items as soon as the modal is shown
+        /**
+         * Move focus onto the banner so users
+         * who navgate with the keyboard can interact with it
+         * */
         const bannerElem = document.getElementById(BANNER_ID);
 
         if (bannerElem) {

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -11,6 +11,7 @@ import { FontsContextInterface, IabPurpose } from '../types';
 import { FontsContext } from './FontsContext';
 import { Roundel } from './svgs/Roundel';
 
+const BANNER_ID = 'cmpBanner';
 const INFO_LIST_ID = 'cmpInfoList';
 const PURPOSE_LIST_ID = 'cmpPurposeList';
 
@@ -35,6 +36,10 @@ const bannerStyles = css`
 
     ${until.mobileLandscape} {
         height: 320px;
+    }
+
+    :focus {
+        outline: none;
     }
 `;
 
@@ -284,6 +289,16 @@ class Banner extends Component<Props, State> {
         };
     }
 
+    public componentDidMount(): void {
+        // This enables scrolling the modal using arrow keys as well
+        // as tabing through the items as soon as the modal is shown
+        const bannerElem = document.getElementById(BANNER_ID);
+
+        if (bannerElem) {
+            (bannerElem as HTMLElement).focus();
+        }
+    }
+
     public render(): React.ReactNode {
         const { showInfo, showPurposes } = this.state;
         const {
@@ -299,7 +314,7 @@ class Banner extends Component<Props, State> {
                     bodySerif,
                     bodySans,
                 }: FontsContextInterface) => (
-                    <div css={bannerStyles}>
+                    <div css={bannerStyles} id={BANNER_ID} tabIndex={-1}>
                         <div css={outerContainerStyles}>
                             <div css={roundelContainerStyles}>
                                 <Roundel />

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -18,7 +18,7 @@ import {
 import { IabPurposes } from './IabPurposes';
 import { Roundel } from './svgs/Roundel';
 
-const SCROLLABLE_ID = 'scrollable';
+const SCROLLABLE_ID = 'cmpScrollable';
 
 const overlayContainerStyles = css`
     position: fixed;

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -204,8 +204,10 @@ class Modal extends Component<Props, State> {
             this.hideScrollbar();
         });
 
-        // This enables scrolling the modal using arrow keys as well
-        // as tabing through the items as soon as the modal is shown
+        /**
+         * This enables scrolling the modal using arrow keys as well
+         * as tabing through the items as soon as the modal is shown
+         * */
         const scrollableElem = document.getElementById(SCROLLABLE_ID);
         if (scrollableElem) {
             (scrollableElem as HTMLElement).focus();


### PR DESCRIPTION
This is an accessibility improvement for the CMP UI. Currently when it renders it is somewhere at the bottom of the pages tab index, this means users who navigate using a keyboard have to tab through the entire page before they can interact with it.

By moving focus onto the banner programmatically after it renders the tab-able elements within it (the links and buttons) move to the top of the tab index, so the first tab stroke after it renders is within the banner.