### PR TITLE
fix and update TCFv2 build

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,9 +1,3 @@
 module.exports = {
-    presets: [
-        '@babel/preset-env',
-        '@babel/preset-typescript',
-        '@babel/preset-react',
-        ['@emotion/babel-preset-css-prop', { sourceMap: false }],
-    ],
-    plugins: ['@babel/plugin-proposal-class-properties'],
+	presets: ['@babel/preset-env', '@babel/preset-typescript'],
 };

--- a/package.json
+++ b/package.json
@@ -1,49 +1,34 @@
 {
 	"name": "@guardian/consent-management-platform",
 	"version": "3.4.8",
-	"description": "Library of useful utilities for managing consent state across *.theguardian.com",
+	"description": "Consent management for *.theguardian.com.",
+	"homepage": "https://github.com/guardian/consent-management-platform.git",
+	"repository": "https://github.com/guardian/consent-management-platform.git",
+	"license": "Apache-2.0",
 	"main": "dist/index.js",
+	"module": "dist/index.esm.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*"
 	],
 	"scripts": {
-		"build": "yarn validate && yarn build-only",
-		"build-only": "yarn clean && rollup --config && yarn declaration",
+		"build": "npm-run-all clean --parallel compile types",
 		"clean": "rm -rf dist/*",
-		"declaration": "tsc --emitDeclarationOnly --project ./tsconfig.build.json",
+		"compile": "rollup --config",
+		"dev": "rollup --config dev/rollup.config.js --watch",
 		"fix": "yarn lint --fix",
+		"gh-pages:build": "rollup --config rollup.config.gh-pages.js",
+		"gh-pages:serve": "yarn gh-pages:build && serve .gh-pages",
 		"lint": "eslint . --ext=js,ts,tsx",
 		"prepublishOnly": "yarn build",
+		"release": "np --any-branch",
 		"test": "jest --coverage",
 		"tsc": "tsc --noEmit",
-		"validate": "npm-run-all --parallel tsc lint 'test --onlyChanged'",
-		"dev": "rollup --config dev/rollup.config.js --watch",
-		"release": "np",
-		"gh-pages:build": "rollup --config rollup.config.gh-pages.js",
-		"gh-pages:serve": "yarn gh-pages:build && serve .gh-pages"
+		"types": "tsc --emitDeclarationOnly --project ./tsconfig.build.json",
+		"validate": "npm-run-all --parallel tsc lint 'test --onlyChanged'"
 	},
-	"repository": "https://github.com/guardian/consent-management-platform.git",
-	"homepage": "https://github.com/guardian/consent-management-platform.git",
-	"author": "George Haberis <george.haberis@guardian.co.uk>",
-	"contributors": [
-		"Ricardo Costa <ricardo.costa@guardian.co.uk>"
-	],
-	"license": "Apache-2.0",
 	"dependencies": {
-		"consent-string": "1.5.2",
-		"js-cookie": "2.2.1",
-		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.5",
-		"whatwg-fetch": "3.0.0"
-	},
-	"peerDependencies": {
-		"@babel/runtime": "^7.2.0",
-		"@emotion/core": "^10.0.21",
-		"@guardian/src-button": "^1.4.0",
-		"@guardian/src-foundations": "^1.4.0",
-		"@guardian/src-icons": "^1.4.0",
-		"emotion-theming": "^10.0.27",
-		"react": "^16.10.2"
+		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.8"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.9.6",
@@ -80,7 +65,7 @@
 		"prettier": "^2.0.5",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
-		"rollup": "^2.10.9",
+		"rollup": "^2.21.0",
 		"rollup-plugin-babel": "^4.4.0",
 		"rollup-plugin-commonjs": "^10.1.0",
 		"rollup-plugin-livereload": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	],
 	"license": "Apache-2.0",
 	"dependencies": {
-		"@iabtcf/stub": "^1.0.2-5",
 		"consent-string": "1.5.2",
 		"js-cookie": "2.2.1",
 		"old-cmp": "npm:@guardian/consent-management-platform@^3.4.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 		"consent-string": "1.5.2",
 		"js-cookie": "2.2.1",
-		"old-cmp": "npm:@guardian/consent-management-platform@^3.4.5",
+		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.5",
 		"whatwg-fetch": "3.0.0"
 	},
 	"peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,15 +3,20 @@ import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import strip from '@rollup/plugin-strip';
 import replace from 'rollup-plugin-replace';
+import pkg from './package.json';
 
 const extensions = ['.js', '.ts', '.tsx'];
 
 module.exports = {
-	input: ['src/index.ts'],
+	input: 'src/index.ts',
 	output: [
 		{
-			dir: 'dist',
+			file: pkg.main,
 			format: 'cjs',
+		},
+		{
+			file: pkg.module,
+			format: 'esm',
 		},
 	],
 	external: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,34 +7,21 @@ import replace from 'rollup-plugin-replace';
 const extensions = ['.js', '.ts', '.tsx'];
 
 module.exports = {
-	input: ['src/index.ts', 'src/tcf/component/ConsentManagementPlatform.tsx'],
+	input: ['src/index.ts'],
 	output: [
-		{
-			dir: 'dist',
-			format: 'cjs',
-		},
 		{
 			dir: 'dist',
 			format: 'cjs',
 		},
 	],
 	external: [
-		'@babel/runtime/helpers/defineProperty',
-		'@babel/runtime/helpers/extends',
-		'@emotion/core',
-		'@guardian/src-button',
-		'@guardian/src-foundations',
-		'@guardian/src-foundations/accessibility',
-		'@guardian/src-foundations/mq',
-		'@guardian/src-foundations/palette',
-		'@guardian/src-foundations/themes',
-		'@guardian/src-foundations/typography',
-		'@guardian/src-svgs',
-		'react',
+		'@guardian/old-cmp',
+		'@guardian/old-cmp/dist/ConsentManagementPlatform',
 	],
 	plugins: [
 		babel({ extensions }),
 		resolve({ extensions }),
+
 		replace({
 			'process.env.NODE_ENV': JSON.stringify('production'),
 		}),

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,8 +5,8 @@ import { TCFv2 } from './tcfv2';
 
 // just stop Jest erroring on these
 // can be deleted when olde cmp is removed
-jest.mock('old-cmp', () => ({}));
-jest.mock('old-cmp/dist/ConsentManagementPlatform', () => ({}));
+jest.mock('@guardian/old-cmp', () => ({}));
+jest.mock('@guardian/old-cmp/dist/ConsentManagementPlatform', () => ({}));
 
 jest.mock('./ccpa', () => ({
 	CCPA: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,5 +45,5 @@ export {
 	onGuConsentNotification,
 	onIabConsentNotification,
 	shouldShow,
-} from 'old-cmp';
-export { ConsentManagementPlatform } from 'old-cmp/dist/ConsentManagementPlatform';
+} from '@guardian/old-cmp';
+export { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-import stub from '@iabtcf/stub';
+import { stub } from './stub';
 import { mark } from '../lib/mark';
 import { ACCOUNT_ID } from '../lib/accountId';
 import { isGuardianDomain } from '../lib/domain';

--- a/src/tcfv2/stub.js
+++ b/src/tcfv2/stub.js
@@ -1,0 +1,78 @@
+/* eslint-disable */
+
+// https://documentation.sourcepoint.com/web-implementation/sourcepoint-gdpr-and-tcf-v2-support-beta/gdpr-and-tcf-v2-setup-and-configuration#1-two-step-process-to-implement-the-gdpr-and-tcf-v2-code-snippet
+
+export const stub = () => {
+	var e = function () {
+		var e,
+			t = '__tcfapiLocator',
+			a = [],
+			n = window;
+		for (; n; ) {
+			try {
+				if (n.frames[t]) {
+					e = n;
+					break;
+				}
+			} catch (e) {}
+			if (n === window.top) break;
+			n = n.parent;
+		}
+		e ||
+			(!(function e() {
+				var a = n.document,
+					r = !!n.frames[t];
+				if (!r)
+					if (a.body) {
+						var i = a.createElement('iframe');
+						(i.style.cssText = 'display:none'),
+							(i.name = t),
+							a.body.appendChild(i);
+					} else setTimeout(e, 5);
+				return !r;
+			})(),
+			(n.__tcfapi = function () {
+				for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)
+					n[r] = arguments[r];
+				if (!n.length) return a;
+				if ('setGdprApplies' === n[0])
+					n.length > 3 &&
+						2 === parseInt(n[1], 10) &&
+						'boolean' == typeof n[3] &&
+						((e = n[3]), 'function' == typeof n[2] && n[2]('set', !0));
+				else if ('ping' === n[0]) {
+					var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: 'stub' };
+					'function' == typeof n[2] && n[2](i);
+				} else a.push(n);
+			}),
+			n.addEventListener(
+				'message',
+				function (e) {
+					var t = 'string' == typeof e.data,
+						a = {};
+					try {
+						a = t ? JSON.parse(e.data) : e.data;
+					} catch (e) {}
+					var n = a.__tcfapiCall;
+					n &&
+						window.__tcfapi(
+							n.command,
+							n.version,
+							function (a, r) {
+								var i = {
+									__tcfapiReturn: {
+										returnValue: a,
+										success: r,
+										callId: n.callId,
+									},
+								};
+								t && (i = JSON.stringify(i)), e.source.postMessage(i, '*');
+							},
+							n.parameter,
+						);
+				},
+				!1,
+			));
+	};
+	'undefined' != typeof module ? (module.exports = e) : e();
+};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,6 @@
 		"rootDir": "src",
 		"declaration": true,
 		"outDir": "dist"
-	}
+	},
+	"include": ["src/types.d.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,9 @@
 {
-    "extends": "./tsconfig.json",
-    "files": ["src/index.ts", "src/ConsentManagementPlatform.tsx"],
-    "compilerOptions": {
-        "rootDir": "src",
-        "declaration": true,
-        "outDir": "dist"
-    }
+	"extends": "./tsconfig.json",
+	"files": ["src/index.ts"],
+	"compilerOptions": {
+		"rootDir": "src",
+		"declaration": true,
+		"outDir": "dist"
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,5 @@
 		"esModuleInterop": true,
 		"allowJs": true
 	},
-	"include": ["src/types.d.ts"],
 	"exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
-    "compilerOptions": {
-        "target": "es5", // compile to es5 since to build a package with browser compatibility.
-        "lib": ["dom", "es7"],
-        "strict": true,
-        "jsx": "preserve",
-        "esModuleInterop": true,
-        "allowJs": true
-    },
-    "exclude": ["node_modules", "dist"]
+	"compilerOptions": {
+		"target": "es5", // compile to es5 since to build a package with browser compatibility.
+		"lib": ["dom", "es7"],
+		"strict": true,
+		"jsx": "preserve",
+		"esModuleInterop": true,
+		"allowJs": true
+	},
+	"include": ["src/types.d.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,7 +1043,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.5":
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.8":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
   integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
@@ -6429,7 +6429,7 @@ rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.10.9:
+rollup@^2.21.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.21.0.tgz#d2e114533812043d5c9b7b0a83f1b2a242e4e1d6"
   integrity sha512-BEGgy+wSzux7Ycq58pRiWEOBZaXRXTuvzl1gsm7gqmsAHxkWf9nyA5V2LN9fGSHhhDQd0/C13iRzSh4bbIpWZQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.5":
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
+  integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
+  dependencies:
+    consent-string "1.5.2"
+    js-cookie "2.2.1"
+    whatwg-fetch "3.0.0"
+
 "@guardian/src-button@^1.4.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-1.6.0.tgz#f581f75fbca4835e19998c9268482f74491c6bea"
@@ -5512,15 +5521,6 @@ object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-"old-cmp@npm:@guardian/consent-management-platform@^3.4.5":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.5.tgz#6d26f70b76d0ddd4ed1090433c992d61ccfbb9c7"
-  integrity sha512-aQvZ7aWrTAnda8FoWWoH9PTGRJQc4CQ7aO7oqkGgx0C3MJKayzLYe1Gsa3jlB5fuh4b8Nrw71PQ9HFglPmjEaw==
-  dependencies:
-    consent-string "1.5.2"
-    js-cookie "2.2.1"
-    whatwg-fetch "3.0.0"
 
 on-headers@~1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,11 +1068,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.6.0.tgz#a5ef68026d841e2d0c7c2622c19ca94b4ac59454"
   integrity sha512-2hdWKC3CTlKM2FL6PCMSFbG6sD5rLYhKwhUrZhmBVmTdsvxxU7NMGwjAMymxceoj4S6psDnrHBe7C+KkCyIQOw==
 
-"@iabtcf/stub@^1.0.2-5":
-  version "1.0.2-5"
-  resolved "https://registry.yarnpkg.com/@iabtcf/stub/-/stub-1.0.2-5.tgz#60336641b5c65bb9713040e7c48cf944dc7b7eb8"
-  integrity sha512-AuRq0/oqvoduDwBkVYBI0uonHTUHtEDmOOa3NOtwQ0d93M/+I3issM6IDaRftczn+XA1EgA8mAJfxBumL+7o+w==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
- installs old CMP with `@guardian` scope
- stops trying to build the old CMP
- adds an ES module version to the package
- removes the IAB tcf stub for the sourcepoint one (hopefully less likely to get bitten)
- cleans up `package.json`