### PR TITLE
Fix a typo in the copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -346,7 +346,7 @@ class Banner extends Component<Props, State> {
                                                 through cookies and similar
                                                 technologies – to improve your
                                                 experience on our site, analyse
-                                                how you use it, show you
+                                                how you use it and show you
                                                 personalised advertising.
                                             </p>
                                             <p>


### PR DESCRIPTION
Fixes a small typo in the copy of the banner.