### PR TITLE
Remove copy AB test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/consent-management-platform",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "description": "Library of useful utilities for managing consent state across *.theguardian.com",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/component/Banner.tsx
+++ b/src/component/Banner.tsx
@@ -328,76 +328,42 @@ class Banner extends Component<Props, State> {
                                     </h1>
                                 </div>
                                 <div css={mobileScrollable}>
-                                    {this.props.variant ===
-                                    'commercialCmpCopy-variant' ? (
-                                        <>
-                                            <p>
-                                                We and our{' '}
-                                                <button
-                                                    css={buttonAsLinkStyles}
-                                                    onClick={() => {
-                                                        onOptionsClick(true);
-                                                    }}
-                                                    tabIndex={1}
-                                                >
-                                                    partners
-                                                </button>{' '}
-                                                use your information – collected
-                                                through cookies and similar
-                                                technologies – to improve your
-                                                experience on our site, analyse
-                                                how you use it and show you
-                                                personalised advertising.
-                                            </p>
-                                            <p>
-                                                You can find out more in our{' '}
-                                                <a
-                                                    data-link-name="first-pv-consent : to-privacy"
-                                                    href={privacyPolicyUrl}
-                                                >
-                                                    privacy policy
-                                                </a>{' '}
-                                                and{' '}
-                                                <a
-                                                    data-link-name="first-pv-consent : to-cookies"
-                                                    href={cookiePolicyUrl}
-                                                >
-                                                    cookie policy
-                                                </a>
-                                                , and manage your consent at any
-                                                time by going to ‘Privacy
-                                                settings’ at the bottom of any
-                                                page.
-                                            </p>
-                                        </>
-                                    ) : (
-                                        <>
-                                            <p>
-                                                We use cookies to improve your
-                                                experience on our site and to
-                                                show you personalised
-                                                advertising.
-                                            </p>
-                                            <p>
-                                                To find out more, read our{' '}
-                                                <a
-                                                    data-link-name="first-pv-consent : to-privacy"
-                                                    href={privacyPolicyUrl}
-                                                >
-                                                    privacy policy
-                                                </a>{' '}
-                                                and{' '}
-                                                <a
-                                                    data-link-name="first-pv-consent : to-cookies"
-                                                    href={cookiePolicyUrl}
-                                                >
-                                                    cookie policy
-                                                </a>
-                                                .
-                                            </p>
-                                        </>
-                                    )}
-
+                                    <p>
+                                        We and our{' '}
+                                        <button
+                                            css={buttonAsLinkStyles}
+                                            onClick={() => {
+                                                onOptionsClick(true);
+                                            }}
+                                            tabIndex={1}
+                                        >
+                                            partners
+                                        </button>{' '}
+                                        use your information – collected through
+                                        cookies and similar technologies – to
+                                        improve your experience on our site,
+                                        analyse how you use it and show you
+                                        personalised advertising.
+                                    </p>
+                                    <p>
+                                        You can find out more in our{' '}
+                                        <a
+                                            data-link-name="first-pv-consent : to-privacy"
+                                            href={privacyPolicyUrl}
+                                        >
+                                            privacy policy
+                                        </a>{' '}
+                                        and{' '}
+                                        <a
+                                            data-link-name="first-pv-consent : to-cookies"
+                                            href={cookiePolicyUrl}
+                                        >
+                                            cookie policy
+                                        </a>
+                                        , and manage your consent at any time by
+                                        going to ‘Privacy settings’ at the
+                                        bottom of any page.
+                                    </p>
                                     <button
                                         css={collapsibleButtonStyles(
                                             showInfo,


### PR DESCRIPTION
This PR removes the AB test for testing copy introduced in PRs https://github.com/guardian/consent-management-platform/pull/75 and https://github.com/guardian/consent-management-platform/pull/78 making the variant the standard version.