### PR TITLE
Move src-* dependencies into peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
-        "@guardian/src-button": "^0.13.0",
-        "@guardian/src-foundations": "^0.13.0",
-        "@guardian/src-svgs": "^0.13.0",
         "consent-string": "^1.5.1",
         "js-cookie": "^2.2.1",
         "whatwg-fetch": "^3.0.0"
     },
     "peerDependencies": {
         "@emotion/core": "^10.0.21",
+        "@guardian/src-button": "^0.16.1",
+        "@guardian/src-foundations": "^0.16.1",
+        "@guardian/src-svgs": "0.16.1",
         "emotion-theming": "^10.0.27",
         "react": "^16.10.2"
     },
@@ -49,6 +49,9 @@
         "@babel/preset-typescript": "^7.6.0",
         "@emotion/babel-preset-css-prop": "^10.0.17",
         "@emotion/core": "^10.0.21",
+        "@guardian/src-button": "^0.16.1",
+        "@guardian/src-foundations": "^0.16.1",
+        "@guardian/src-svgs": "0.16.1",
         "@types/jest": "^24.0.16",
         "@types/js-cookie": "^2.2.2",
         "@types/react": "^16.9.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "2.0.10",
+    "version": "3.0.0",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,12 @@ module.exports = {
             format: 'cjs',
         },
     ],
-    external: ['react', '@emotion/core'],
+    external: [
+        'react',
+        '@emotion/core',
+        '@guardian/src-button',
+        '@guardian/src-foundations',
+        '@guardian/src-svgs',
+    ],
     plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 };

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -106,12 +106,12 @@ const contentContainerStyles = (bodySerif: string) => css`
 `;
 
 const headlineStyles = (headlineSerif: string) => css`
-    font-size: ${headlineSizes.small}rem;
+    font-size: ${headlineSizes.small}px;
     font-weight: 700;
     line-height: 1.5;
 
     ${from.leftCol} {
-        font-size: ${headlineSizes.medium}rem;
+        font-size: ${headlineSizes.medium}px;
     }
 
     font-family: ${headlineSerif};

--- a/src/component/CmpCollapsible.tsx
+++ b/src/component/CmpCollapsible.tsx
@@ -18,7 +18,7 @@ const panelStyles = (collapsed: boolean, bodySans: string) => css`
 
     p {
         font-family: ${bodySans};
-        font-size: ${bodySizes.medium}rem;
+        font-size: ${bodySizes.medium}px;
         line-height: 1.5rem;
         margin-bottom: 8px;
     }

--- a/src/component/CollapseItemButton.tsx
+++ b/src/component/CollapseItemButton.tsx
@@ -21,9 +21,9 @@ const collapseItemButtonStyles = (collapsed: boolean, bodySans: string) => css`
         pointer-events: none;
     }
     font-family: ${bodySans};
-    font-size: ${headlineSizes.xxxsmall}rem;
+    font-size: ${headlineSizes.xxxsmall}px;
     ${from.mobileLandscape} {
-        font-size: ${headlineSizes.xxsmall}rem;
+        font-size: ${headlineSizes.xxsmall}px;
     }
     line-height: 1.15rem;
     font-weight: 700;

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -71,12 +71,12 @@ const headerStyles = css`
 
 const primaryHeadlineStyles = (headlineSerif: string) => css`
     font-family: ${headlineSerif};
-    font-size: ${headlineSizes.xsmall}rem;
+    font-size: ${headlineSizes.xsmall}px;
     font-weight: 700;
     line-height: 1.5;
 
     ${from.leftCol} {
-        font-size: ${headlineSizes.small}rem;
+        font-size: ${headlineSizes.small}px;
     }
 `;
 
@@ -90,11 +90,11 @@ const copyContainerStyles = (headlineSerif: string) => css`
     font-family: ${headlineSerif};
 
     h2 {
-        font-size: ${headlineSizes.xxxsmall}rem;
+        font-size: ${headlineSizes.xxxsmall}px;
         line-height: 1.35rem;
 
         ${from.phablet} {
-            font-size: ${headlineSizes.xxsmall}rem;
+            font-size: ${headlineSizes.xxsmall}px;
         }
     }
 `;
@@ -132,7 +132,7 @@ const buttonContainerStyles = (bodySerif: string) => css`
 
     p {
         font-family: ${bodySerif};
-        font-size: ${bodySizes.small}rem;
+        font-size: ${bodySizes.small}px;
         line-height: 1.35rem;
         font-weight: 700;
         margin-bottom: 8px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,22 +931,30 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/src-button@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.13.0.tgz#0071e83dff911d43a700fbaaa659ed741bdd486d"
-  integrity sha512-ykKQ1IgU6fWvysmCmj3HWVYql0Hc/WuzYGZMh7EDDAB39YEfbH54ZMjYM3+SNkqoa0yNqRRhivCFpMyPm3mjpA==
+"@guardian/src-button@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.16.1.tgz#f8833c8906f00a9f36295901282529220452d647"
+  integrity sha512-2wRywzccYNDG7WmVOL/ISQ0zoDCFbgHKrAMtBVx8C09kHRxcYRj4zvH20+psvL5u8ZrLYFB3Pm+GwX9Y8VgndQ==
   dependencies:
-    "@guardian/src-svgs" "^0.13.0"
+    "@guardian/src-helpers" "^0.16.1"
+    "@guardian/src-svgs" "^0.16.1"
 
-"@guardian/src-foundations@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
-  integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
+"@guardian/src-foundations@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.16.1.tgz#d5e52a57012c588d146b05ded7f9fbc4a9af40d5"
+  integrity sha512-E6YDqq53gy5CoO8xFPWDBjiYiI0o+4BE1/mFcwkpWGwtpkSnxi21LhkaQ63r+KRxoDB29clc86ChbNHXw9keFA==
 
-"@guardian/src-svgs@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.13.0.tgz#97d893a6e33feb255666fef6779ffe18a7c4e2f5"
-  integrity sha512-cDIGNOaatYVDk+eWCv2cAdBlXZ2ECDxOcc897GowJYCHmy+HifL0AvzHlHRLKYRQXzVcaPfoXDOjVonA4ViHqw==
+"@guardian/src-helpers@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-0.16.1.tgz#cf1e5e6a2c36bb1d91c9785cbfe7f48b735644aa"
+  integrity sha512-SYWrWK5tm+axqRFRY9QjfFt/CS8v1ROh6o1/oy8hQxgiJExXsgLkbv0R8lgKkZaC8luO1dEgQYYXgQiqM+dsIA==
+  dependencies:
+    "@guardian/src-foundations" "^0.16.1"
+
+"@guardian/src-svgs@0.16.1", "@guardian/src-svgs@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.16.1.tgz#331d6bb30513c45b09e5b4807832eb4a146a27ea"
+  integrity sha512-OudfWJaKpTTP0J1QckqX0NmfneXgQ5YieZ/4em2lNXGZFEfYyxHnIXrAQE5LjmIGR8eJQoIikkwWiAFt4ziHXQ==
 
 "@jest/console@^24.7.1":
   version "24.7.1"


### PR DESCRIPTION
The Dotcom team identified that the CMP Component when bundled is bringing its own versions of `src-foundations`, `src-button` and `src-svgs` dependencies. These are already being bundled by DCR and other dependent packages

Since CMP is designed to be consumed by other applications,  these modules should be externalised, and specified as `peerDependencies`, rather than bundled with the CMP Component.

This PR does that by enacting the following changes:

- externalise src-* packages in the rollup config
- specify scr-* packages as peerDependencies rather than dependencies 
- Upgrade src-* packages to the latest version (0.16.1)
- `src-foundations@0.16.1` now exports `headlineSizes`/`bodySizes` as `px` values and not `rem` values, so this required an update to some styles.

After running a before/after bundle comparison on `dotcom-rendering` I found the change led to the desired drop in bundle size of ~ 3kb (compressed):

**Before (non-legacy dcr bundle)**
<img width="329" alt="modern-old" src="https://user-images.githubusercontent.com/1590704/78567815-234d3780-7819-11ea-9c9e-5dc5f4045a4d.png">

**After (non-legacy drc bundle)**
<img width="331" alt="modern-new" src="https://user-images.githubusercontent.com/1590704/78567840-2e07cc80-7819-11ea-8a79-43b3c628382f.png">

**Before (legacy dcr bundle)**
<img width="328" alt="legacy-old" src="https://user-images.githubusercontent.com/1590704/78567904-4677e700-7819-11ea-9f9f-170252d625b3.png">

**After (legacy dcr bundle)**
<img width="334" alt="legacy-new" src="https://user-images.githubusercontent.com/1590704/78567940-51cb1280-7819-11ea-961e-a2a66d88ab2c.png">
