### PR TITLE
Accessibility update - add tabIndex

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
-        "@guardian/src-button": "^0.5.1",
-        "@guardian/src-foundations": "^0.10.0",
-        "@guardian/src-svgs": "^0.0.6",
         "consent-string": "^1.5.1",
         "js-cookie": "^2.2.1",
         "whatwg-fetch": "^3.0.0"
     },
     "peerDependencies": {
         "@emotion/core": "^10.0.21",
+        "@guardian/src-button": "^0.13.0",
+        "@guardian/src-foundations": "^0.13.0",
+        "@guardian/src-svgs": "^0.13.0",
         "emotion-theming": "^10.0.27",
         "react": "^16.10.2"
     },
@@ -49,6 +49,9 @@
         "@babel/preset-typescript": "^7.6.0",
         "@emotion/babel-preset-css-prop": "^10.0.17",
         "@emotion/core": "^10.0.21",
+        "@guardian/src-button": "^0.13.0",
+        "@guardian/src-foundations": "^0.13.0",
+        "@guardian/src-svgs": "^0.13.0",
         "@types/jest": "^24.0.16",
         "@types/js-cookie": "^2.2.2",
         "@types/react": "^16.9.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.9-beta.3",
+    "version": "2.0.9",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.8",
+    "version": "2.0.9-beta.3",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -29,15 +29,15 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
+        "@guardian/src-button": "^0.13.0",
+        "@guardian/src-foundations": "^0.13.0",
+        "@guardian/src-svgs": "^0.13.0",
         "consent-string": "^1.5.1",
         "js-cookie": "^2.2.1",
         "whatwg-fetch": "^3.0.0"
     },
     "peerDependencies": {
         "@emotion/core": "^10.0.21",
-        "@guardian/src-button": "^0.13.0",
-        "@guardian/src-foundations": "^0.13.0",
-        "@guardian/src-svgs": "^0.13.0",
         "emotion-theming": "^10.0.27",
         "react": "^16.10.2"
     },
@@ -49,9 +49,6 @@
         "@babel/preset-typescript": "^7.6.0",
         "@emotion/babel-preset-css-prop": "^10.0.17",
         "@emotion/core": "^10.0.21",
-        "@guardian/src-button": "^0.13.0",
-        "@guardian/src-foundations": "^0.13.0",
-        "@guardian/src-svgs": "^0.13.0",
         "@types/jest": "^24.0.16",
         "@types/js-cookie": "^2.2.2",
         "@types/react": "^16.9.9",

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -345,6 +345,7 @@ class Banner extends Component<Props, State> {
                                         }}
                                         aria-expanded={showInfo}
                                         aria-controls={INFO_LIST_ID}
+                                        tabIndex={1}
                                     >
                                         <span css={visuallyHiddenStyles}>
                                             Show
@@ -390,6 +391,7 @@ class Banner extends Component<Props, State> {
                                         }}
                                         aria-expanded={showPurposes}
                                         aria-controls={PURPOSE_LIST_ID}
+                                        tabIndex={2}
                                     >
                                         <span css={visuallyHiddenStyles}>
                                             Show
@@ -421,6 +423,7 @@ class Banner extends Component<Props, State> {
 
                                                 onEnableAllAndCloseClick();
                                             }}
+                                            tabIndex={3}
                                         >
                                             I&apos;m OK with that
                                         </Button>
@@ -431,6 +434,7 @@ class Banner extends Component<Props, State> {
                                             onClick={() => {
                                                 onOptionsClick();
                                             }}
+                                            tabIndex={4}
                                         >
                                             Options
                                         </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,20 +931,22 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/src-button@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.5.1.tgz#b107a5a075e2ad41c59f3d52429a614273f247de"
-  integrity sha512-4i4o+qCd6o/W0Xi5IKcLz0aS+NUBNdBien5pmPlbcRIq/0TBVt7XAKxK4avrf7BiCWAAAtg/0ejq8AWx0wlPjw==
+"@guardian/src-button@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.13.0.tgz#0071e83dff911d43a700fbaaa659ed741bdd486d"
+  integrity sha512-ykKQ1IgU6fWvysmCmj3HWVYql0Hc/WuzYGZMh7EDDAB39YEfbH54ZMjYM3+SNkqoa0yNqRRhivCFpMyPm3mjpA==
+  dependencies:
+    "@guardian/src-svgs" "^0.13.0"
 
-"@guardian/src-foundations@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.10.0.tgz#b7773484f2b9e661d31f1d400950a83fb261fe63"
-  integrity sha512-w5xvrYqCLngxFUsivhVhJ35EppFi2GtPMAUxN6EG/Hc9FDD3qiWHiT0nwSPOReNq3UXOLH6DxbNxanFVaOelCg==
+"@guardian/src-foundations@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
+  integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
-"@guardian/src-svgs@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.0.6.tgz#f8ec43935c5df3860f69cc356b9574a7a72c28e0"
-  integrity sha512-qlHe80XVEyTeiolgNjLsrq7z+19acIa0XIfMByAjo8zDw85S58Fjp/b0XYsYc0V7G8XamZRnMgjFNdF++FUZEw==
+"@guardian/src-svgs@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.13.0.tgz#97d893a6e33feb255666fef6779ffe18a7c4e2f5"
+  integrity sha512-cDIGNOaatYVDk+eWCv2cAdBlXZ2ECDxOcc897GowJYCHmy+HifL0AvzHlHRLKYRQXzVcaPfoXDOjVonA4ViHqw==
 
 "@jest/console@^24.7.1":
   version "24.7.1"


### PR DESCRIPTION
Any user using keyboard navigation who loads the Guardian and sees the CMP UI has to tab through the entire page to reach it. Following the change to `@guardian/src-button` here https://github.com/guardian/source/pull/216/files we can now add the `tabIndex` attribute to our `<Button>` components, which means the CMP UI now becomes the first item the tab index moves to from the toolbar. 