### PR TITLE
Bump old CMP to 3.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"validate": "npm-run-all --parallel tsc lint 'test --onlyChanged'"
 	},
 	"dependencies": {
-		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.8"
+		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.9"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.9.6",

--- a/src/oldCmp.ts
+++ b/src/oldCmp.ts
@@ -2,6 +2,7 @@ import {
 	init,
 	onGuConsentNotification,
 	onIabConsentNotification,
+	checkWillShowUi,
 	shouldShow,
 } from '@guardian/old-cmp';
 import { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';
@@ -10,6 +11,7 @@ export const oldCmp = {
 	init,
 	onGuConsentNotification,
 	onIabConsentNotification,
+	checkWillShowUi,
 	shouldShow,
 	ConsentManagementPlatform,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.8":
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
-  integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.9":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.9.tgz#6bd6108e12cb122c4a1fcba4ae657f4d0b67ad0b"
+  integrity sha512-9TRCahVCILDvD78xQpADaZMqqUZM1opsBXKPasVdEt3hnRyMwVB+l68DpydIEK8DZE9S2jxbuqtOEKrci/qMsw==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"


### PR DESCRIPTION
## What does this change?
- The old CMP now expose the `InitOptions` interface in v3.4.9, otherwise publishing the v4 packages does not work.
- The new CMP exposes `oldCmp.checkWillShowUi`

Force-pushing to TCFv2, so this PR now contains commit 7519f85a94ec5c76a634c21e1a635a52dbd17da4

## How can we measure success?
The v4 package can be released to NPM.