### PR TITLE
Stop CCPA stub being added to every page

### DIFF
--- a/src/ccpa/sourcepoint-stub.js
+++ b/src/ccpa/sourcepoint-stub.js
@@ -1,54 +1,55 @@
 /* eslint-disable */
-
-var e = false;
-var c = window;
-var t = document;
-function r() {
-    if (!c.frames['__uspapiLocator']) {
-        if (t.body) {
-            var a = t.body;
-            var e = t.createElement('iframe');
-            e.style.cssText = 'display:none';
-            e.name = '__uspapiLocator';
-            a.appendChild(e);
-        } else {
-            setTimeout(r, 5);
-        }
-    }
-}
-r();
-function p() {
-    var a = arguments;
-    __uspapi.a = __uspapi.a || [];
-    if (!a.length) {
-        return __uspapi.a;
-    } else if (a[0] === 'ping') {
-        a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true);
-    } else {
-        __uspapi.a.push([].slice.apply(a));
-    }
-}
-function l(t) {
-    var r = typeof t.data === 'string';
-    try {
-        var a = r ? JSON.parse(t.data) : t.data;
-        if (a.__cmpCall) {
-            var n = a.__cmpCall;
-            c.__uspapi(n.command, n.parameter, function (a, e) {
-                var c = {
-                    __cmpReturn: {
-                        returnValue: a,
-                        success: e,
-                        callId: n.callId,
-                    },
-                };
-                t.source.postMessage(r ? JSON.stringify(c) : c, '*');
-            });
-        }
-    } catch (a) {}
-}
-if (typeof __uspapi !== 'function') {
-    c.__uspapi = p;
-    __uspapi.msgHandler = l;
-    c.addEventListener('message', l, false);
-}
+export const runStub = () => {
+	var e = false;
+	var c = window;
+	var t = document;
+	function r() {
+		if (!c.frames['__uspapiLocator']) {
+			if (t.body) {
+				var a = t.body;
+				var e = t.createElement('iframe');
+				e.style.cssText = 'display:none';
+				e.name = '__uspapiLocator';
+				a.appendChild(e);
+			} else {
+				setTimeout(r, 5);
+			}
+		}
+	}
+	r();
+	function p() {
+		var a = arguments;
+		__uspapi.a = __uspapi.a || [];
+		if (!a.length) {
+			return __uspapi.a;
+		} else if (a[0] === 'ping') {
+			a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true);
+		} else {
+			__uspapi.a.push([].slice.apply(a));
+		}
+	}
+	function l(t) {
+		var r = typeof t.data === 'string';
+		try {
+			var a = r ? JSON.parse(t.data) : t.data;
+			if (a.__cmpCall) {
+				var n = a.__cmpCall;
+				c.__uspapi(n.command, n.parameter, function (a, e) {
+					var c = {
+						__cmpReturn: {
+							returnValue: a,
+							success: e,
+							callId: n.callId,
+						},
+					};
+					t.source.postMessage(r ? JSON.stringify(c) : c, '*');
+				});
+			}
+		} catch (a) {}
+	}
+	if (typeof __uspapi !== 'function') {
+		c.__uspapi = p;
+		__uspapi.msgHandler = l;
+		c.addEventListener('message', l, false);
+	}
+};

--- a/src/ccpa/sourcepoint.test.js
+++ b/src/ccpa/sourcepoint.test.js
@@ -5,6 +5,10 @@ import { init } from './sourcepoint';
 describe('Sourcepoint', () => {
 	init();
 
+	it('injects the stub', () => {
+		expect(document.getElementById('sourcepoint-ccpa-stub')).toBeTruthy();
+	});
+
 	it('injects the lib', () => {
 		expect(document.getElementById('sourcepoint-ccpa-lib')).toBeTruthy();
 	});

--- a/src/ccpa/sourcepoint.test.js
+++ b/src/ccpa/sourcepoint.test.js
@@ -5,10 +5,6 @@ import { init } from './sourcepoint';
 describe('Sourcepoint', () => {
 	init();
 
-	it('injects the stub', () => {
-		expect(document.getElementById('sourcepoint-ccpa-stub')).toBeTruthy();
-	});
-
 	it('injects the lib', () => {
 		expect(document.getElementById('sourcepoint-ccpa-lib')).toBeTruthy();
 	});

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-import './sourcepoint-stub';
+import { runStub } from './sourcepoint-stub';
 import { mark } from '../mark';
 import { isGuardianDomain } from '../domain';
 
@@ -32,13 +32,6 @@ declare global {
 	}
 }
 
-const createCcpaStubScriptElement = (): HTMLElement => {
-	const ccpaStubSrc = `(function () { var e = false; var c = window; var t = document; function r() { if (!c.frames["__uspapiLocator"]) { if (t.body) { var a = t.body; var e = t.createElement("iframe"); e.style.cssText = "display:none"; e.name = "__uspapiLocator"; a.appendChild(e) } else { setTimeout(r, 5) } } } r(); function p() { var a = arguments; __uspapi.a = __uspapi.a || []; if (!a.length) { return __uspapi.a } else if (a[0] === "ping") { a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true) } else { __uspapi.a.push([].slice.apply(a)) } } function l(t) { var r = typeof t.data === "string"; try { var a = r ? JSON.parse(t.data) : t.data; if (a.__cmpCall) { var n = a.__cmpCall; c.__uspapi(n.command, n.parameter, function (a, e) { var c = { __cmpReturn: { returnValue: a, success: e, callId: n.callId } }; t.source.postMessage(r ? JSON.stringify(c) : c, "*") }) } } catch (a) { } } if (typeof __uspapi !== "function") { c.__uspapi = p; __uspapi.msgHandler = l; c.addEventListener("message", l, false) } })();`;
-	const ccpaStub = document.createElement('script');
-	ccpaStub.id = 'sourcepoint-ccpa-stub';
-	ccpaStub.innerHTML = ccpaStubSrc;
-	return ccpaStub;
-};
 export interface MsgData {
 	msg_id: number;
 }
@@ -75,8 +68,7 @@ export const init = (onCcpaReadyCallback: onReadyCallback) => {
 			'Sourcepoint CCPA global (window._sp_ccpa) is already defined!',
 		);
 	}
-	const ccpaStub = createCcpaStubScriptElement();
-	document.head.appendChild(ccpaStub);
+	runStub();
 
 	window._sp_ccpa = {
 		config: {

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -32,6 +32,13 @@ declare global {
 	}
 }
 
+const createCcpaStubScriptElement = (): HTMLElement => {
+	const ccpaStubSrc = `(function () { var e = false; var c = window; var t = document; function r() { if (!c.frames["__uspapiLocator"]) { if (t.body) { var a = t.body; var e = t.createElement("iframe"); e.style.cssText = "display:none"; e.name = "__uspapiLocator"; a.appendChild(e) } else { setTimeout(r, 5) } } } r(); function p() { var a = arguments; __uspapi.a = __uspapi.a || []; if (!a.length) { return __uspapi.a } else if (a[0] === "ping") { a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true) } else { __uspapi.a.push([].slice.apply(a)) } } function l(t) { var r = typeof t.data === "string"; try { var a = r ? JSON.parse(t.data) : t.data; if (a.__cmpCall) { var n = a.__cmpCall; c.__uspapi(n.command, n.parameter, function (a, e) { var c = { __cmpReturn: { returnValue: a, success: e, callId: n.callId } }; t.source.postMessage(r ? JSON.stringify(c) : c, "*") }) } } catch (a) { } } if (typeof __uspapi !== "function") { c.__uspapi = p; __uspapi.msgHandler = l; c.addEventListener("message", l, false) } })();`;
+	const ccpaStub = document.createElement('script');
+	ccpaStub.id = 'sourcepoint-ccpa-stub';
+	ccpaStub.innerHTML = ccpaStubSrc;
+	return ccpaStub;
+};
 export interface MsgData {
 	msg_id: number;
 }
@@ -68,6 +75,8 @@ export const init = (onCcpaReadyCallback: onReadyCallback) => {
 			'Sourcepoint CCPA global (window._sp_ccpa) is already defined!',
 		);
 	}
+	const ccpaStub = createCcpaStubScriptElement();
+	document.head.appendChild(ccpaStub);
 
 	window._sp_ccpa = {
 		config: {


### PR DESCRIPTION
## What does this change?
Only adds CCPA stub from Sourcepoint when CCPA is actually in use.
Reintroduces the code from #109 and puts the script element creation inside a function.

## Images
### CCPA
![image](https://user-images.githubusercontent.com/9122944/86235338-2e9dce00-bb90-11ea-8bd2-b550030887a3.png)


### TCF
![image](https://user-images.githubusercontent.com/9122944/86145160-808e1780-baee-11ea-92df-42f361f1a3a7.png)

