### PR TITLE
handle some messages not setting consent when dismissed

### DIFF
--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -46,6 +46,16 @@ export const init = () => {
 				onMessageReceiveData: (data) => {
 					resolveWillShowPrivacyMessage?.(data.msg_id !== 0);
 				},
+				onMessageChoiceSelect: (_choiceId, choiceTypeID) => {
+					if (
+						// https://documentation.sourcepoint.com/web-implementation/sourcepoint-set-up-and-configuration-v2/optional-callbacks#choice-type-id-descriptions
+						choiceTypeID === 11 ||
+						choiceTypeID === 13 ||
+						choiceTypeID === 15
+					) {
+						setTimeout(invokeCallbacks, 0);
+					}
+				},
 			},
 		},
 	};

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -42,6 +42,16 @@ export const init = () => {
 				onMessageReceiveData: (data) => {
 					resolveWillShowPrivacyMessage?.(data.messageId !== 0);
 				},
+				onMessageChoiceSelect: (_choiceId, choiceTypeID) => {
+					if (
+						// https://documentation.sourcepoint.com/web-implementation/sourcepoint-set-up-and-configuration-v2/optional-callbacks#choice-type-id-descriptions
+						choiceTypeID === 11 ||
+						choiceTypeID === 13 ||
+						choiceTypeID === 15
+					) {
+						setTimeout(invokeCallbacks, 0);
+					}
+				},
 			},
 		},
 	};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -61,7 +61,7 @@ interface Window {
 			events?: {
 				onConsentReady: () => void;
 				onMessageReady: () => void;
-				onMessageReceiveData?: (data: { messageId: 0 | string }) => void;
+				onMessageReceiveData: (data: { messageId: 0 | string }) => void;
 				onMessageChoiceSelect: (
 					arg0: number,
 					arg1: SourcePointChoiceType,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,22 @@ interface SourcepointImplementation {
 	showPrivacyManager: () => void;
 }
 
+type SourcePointChoiceType =
+	| 1
+	| 2
+	| 3
+	| 4
+	| 5
+	| 6
+	| 7
+	| 9
+	| 10
+	| 11
+	| 12
+	| 13
+	| 14
+	| 15;
+
 // globals set on the window by the CMP library
 interface Window {
 	// sourcepoint's libraries - only one should be present at a time
@@ -21,9 +37,13 @@ interface Window {
 				framework: 'ccpa';
 			};
 			events?: {
-				onConsentReady?: () => void;
-				onMessageReady?: () => void;
-				onMessageReceiveData?: (data: { msg_id: 0 | string }) => void;
+				onConsentReady: () => void;
+				onMessageReady: () => void;
+				onMessageReceiveData: (data: { msg_id: 0 | string }) => void;
+				onMessageChoiceSelect: (
+					arg0: number,
+					arg1: SourcePointChoiceType,
+				) => void;
 			};
 		};
 		loadPrivacyManagerModal?: (unknown: unknown, id: string) => {}; // this function is undocumented
@@ -39,9 +59,13 @@ interface Window {
 				framework: 'tcfv2';
 			};
 			events?: {
-				onConsentReady?: () => void;
-				onMessageReady?: () => void;
+				onConsentReady: () => void;
+				onMessageReady: () => void;
 				onMessageReceiveData?: (data: { messageId: 0 | string }) => void;
+				onMessageChoiceSelect: (
+					arg0: number,
+					arg1: SourcePointChoiceType,
+				) => void;
 			};
 		};
 		loadPrivacyManagerModal?: (id: number) => {};


### PR DESCRIPTION
`onConsentChange` callbacks are also now invoked after the user dismisses banners that sourcepoint doesn't think of as setting consent (e.g. CCPA).

fixes https://trello.com/c/5XgaVhHG