### PR TITLE
IAB compliancy update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -347,7 +347,7 @@ class Banner extends Component<Props, State> {
                                                 technologies – to improve your
                                                 experience on our site, analyse
                                                 how you use it, show you
-                                                personalised advertising. .
+                                                personalised advertising.
                                             </p>
                                             <p>
                                                 To find out more, read our{' '}

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -287,7 +287,7 @@ interface Props {
     cookiePolicyUrl: string;
     iabPurposes: IabPurpose[];
     onEnableAllAndCloseClick: () => void;
-    onOptionsClick: () => void;
+    onOptionsClick: (shouldFocusVendors: boolean) => void;
     variant?: string;
 }
 
@@ -336,7 +336,7 @@ class Banner extends Component<Props, State> {
                                                 <button
                                                     css={buttonAsLinkStyles}
                                                     onClick={() => {
-                                                        onOptionsClick();
+                                                        onOptionsClick(true);
                                                     }}
                                                     tabIndex={1}
                                                 >
@@ -500,7 +500,7 @@ class Banner extends Component<Props, State> {
                                             size="default"
                                             css={buttonStyles(bodySans)}
                                             onClick={() => {
-                                                onOptionsClick();
+                                                onOptionsClick(false);
                                             }}
                                             tabIndex={5}
                                         >

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -350,7 +350,7 @@ class Banner extends Component<Props, State> {
                                                 personalised advertising.
                                             </p>
                                             <p>
-                                                To find out more, read our{' '}
+                                                You can find out more in our
                                                 <a
                                                     data-link-name="first-pv-consent : to-privacy"
                                                     href={privacyPolicyUrl}
@@ -364,13 +364,10 @@ class Banner extends Component<Props, State> {
                                                 >
                                                     cookie policy
                                                 </a>
-                                                .
-                                            </p>
-                                            <p>
-                                                You can change the settings for
-                                                this browser at any time by
-                                                clicking the privacy settings in
-                                                the footer of the page.
+                                                , and manage your consent at any
+                                                time by going to ‘Privacy
+                                                settings’ at the bottom of any
+                                                page.
                                             </p>
                                         </>
                                     ) : (

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -370,7 +370,7 @@ class Banner extends Component<Props, State> {
                                                 You can change the settings for
                                                 this browser at any time by
                                                 clicking the privacy settings in
-                                                the footer of the page
+                                                the footer of the page.
                                             </p>
                                         </>
                                     ) : (

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -332,14 +332,7 @@ class Banner extends Component<Props, State> {
                                     'commercialCmpCopy-variant' ? (
                                         <>
                                             <p>
-                                                We use your information –
-                                                collected through cookies and
-                                                similar technologies – to
-                                                improve your experience on our
-                                                site, analyse how you use it,
-                                                show you personalised
-                                                advertising and share that
-                                                information with{' '}
+                                                We and our{' '}
                                                 <button
                                                     css={buttonAsLinkStyles}
                                                     onClick={() => {
@@ -347,9 +340,14 @@ class Banner extends Component<Props, State> {
                                                     }}
                                                     tabIndex={1}
                                                 >
-                                                    advertising partners
-                                                </button>
-                                                .
+                                                    partners
+                                                </button>{' '}
+                                                use your information – collected
+                                                through cookies and similar
+                                                technologies – to improve your
+                                                experience on our site, analyse
+                                                how you use it, show you
+                                                personalised advertising. .
                                             </p>
                                             <p>
                                                 To find out more, read our{' '}
@@ -370,9 +368,9 @@ class Banner extends Component<Props, State> {
                                             </p>
                                             <p>
                                                 You can change the settings for
-                                                this this browser at any time by
+                                                this browser at any time by
                                                 clicking the privacy settings in
-                                                the footer of the
+                                                the footer of the page
                                             </p>
                                         </>
                                     ) : (

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -350,7 +350,7 @@ class Banner extends Component<Props, State> {
                                                 personalised advertising.
                                             </p>
                                             <p>
-                                                You can find out more in our
+                                                You can find out more in our{' '}
                                                 <a
                                                     data-link-name="first-pv-consent : to-privacy"
                                                     href={privacyPolicyUrl}

--- a/src/component/CmpCollapsible.tsx
+++ b/src/component/CmpCollapsible.tsx
@@ -29,6 +29,7 @@ interface Props {
     value?: ItemState;
     updateItem?: (updatedValue: boolean) => void;
     showError?: boolean;
+    expandedByDefault?: boolean;
 }
 
 interface State {
@@ -40,7 +41,7 @@ export class CmpCollapsible extends Component<Props, State> {
         super(props);
 
         this.state = {
-            collapsed: false,
+            collapsed: !!props.expandedByDefault, // TODO: collapsed has the wrong meaning. Should be the opposite.
         };
     }
 

--- a/src/component/CmpListItem.tsx
+++ b/src/component/CmpListItem.tsx
@@ -25,11 +25,19 @@ interface Props {
     updateItem?: (updatedValue: boolean) => void;
     isNested?: boolean;
     showError?: boolean;
+    expandedByDefault?: boolean;
 }
 
 export class CmpListItem extends Component<Props, {}> {
     public render(): React.ReactNode {
-        const { name, value, updateItem, isNested, showError } = this.props;
+        const {
+            name,
+            value,
+            updateItem,
+            isNested,
+            showError,
+            expandedByDefault,
+        } = this.props;
 
         return (
             <li css={itemContainerStyles(!!isNested)}>
@@ -38,6 +46,7 @@ export class CmpListItem extends Component<Props, {}> {
                     value={value}
                     updateItem={updateItem}
                     showError={showError}
+                    expandedByDefault={expandedByDefault}
                 >
                     {this.props.children}
                 </CmpCollapsible>

--- a/src/component/ConsentManagementPlatform.tsx
+++ b/src/component/ConsentManagementPlatform.tsx
@@ -28,6 +28,7 @@ interface State {
     guPurposeList: GuPurposeList;
     parsedIabVendorList?: ParsedIabVendorList;
     mode: 'banner' | 'modal';
+    focusVendors: boolean;
 }
 
 interface Props {
@@ -46,6 +47,7 @@ class ConsentManagementPlatform extends Component<Props, State> {
 
         this.state = {
             mode: forceModal ? 'modal' : 'banner',
+            focusVendors: false,
             guPurposeList: getGuPurposeList(),
         };
 
@@ -74,7 +76,7 @@ class ConsentManagementPlatform extends Component<Props, State> {
     }
 
     public render(): React.ReactNode {
-        const { mode, parsedIabVendorList } = this.state;
+        const { mode, focusVendors, parsedIabVendorList } = this.state;
         const { fontFamilies } = this.props;
 
         const bannerMode = mode === 'banner';
@@ -91,12 +93,18 @@ class ConsentManagementPlatform extends Component<Props, State> {
                         onEnableAllAndCloseClick={() => {
                             this.enableAllAndClose();
                         }}
-                        onOptionsClick={() => this.setState({ mode: 'modal' })}
+                        onOptionsClick={shouldFocusVendors =>
+                            this.setState({
+                                mode: 'modal',
+                                focusVendors: shouldFocusVendors,
+                            })
+                        }
                         variant={this.props.variant}
                     />
                 )}
                 {parsedIabVendorList && !bannerMode && (
                     <Modal
+                        focusVendors={focusVendors}
                         parsedVendorList={parsedIabVendorList}
                         onSaveAndCloseClick={(iabState: IabPurposeState) => {
                             this.saveAndCloseClick(iabState);
@@ -110,7 +118,10 @@ class ConsentManagementPlatform extends Component<Props, State> {
                             if (forceModal) {
                                 onClose();
                             } else {
-                                this.setState({ mode: 'banner' });
+                                this.setState({
+                                    mode: 'banner',
+                                    focusVendors: false,
+                                });
                             }
                         }}
                     />

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from 'emotion-theming';
 import { Features } from './Features';
 import { Vendors } from './Vendors';
 import { FontsContext } from './FontsContext';
+import { VENDORS_ID } from './utils/config';
 import { getConsentState } from '../store';
 import {
     GuPurposeState,
@@ -200,6 +201,13 @@ class Modal extends Component<Props, State> {
         const scrollableElem = document.getElementById(SCROLLABLE_ID);
         if (scrollableElem) {
             (scrollableElem as HTMLElement).focus();
+        }
+
+        if (this.props.focusVendors) {
+            const vendorsElem = window.document.getElementById(VENDORS_ID);
+            if (vendorsElem) {
+                vendorsElem.scrollIntoView({ behavior: 'smooth' });
+            }
         }
     }
 

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -18,7 +18,7 @@ import {
 import { IabPurposes } from './IabPurposes';
 import { Roundel } from './svgs/Roundel';
 
-const SCROLLABLE_ID = 'scrollable';
+const SCROLLABLE_ID = 'cmp-scrollable';
 
 const overlayContainerStyles = css`
     position: fixed;

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -177,6 +177,7 @@ interface State {
 }
 
 interface Props {
+    focusVendors: boolean;
     parsedVendorList: ParsedIabVendorList;
     onSaveAndCloseClick: (iabState: IabPurposeState) => void;
     onEnableAllAndCloseClick: () => void;
@@ -203,9 +204,10 @@ class Modal extends Component<Props, State> {
     }
 
     public render(): React.ReactNode {
-        const { parsedVendorList } = this.props;
+        const { focusVendors, parsedVendorList } = this.props;
         const { iabState, iabNullResponses } = this.state;
-
+        // eslint-disable-next-line no-console
+        console.log('focusVendor', focusVendors);
         return (
             <FontsContext.Consumer>
                 {({

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -206,8 +206,7 @@ class Modal extends Component<Props, State> {
     public render(): React.ReactNode {
         const { focusVendors, parsedVendorList } = this.props;
         const { iabState, iabNullResponses } = this.state;
-        // eslint-disable-next-line no-console
-        console.log('focusVendor', focusVendors);
+
         return (
             <FontsContext.Consumer>
                 {({
@@ -266,6 +265,7 @@ class Modal extends Component<Props, State> {
                                     />
                                     <Vendors
                                         vendors={parsedVendorList.vendors}
+                                        expandedByDefault={focusVendors}
                                     />
                                 </div>
                             </div>

--- a/src/component/Vendors.tsx
+++ b/src/component/Vendors.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { CmpListItem } from './CmpListItem';
 import { ParsedIabVendor } from '../types';
+import { VENDORS_ID } from './utils/config';
 
 interface Props {
     vendors: ParsedIabVendor[];
@@ -14,7 +15,7 @@ const cmpListStyles = css`
 `;
 
 export const Vendors = (props: Props) => (
-    <ul css={cmpListStyles}>
+    <ul id={VENDORS_ID} css={cmpListStyles}>
         <CmpListItem
             name="Vendors"
             expandedByDefault={props.expandedByDefault}

--- a/src/component/Vendors.tsx
+++ b/src/component/Vendors.tsx
@@ -5,6 +5,7 @@ import { ParsedIabVendor } from '../types';
 
 interface Props {
     vendors: ParsedIabVendor[];
+    expandedByDefault?: boolean;
 }
 
 const cmpListStyles = css`
@@ -14,7 +15,11 @@ const cmpListStyles = css`
 
 export const Vendors = (props: Props) => (
     <ul css={cmpListStyles}>
-        <CmpListItem name="Vendors" key={`vendorsCollapsible`}>
+        <CmpListItem
+            name="Vendors"
+            expandedByDefault={props.expandedByDefault}
+            key={`vendorsCollapsible`}
+        >
             <ul css={cmpListStyles}>
                 {props.vendors.map(
                     (vendor: ParsedIabVendor): React.ReactNode => {

--- a/src/component/utils/config.ts
+++ b/src/component/utils/config.ts
@@ -1,5 +1,6 @@
 import { FontsContextInterface } from '../../types';
 
+export const VENDORS_ID = 'cmp-vendors';
 export const SCROLLABLE_ID = 'cmpScrollable';
 export const CONTENT_ID = 'cmpContent';
 export const PURPOSES_ID = 'cmpPurposes';

--- a/src/component/utils/config.ts
+++ b/src/component/utils/config.ts
@@ -1,9 +1,6 @@
 import { FontsContextInterface } from '../../types';
 
 export const VENDORS_ID = 'cmp-vendors';
-export const SCROLLABLE_ID = 'cmpScrollable';
-export const CONTENT_ID = 'cmpContent';
-export const PURPOSES_ID = 'cmpPurposes';
 export const DEFAULT_FONT_FAMILIES: FontsContextInterface = {
     headlineSerif: 'GH Guardian Headline, Georgia, serif',
     bodySerif: 'GuardianTextEgyptian, Georgia, serif',


### PR DESCRIPTION
This PR updates the copy on the banner and the behaviour when clicking the 'partners' link/button so address compliancy issues reported by the IAB.

When clicking the 'partners' link it will now open the modal with the Vendors section expanded and scroll to it, making it visible for the user.

Screenshot showing the updated copy:
![Screenshot 2020-04-23 at 15 53 12](https://user-images.githubusercontent.com/48949546/80113775-a50fc580-857a-11ea-8643-d3e3f4c1adf1.png)


Also took the opportunity to remove some unused config variables.
