### PR TITLE
TCFv2 expose old CCPA init()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import {
+	init,
 	onGuConsentNotification,
 	onIabConsentNotification,
 	shouldShow,
@@ -48,6 +49,7 @@ export const cmp = {
 export { onConsentChange } from './onConsentChange';
 
 export const oldCmp = {
+	init,
 	onGuConsentNotification,
 	onIabConsentNotification,
 	shouldShow,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import {
-	init,
+	init as oldInit,
 	onGuConsentNotification,
 	onIabConsentNotification,
 	shouldShow,
@@ -49,7 +49,7 @@ export const cmp = {
 export { onConsentChange } from './onConsentChange';
 
 export const oldCmp = {
-	init,
+	oldInit,
 	onGuConsentNotification,
 	onIabConsentNotification,
 	shouldShow,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { oldCmp as olderCmp } from './oldCmp';
+import { oldCmp } from './oldCmp';
 import { CCPA } from './ccpa';
 import { TCFv2 } from './tcfv2';
 
@@ -42,4 +42,4 @@ export const cmp = {
 
 export { onConsentChange } from './onConsentChange';
 
-export const oldCmp = olderCmp;
+export { oldCmp };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 /* eslint-disable no-console */
 
-import {
-	init as oldInit,
-	onGuConsentNotification,
-	onIabConsentNotification,
-	shouldShow,
-} from '@guardian/old-cmp';
-import { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';
+import { oldCmp as olderCmp } from './oldCmp';
 import { CCPA } from './ccpa';
 import { TCFv2 } from './tcfv2';
 
@@ -48,10 +42,4 @@ export const cmp = {
 
 export { onConsentChange } from './onConsentChange';
 
-export const oldCmp = {
-	oldInit,
-	onGuConsentNotification,
-	onIabConsentNotification,
-	shouldShow,
-	ConsentManagementPlatform,
-};
+export const oldCmp = olderCmp;

--- a/src/oldCmp.ts
+++ b/src/oldCmp.ts
@@ -1,0 +1,15 @@
+import {
+	init,
+	onGuConsentNotification,
+	onIabConsentNotification,
+	shouldShow,
+} from '@guardian/old-cmp';
+import { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';
+
+export const oldCmp = {
+	init,
+	onGuConsentNotification,
+	onIabConsentNotification,
+	shouldShow,
+	ConsentManagementPlatform,
+};

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,5 +1,54 @@
+/* eslint-disable no-underscore-dangle */
+import waitForExpect from 'wait-for-expect';
+import { onConsentChange, invokeCallbacks } from './onConsentChange';
+
+const uspData = {
+	version: 1,
+	uspString: '1YYN',
+};
+window.__uspapi = jest.fn((a, b, callback) => {
+	callback(uspData, true);
+});
+
 describe('onConsentChange', () => {
-	it('has a test', () => {
-		expect(true).toBeTruthy();
+	it('invokes callbacks correctly', () => {
+		const callback = jest.fn();
+		const instantCallback = jest.fn();
+		onConsentChange(callback);
+		expect(callback).toHaveBeenCalledTimes(0);
+		invokeCallbacks();
+		return waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		}).then(() => {
+			onConsentChange(instantCallback);
+			return waitForExpect(() => {
+				expect(callback).toHaveBeenCalledTimes(1);
+				expect(instantCallback).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
+
+	it('invokes callbacks only if there is a new state', () => {
+		const callback = jest.fn();
+		onConsentChange(callback);
+		invokeCallbacks();
+		return waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		})
+			.then(invokeCallbacks)
+			.then(() => {
+				return waitForExpect(() => {
+					expect(callback).toHaveBeenCalledTimes(1);
+				});
+			})
+			.then(() => {
+				uspData.uspString = '1YNN';
+			})
+			.then(invokeCallbacks)
+			.then(() =>
+				waitForExpect(() => {
+					expect(callback).toHaveBeenCalledTimes(2);
+				}),
+			);
 	});
 });

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -34,8 +34,10 @@ export const invokeCallbacks = () => {
 const getConsentState: () => Promise<ComparedConsentState> = () =>
 	new Promise((resolve, reject) => {
 		// in USA - https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md
+		/* istanbul ignore else */
 		if (window.__uspapi) {
 			window.__uspapi('getUSPData', 1, (uspData, success) => {
+				/* istanbul ignore else */
 				if (success) {
 					let doNotSell = false;
 
@@ -94,3 +96,5 @@ export const onConsentChange = (callBack: Callback) => {
 			// do nothing - callback will be added the list anyway
 		});
 };
+
+export const _ = { getConsentState };

--- a/src/tcfv2/sourcepoint.test.js
+++ b/src/tcfv2/sourcepoint.test.js
@@ -4,10 +4,6 @@ import url from 'url';
 import { init } from './sourcepoint';
 import { ACCOUNT_ID } from '../lib/accountId';
 
-jest.mock('../onConsentChange', () => ({
-	invokeCallbacks: jest.fn(),
-}));
-
 describe('Sourcepoint TCF', () => {
 	afterEach(() => {
 		window._sp_ = undefined;


### PR DESCRIPTION
## What does this change?

While the AB test is running, we will still need to expose the old CMP's `init()` for users in the USA.
The three 3, mutually-exclusive groups—thanks @ripecosta for clarifying—that a user might fall in are:

1. In USA: old CCPA _(requires `init({ccpaApplies: true})`)_
2. In RotW: old TCFv1 _(no `init()` required)_
3. In RotW (1%): new TCFv2 _(new `init({isInUsa: false})`)_

The old CMP's init is required for **Group 1**, and this PR aims to fix that. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?
The TCFv2 AB test will run smoothly. 

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Further notes
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

In frontend, the CMP will then be called through [`guardian/frontend/…/javascripts/boot.js#36`](https://github.com/guardian/frontend/blob/193bc01c52fe773d449d86604feba027e29ab6e2/static/src/javascripts/boot.js#L36)  :

```js
// Start CMP
if (isCcpaApplicable()) {
  oldCmp.init({ useCcpa: true });
} else if (isInTcfv2Test()) {
  cmp.init({ isInUsa: isInUsa() });
}
```