### PR TITLE
Show scrollbar in modal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,10 @@
         "@typescript-eslint/consistent-type-definitions": 0,
         "@typescript-eslint/explicit-function-return-type": 0,
         "@typescript-eslint/no-use-before-define": 0,
+        "class-methods-use-this": [
+            2,
+            { "exceptMethods": ["componentDidMount"] }
+        ],
         "import/no-default-export": 2,
         "import/prefer-default-export": 0,
         "import/no-unresolved": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -99,17 +99,15 @@ const copyContainerStyles = (headlineSerif: string) => css`
     }
 `;
 
-const scrollableAreaStyles = (scrollbarWidth: number) => css`
+const scrollableAreaStyles = css`
     width: 100%;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
-    padding-right: ${scrollbarWidth}px; /* Increase/decrease this value for cross-browser compatibility */
     box-sizing: content-box;
 `;
 
-const scrollableContainerStyles = (scrollbarWidth: number) => css`
+const scrollableContainerStyles = css`
     background-color: ${palette.neutral[100]};
-    margin-right: -${scrollbarWidth}px;
     overflow: hidden;
     display: flex;
     flex-direction: column;
@@ -176,7 +174,6 @@ interface State {
     guState: GuPurposeState;
     iabState: IabPurposeState;
     iabNullResponses: number[];
-    scrollbarWidth: number;
 }
 
 interface Props {
@@ -193,17 +190,10 @@ class Modal extends Component<Props, State> {
         this.state = {
             ...getConsentState(true),
             iabNullResponses: [],
-            scrollbarWidth: 0,
         };
     }
 
     public componentDidMount(): void {
-        this.hideScrollbar();
-
-        window.addEventListener('resize', () => {
-            this.hideScrollbar();
-        });
-
         // This enables scrolling the modal using arrow keys as well
         // as tabing through the items as soon as the modal is shown
         const scrollableElem = document.getElementById(SCROLLABLE_ID);
@@ -214,7 +204,7 @@ class Modal extends Component<Props, State> {
 
     public render(): React.ReactNode {
         const { parsedVendorList } = this.props;
-        const { iabState, iabNullResponses, scrollbarWidth } = this.state;
+        const { iabState, iabNullResponses } = this.state;
 
         return (
             <FontsContext.Consumer>
@@ -234,12 +224,10 @@ class Modal extends Component<Props, State> {
                                     <Roundel />
                                 </div>
                             </div>
-                            <div
-                                css={scrollableContainerStyles(scrollbarWidth)}
-                            >
+                            <div css={scrollableContainerStyles}>
                                 <div
                                     id={SCROLLABLE_ID}
-                                    css={scrollableAreaStyles(scrollbarWidth)}
+                                    css={scrollableAreaStyles}
                                     tabIndex={-1}
                                 >
                                     <div
@@ -373,21 +361,6 @@ class Modal extends Component<Props, State> {
                   )
                 : [],
         }));
-    }
-
-    private hideScrollbar(): void {
-        const scrollableElem = document.getElementById(SCROLLABLE_ID);
-
-        if (!scrollableElem) {
-            return;
-        }
-
-        const scrollbarWidth =
-            scrollableElem.offsetWidth - scrollableElem.clientWidth;
-
-        this.setState({
-            scrollbarWidth,
-        });
     }
 }
 


### PR DESCRIPTION
This PR reveals the scrollbar on the scrollable area of the `Modal` component. We had removed the scrollbar from the CMP UI back when it was a side banner to avoid having 2 scrollbars. When we moved to a bottom banner + modal UI we never revisited that decision but recent accessibility issues have caused us to rethink it. We have decided to reinstate it.

**Before:**
![modal](https://user-images.githubusercontent.com/1590704/75342456-63baac80-588e-11ea-883a-4bad9c88646d.gif)

**After:**
![modal-scrollbar](https://user-images.githubusercontent.com/1590704/75342476-6ddcab00-588e-11ea-9dfb-345b58ab8271.gif)
