### PR TITLE
Fix stub for our implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/consent-management-platform",
-	"version": "4.0.0-3",
+	"version": "4.0.0-4",
 	"description": "Consent management for *.theguardian.com.",
 	"homepage": "https://github.com/guardian/consent-management-platform.git",
 	"repository": "https://github.com/guardian/consent-management-platform.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/consent-management-platform",
-	"version": "4.0.0-4",
+	"version": "4.0.0-5",
 	"description": "Consent management for *.theguardian.com.",
 	"homepage": "https://github.com/guardian/consent-management-platform.git",
 	"repository": "https://github.com/guardian/consent-management-platform.git",

--- a/src/oldCmp.ts
+++ b/src/oldCmp.ts
@@ -4,6 +4,7 @@ import {
 	onIabConsentNotification,
 	checkWillShowUi,
 	shouldShow,
+	setErrorHandler,
 } from '@guardian/old-cmp';
 import { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';
 
@@ -13,5 +14,6 @@ export const oldCmp = {
 	onIabConsentNotification,
 	checkWillShowUi,
 	shouldShow,
+	setErrorHandler,
 	ConsentManagementPlatform,
 };

--- a/src/tcfv2/stub.js
+++ b/src/tcfv2/stub.js
@@ -74,5 +74,8 @@ export const stub = () => {
 				!1,
 			));
 	};
-	'undefined' != typeof module ? (module.exports = e) : e();
+	// TODO: Understand why this fix is needed
+	// When module is defined, it does not allow rewriting of exports
+	// 'undefined' != typeof module ? (module.exports = e) : e();
+	e();
 };


### PR DESCRIPTION
## What does this change?
We are implementing the IAB stub from SourcePoint in a non-standard manner, and this fixes an error:

```log
index.esm.js:324 Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'
    at stub (index.esm.js:324)
    at init (index.esm.js:333)
    at Object.init (index.esm.js:380)
    at Object.init$4 [as init] (index.esm.js:417)
    at boot.js:40
    at wrapped (raven.js:347)
```

## How can we measure success?
Frontend now works.