### PR TITLE
TCFv2 onConsentChange tests

### DIFF
--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import waitForExpect from 'wait-for-expect';
-import { onConsentChange, invokeCallbacks, _ } from './onConsentChange';
+import { onConsentChange, invokeCallbacks } from './onConsentChange';
 
 const uspData = {
 	version: 1,

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -16,7 +16,6 @@ describe('onConsentChange', () => {
 	});
 
 	it('invokes callbacks correctly', () => {
-		// const shouldChange = false;
 		const callback = jest.fn();
 		const instantCallback = jest.fn();
 		onConsentChange(callback);

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,5 +1,59 @@
+/* eslint-disable no-underscore-dangle */
+import waitForExpect from 'wait-for-expect';
+import { onConsentChange, invokeCallbacks, _ } from './onConsentChange';
+
+const uspData = {
+	version: 1,
+	uspString: '1YYN',
+};
+window.__uspapi = jest.fn((a, b, callback) => {
+	callback(uspData, true);
+});
+
 describe('onConsentChange', () => {
-	it('has a test', () => {
-		expect(true).toBeTruthy();
+	it('can fake the USP Api', () => {
+		expect(window.__uspapi).toBeDefined();
+	});
+
+	it('invokes callbacks correctly', () => {
+		// const shouldChange = false;
+		const callback = jest.fn();
+		const instantCallback = jest.fn();
+		onConsentChange(callback);
+		expect(callback).toHaveBeenCalledTimes(0);
+		invokeCallbacks();
+		return waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		}).then(() => {
+			onConsentChange(instantCallback);
+			return waitForExpect(() => {
+				expect(callback).toHaveBeenCalledTimes(1);
+				expect(instantCallback).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
+
+	it('invokes callbacks only if there is a new state', () => {
+		const callback = jest.fn();
+		onConsentChange(callback);
+		invokeCallbacks();
+		return waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		})
+			.then(invokeCallbacks)
+			.then(() => {
+				return waitForExpect(() => {
+					expect(callback).toHaveBeenCalledTimes(1);
+				});
+			})
+			.then(() => {
+				uspData.uspString = '1YNN';
+			})
+			.then(invokeCallbacks)
+			.then(() =>
+				waitForExpect(() => {
+					expect(callback).toHaveBeenCalledTimes(2);
+				}),
+			);
 	});
 });

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -11,10 +11,6 @@ window.__uspapi = jest.fn((a, b, callback) => {
 });
 
 describe('onConsentChange', () => {
-	it('can fake the USP Api', () => {
-		expect(window.__uspapi).toBeDefined();
-	});
-
 	it('invokes callbacks correctly', () => {
 		const callback = jest.fn();
 		const instantCallback = jest.fn();

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -34,8 +34,10 @@ export const invokeCallbacks = () => {
 const getConsentState: () => Promise<ComparedConsentState> = () =>
 	new Promise((resolve, reject) => {
 		// in USA - https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md
+		/* istanbul ignore else */
 		if (window.__uspapi) {
 			window.__uspapi('getUSPData', 1, (uspData, success) => {
+				/* istanbul ignore else */
 				if (success) {
 					let doNotSell = false;
 
@@ -94,3 +96,5 @@ export const onConsentChange = (callBack: Callback) => {
 			// do nothing - callback will be added the list anyway
 		});
 };
+
+export const _ = { getConsentState };

--- a/src/tcfv2/sourcepoint.test.js
+++ b/src/tcfv2/sourcepoint.test.js
@@ -4,10 +4,6 @@ import url from 'url';
 import { init } from './sourcepoint';
 import { ACCOUNT_ID } from '../lib/accountId';
 
-jest.mock('../onConsentChange', () => ({
-	invokeCallbacks: jest.fn(),
-}));
-
 describe('Sourcepoint TCF', () => {
 	afterEach(() => {
 		window._sp_ = undefined;


### PR DESCRIPTION
## What does this change?
This adds tests for `onConsentChange`. Test coverage is 100% thanks to `/* istanbul ignore else */`. See syntax on [BestofJS](https://bestofjs.org/projects/istanbul#Parsing%20Hints)

## How can we measure success?
We can mock the `window.__uspapi` and test our work.
