### PR TITLE
Define CMP v4 API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4

--- a/.prettierrc
+++ b/.prettierrc
@@ -9,11 +9,11 @@
 	"singleQuote": true,
 	"trailingComma": "all",
 	"useTabs": true,
-	"tabWidth": 4,
 	"overrides": [
 		{
 			"files": "*.md",
 			"options": {
+				"tabWidth": 4,
 				"useTabs": false
 			}
 		}

--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,14 @@
 	"semi": true,
 	"singleQuote": true,
 	"trailingComma": "all",
-	"useTabs": true
+	"useTabs": true,
+	"tabWidth": 4,
+	"overrides": [
+		{
+			"files": "*.md",
+			"options": {
+				"useTabs": false
+			}
+		}
+	]
 }

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ The CMP applies the CCPA to users in the USA, and TCFv2 to everyone else.
 ## Usage
 
 ```js
-import { init, onConsentNotification } from '@guardian/consent-management-platform';
+import {
+    init,
+    onConsentNotification,
+} from '@guardian/consent-management-platform';
 
-init({ isInUS: true });
+init({ isInUsa: true });
 
 onConsentNotification(({ tcfState, ccpaState }) => {
     if (ccpaState) {
@@ -32,11 +35,11 @@ returns: `void`
 
 Adds the relevent privacy framework to the page. It needs to be run before any other API call.
 
-#### options.isInUS
+#### options.isInUsa
 
 type: `boolean`
 
-_Required!_ Declare whether your user is in the US or not.
+_Required!_ Declare whether your user is in the USA or not.
 
 ### onConsentNotification(callback)
 
@@ -57,7 +60,7 @@ If the consent state has already been acquired when `onConsentNotification` is c
 
 type: `Object` or `undefined`
 
-Reports the user's consent to the various TCFv2 uses:
+Reports the user's preferences to the TCFv2 purposes:
 
 ```js
 {
@@ -75,7 +78,7 @@ Reports whether user has withdrawn consent to sell their data:
 
 ```js
 {
-    doNotSell: Boolean
+    doNotSell: Boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ The CMP applies the CCPA to users in the USA, and TCFv2 to everyone else.
 ## Usage
 
 ```js
-import {
-    init,
-    onConsentNotification,
-} from '@guardian/consent-management-platform';
+import { init, onConsentNotification } from '@guardian/consent-management-platform';
 
 init({ isInUS: true });
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ onConsentNotification((tcfState, ccpaState) => {
 	if (tcfState !== null) {
 		console.log(tcfState); // { 1: true || false, 1: true || false, ... }
 	} else {
-		console.log(tcfState); // true || false
+		console.log(ccpaState); // true || false
 	}
 });
 ```

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ checkUiWillShow()
 
 returns: `void`
 
-Surfaces the relevant privacy manager, allowing the user to change their privacy preferences after the initial privacy message.
+Shows the relevant privacy manager, allowing the user to update their privacy preferences after they've closed the initial privacy message.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ If `InitOptions.isInUS` is missing, `init` will default to running in TCF mode.
 
 `onConsentNotification(callback: ConsentCallack): void`
 
-When `onConsentNotification` is called it will add the supplied callback to a list of a callbacks. These will be fired when 1) after the consent state is first checked, and 2) the consent state changes (eg. if a user resurfaces the privacy manager and makes change to their privacy preferences). If the consent state is already known when `onConsentNotification` is called the callback is fired immediately. The signatures for the callback function and its parameters are:
+When `onConsentNotification` is called it will add the supplied callback to a list of a callbacks. These will be fired when 1) after the consent state is first checked, and 2) the consent state changes (eg. if a user resurfaces the privacy manager and makes change to their privacy preferences). If the consent state is already known when `onConsentNotification` is called the callback is fired immediately.
+
+The signatures for the callback function and its parameters are:
 
 ```
 interface TcfState {

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ If you need to conditionally run some code based on a user's consent state you c
 
 ## What is the API?
 
-[init](#init)
-[onConsentNotification](#onconsentnotification)
-[checkWillShowUi](#checkwillshowui)
+[init](#init)<br />
+[onConsentNotification](#onconsentnotification)<br />
+[checkWillShowUi](#checkwillshowui)<br />
 [showPrivacyManager](#showprivacymanager)
 
 ### init
@@ -61,7 +61,7 @@ type CcpaState = boolean
 type ConsentCallback = (tcfSate: TcfState | null, ccpaState: CcpaState | null) => void
 ```
 
-The keys in `TCFState` will match the TCF purpose IDs.
+The keys in `TCFState` will match the TCF purpose IDs.<br />
 The value of `ccpaState` will be the inverse of the [CCPA opt-out flag](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md#us-privacy-string-format) when in CCPA mode. This is to provide a homogenous way to handle consent between the TCF and the CCPA frameworks where `true` means consent has been given and `false` means consent has been denied.
 
 If `onConsentNotification` is called before `init`, it will do nothing.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 Welcome to the Consent Management Platform, a library to manage privacy frameworks across \*.theguardian.com, from messaging to managing and reporting the privacy state. All exports include Typescript definitions.
 
-from messaging to state
-
-## What useful utilities does this offer?
+## What utilities does this offer?
 
 ### TCF and CCPA privacy frameworks
 
-If you need to use Sourcepoint's implementation of the TCF or CCPA privacy frameworks, you can inititalise them on your page using the `init` function.
+If you need to use the TCF or CCPA privacy frameworks, you can inititalise them on your page using the `init` function.
 
 ### Consent notifications
 
@@ -27,7 +25,7 @@ If you need to conditionally run some code based on a user's consent state you c
 
 This functions tale 1 argument, a configuration object.
 
-When `init` is called, it will add Sourcepoint's implementation of the TCF or the CCPA privacy frameworks to the page, depending on the configuration options received. In the rest of this document we will refer to these and TCF mode and CCPA mode, respectively. It needs to be run before any other API call.
+When `init` is called, it will add the TCF or the CCPA privacy framework to the page, depending on the configuration options received. We refer to these as TCF mode and CCPA mode, respectively. This function needs to be run before any other API call.
 
 The configuration object that it requires is:
 

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ The CMP applies the CCPA to users in the USA, and TCFv2 to everyone else.
 
 ```js
 import {
-	init,
-	onConsentNotification,
+    init,
+    onConsentNotification,
 } from '@guardian/consent-management-platform';
 
 init({ isInUS: true });
 
 onConsentNotification(({ tcfState, ccpaState }) => {
-	if (ccpaState) {
-		console.log(ccpaState); // { doNotSell: true || false }
-	}
-	if (tcfState) {
-		console.log(tcfState); // { 1: true || false, 1: true || false, ... }
-	}
+    if (ccpaState) {
+        console.log(ccpaState); // { doNotSell: true || false }
+    }
+    if (tcfState) {
+        console.log(tcfState); // { 1: true || false, 1: true || false, ... }
+    }
 });
 ```
 
@@ -77,7 +77,7 @@ Reports whether user has withdrawn consent to sell their data:
 
 ```js
 {
-	doNotSell: Boolean;
+    doNotSell: Boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Reports whether user has withdrawn consent to sell their data:
 
 ```js
 {
-    doNotSell: Boolean;
+    doNotSell: Boolean
 }
 ```
 
 ### checkUiWillShow()
 
-returns: `Promise<boolean>`
+returns: `Promise<Boolean>`
 
-The returned promise resolves to `true` if the user will be shown the initial privacy message, or `false` if they have already dismissed it.
+The returned promise resolves to `true` if the user will be shown the initial privacy message, or `false` if not.
 
 If it's called before `init()`, it will `reject`.
 
@@ -93,7 +93,7 @@ If it's called before `init()`, it will `reject`.
 ```js
 import { checkUiWillShow } from '@guardian/consent-management-platform';
 
-checkWillShowUi()
+checkUiWillShow()
     .then(result =>
         console.log(result) // true || false
     ).catch(e =>

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Reports the user's consent to the various TCFv2 uses:
 
 ```js
 {
-	1: Boolean,
-	2: Boolean,
-	// etc
+    1: Boolean,
+    2: Boolean,
+    // etc
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ type: `function`
 
 Reports the user's relevant privacy preferences.
 
+##### result
+
+type: `Object`
+
+
 ```js
 {
     tcfState?: Boolean,
@@ -65,7 +70,7 @@ Reports the user's relevant privacy preferences.
 }
 ```
 
-###### result.tcfState
+##### result.tcfState
 
 type: `Object` or `undefined`
 
@@ -79,7 +84,7 @@ Reports the user's preferences to each of the TCFv2 purposes:
 }
 ```
 
-###### result.ccpaState
+##### result.ccpaState
 
 type: `Object` or `undefined`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Consent Management Platform
 
-Welcome to the Consent Management Platform, a library of useful utilities for managing consent state across \*.theguardian.com. All exports include Typescript definitions.
+Welcome to the Consent Management Platform, a library to manage privacy frameworks across \*.theguardian.com, from messaging to managing and reporting the privacy state. All exports include Typescript definitions.
+
+from messaging to state
 
 ## What useful utilities does this offer?
 
@@ -13,6 +15,11 @@ If you need to use Sourcepoint's implementation of the TCF or CCPA privacy frame
 If you need to conditionally run some code based on a user's consent state you can use the function `onConsentNotification`.
 
 ## What is the API?
+
+[init](#init)
+[onConsentNotification](#onconsentnotification)
+[checkWillShowUi](#checkwillshowui)
+[showPrivacyManager](#showprivacymanager)
 
 ### init
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ interface CcpaState {
 interface PrivacyState {
 	tcfState?: TcfState;
 	ccpaState?: CcpaState;
-
 }
 
 type ConsentCallback = (state: PrivacyState) => void

--- a/README.md
+++ b/README.md
@@ -37,23 +37,22 @@ Adds the relevent privacy framework to the page. It needs to be run before any o
 
 #### options.isInUS
 
-type: `boolean`<br>
-required: yes
+type: `boolean`
 
 ### onConsentNotification(callback)
 
 returns: `void`
 
-Callbacks are invoked when the consent state:
-
-- is acquired
-- changes (eg. if a user changes to their privacy preferences).
-
-If the consent state has already been acquired when `onConsentNotification` is called, the callback is invoked immediately.
-
 #### callback(result)
 
-type: `function`<br/>
+type: `function`
+
+Callbacks are invoked when the consent state:
+
+-   is acquired
+-   changes (eg. if a user changes their privacy preferences).
+
+If the consent state has already been acquired when `onConsentNotification` is called, the callback will be invoked immediately.
 
 ##### result.tcfState
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ type ConsentCallback = (tcfSate: TcfState | null, ccpaState: CcpaState | null) =
 ```
 
 The keys in `TCFState` will match the TCF purpose IDs.
-The value of `ccpaState` will be the reverse of the [CCPA opt-out flag](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md#us-privacy-string-format) when in CCPA mode. This is to provide a homogenous way to handle consent between the TCF and the CCPA frameworks where `true` means consent has been given and `false` means consent has been denied.
+The value of `ccpaState` will be the inverse of the [CCPA opt-out flag](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md#us-privacy-string-format) when in CCPA mode. This is to provide a homogenous way to handle consent between the TCF and the CCPA frameworks where `true` means consent has been given and `false` means consent has been denied.
 
 If `onConsentNotification` is called before `init`, it will do nothing.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Adds the relevent privacy framework to the page. It needs to be run before any o
 
 type: `boolean`
 
+_Required!_ Declare whether your user is in the US or not.
+
 ### onConsentNotification(callback)
 
 returns: `void`

--- a/README.md
+++ b/README.md
@@ -39,15 +39,11 @@ Adds the relevent privacy framework to the page. It needs to be run before any o
 
 type: `boolean`
 
-_Required!_ Declare whether your user is in the USA or not.
+_Required! Throws error is not present._ Declare whether your user is in the USA or not.
 
 ### onConsentNotification(callback)
 
 returns: `void`
-
-#### callback(result)
-
-type: `function`
 
 Callbacks are invoked when the consent state:
 
@@ -56,21 +52,34 @@ Callbacks are invoked when the consent state:
 
 If the consent state has already been acquired when `onConsentNotification` is called, the callback will be invoked immediately.
 
-##### result.tcfState
+#### callback(result)
 
-type: `Object` or `undefined`
+type: `function`
 
-Reports the user's preferences to the TCFv2 purposes:
+Reports the user's relevant privacy preferences.
 
 ```js
 {
-    1: Boolean,
-    2: Boolean,
+    tcfState?: Boolean,
+    ccpaState?: Boolean,
+}
+```
+
+###### result.tcfState
+
+type: `Object` or `undefined`
+
+Reports the user's preferences to each of the TCFv2 purposes:
+
+```js
+{
+    1: Boolean;
+    2: Boolean;
     // etc
 }
 ```
 
-##### result.ccpaState
+###### result.ccpaState
 
 type: `Object` or `undefined`
 
@@ -86,9 +95,9 @@ Reports whether user has withdrawn consent to sell their data:
 
 returns: `Promise<Boolean>`
 
-The returned promise resolves to `true` if the user will be shown the initial privacy message, or `false` if not.
+The returned promise resolves to `true` if the user will be shown the initial privacy message, or `false` otherwise.
 
-If it's called before `init()`, it will `reject`.
+If it's called before `init()`, it will return a rejected promise.
 
 **Example:**
 
@@ -97,9 +106,9 @@ import { checkUiWillShow } from '@guardian/consent-management-platform';
 
 checkUiWillShow()
     .then(result =>
-        console.log(result) // true || false
+        console.log(result); // true || false
     ).catch(e =>
-        console.log("checkUiWillShow() failed:", e): // "checkUiWillShow() failed: called before init()"
+        console.log("checkUiWillShow() failed:", e); // "checkUiWillShow() failed: called before init()"
     );
 ```
 
@@ -107,7 +116,7 @@ checkUiWillShow()
 
 returns: `void`
 
-Allows users to change their privacy preferences by (re-)showing the privacy manager after the initial privacy message.
+Surfaces the relevant privacy manager, allowing the user to change their privacy preferences after the initial privacy message.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Consent Management Platform
 
-Welcome to the Consent Management Platform, a library to manage privacy frameworks across \*.theguardian.com, from messaging to managing and reporting the privacy state. All exports include Typescript definitions.
+Welcome to the Consent Management Platform, a library to manage privacy frameworks across \*.theguardian.com, from messaging to reporting the privacy state. All exports include Typescript definitions.
 
 ## What utilities does this offer?
 
@@ -23,7 +23,7 @@ If you need to conditionally run some code based on a user's consent state you c
 
 `init(options: InitOptions): void`
 
-When `init` is called, it will add the TCF or the CCPA privacy framework to the page, depending on the configuration options received. We refer to these as TCF mode and CCPA mode, respectively. This function needs to be run before any other API call.
+Calling `init` will add the TCF or the CCPA privacy framework to the page, depending on the configuration options received. We refer to these as TCF mode and CCPA mode, respectively. This function needs to be run before any other API call.
 
 The configuration object that it requires is:
 
@@ -33,13 +33,13 @@ interface InitOptions {
 }
 ```
 
-If `options.isInUS` is missing, `init` will default to running in TCF mode.
+If `InitOptions.isInUS` is missing, `init` will default to running in TCF mode.
 
 ### onConsentNotification
 
 `onConsentNotification(callback: ConsentCallack): void`
 
-When `onConsentNotification` is called it will add the supplied callback to a list of a callbacks. These callbacks will be fired when 1) the consent state is first obtained, and 2) the consent state is changed (eg. if a user resurfaces the privacy manager and makes change to their privacy preferences). If the consent state is already know when `onConsentNotification` is called the callback is fired immediately. The signatures for the callback function and its parameters are:
+When `onConsentNotification` is called it will add the supplied callback to a list of a callbacks. These will be fired when 1) after the consent state is first checked, and 2) the consent state changes (eg. if a user resurfaces the privacy manager and makes change to their privacy preferences). If the consent state is already known when `onConsentNotification` is called the callback is fired immediately. The signatures for the callback function and its parameters are:
 
 ```
 interface TcfState {
@@ -78,7 +78,7 @@ onConsentNotification(({ tcfState, ccpaState }) => {
 
 `checkUiWillShow(): Promise<boolean>`
 
-The `checkUiWillShow` function returns the promise of a boolean. This boolean will be `true` if the user will shown a TCF or a CCPA privacy message, depending on which mode is running, and `false` otherwise. If called before `init`, it will return a rejected promise.
+The `checkUiWillShow` function returns the promise of a boolean. This boolean will be `true` if the user will be shown a TCF or a CCPA privacy message, depending on which mode is running, and `false` otherwise. If called before `init`, it will return a rejected promise.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Adds the relevent privacy framework to the page. It needs to be run before any o
 
 type: `boolean`
 
-_Required! Throws error is not present._ Declare whether your user is in the USA or not.
+_Required! Throws error if not present._ Declare whether your user is in the USA or not.
 
 ### onConsentNotification(callback)
 


### PR DESCRIPTION
## What does this change?
This PR presents a suggested API for CMP v4 in README.md form. v4 of the CMP will replace our TCF v1 implementation with Sourcepoint's TCF v2 implementation.