### PR TITLE
Types export for old CMP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist
 .dev
 .gh-pages
+/coverage

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 
 type IabPurposeCallback = TcfPurposeCallback | CcpaPurposeCallback;
 
-interface InitOptions {
+export interface InitOptions {
 	useCcpa: boolean;
 }
 


### PR DESCRIPTION
## What does this change?
The `InitOptions` interface needs to be exported for the V4.0.0 to work. Otherwise we get the following error.

```bash
src/oldCmp.ts:9:14 - error TS4023: Exported variable 'oldCmp' has or is using
name 'InitOptions' from external module "@guardian/old-cmp/dist/index"
but cannot be named.
```

## How can we measure success?
Old and new CMP can work together.
