### PR TITLE
TCFv2 fix Sourcepoint IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/consent-management-platform",
-	"version": "4.0.0-7",
+	"version": "4.0.0-8",
 	"description": "Consent management for *.theguardian.com.",
 	"homepage": "https://github.com/guardian/consent-management-platform.git",
 	"repository": "https://github.com/guardian/consent-management-platform.git",

--- a/src/ccpa/index.ts
+++ b/src/ccpa/index.ts
@@ -2,9 +2,8 @@ import {
 	init as initSourcepoint,
 	willShowPrivacyMessage as sourcepointWillShowPrivacyMessage,
 } from './sourcepoint';
+import { VENDOR_LIST_ID_CCPA } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
-
-const VENDOR_LIST_ID = '5eba7ef78c167c47ca8b433d';
 
 const init = () => {
 	mark('cmp-ccpa-init');
@@ -15,7 +14,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_ccpa?.loadPrivacyManagerModal?.(null, VENDOR_LIST_ID);
+	window._sp_ccpa?.loadPrivacyManagerModal?.(null, VENDOR_LIST_ID_CCPA);
 }
 
 export const CCPA: SourcepointImplementation = {

--- a/src/ccpa/index.ts
+++ b/src/ccpa/index.ts
@@ -4,6 +4,8 @@ import {
 } from './sourcepoint';
 import { mark } from '../lib/mark';
 
+const VENDOR_LIST_ID = '5eba7ef78c167c47ca8b433d';
+
 const init = () => {
 	mark('cmp-ccpa-init');
 	initSourcepoint();
@@ -13,7 +15,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_ccpa?.loadPrivacyManagerModal?.(null, '5ed10d99c3b12e4c1052efca');
+	window._sp_ccpa?.loadPrivacyManagerModal?.(null, VENDOR_LIST_ID);
 }
 
 export const CCPA: SourcepointImplementation = {

--- a/src/ccpa/index.ts
+++ b/src/ccpa/index.ts
@@ -2,7 +2,7 @@ import {
 	init as initSourcepoint,
 	willShowPrivacyMessage as sourcepointWillShowPrivacyMessage,
 } from './sourcepoint';
-import { VENDOR_LIST_ID_CCPA } from '../lib/sourcepointConfig';
+import { PRIVACY_MANAGER_CCPA } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
 
 const init = () => {
@@ -14,7 +14,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_ccpa?.loadPrivacyManagerModal?.(null, VENDOR_LIST_ID_CCPA);
+	window._sp_ccpa?.loadPrivacyManagerModal?.(null, PRIVACY_MANAGER_CCPA);
 }
 
 export const CCPA: SourcepointImplementation = {

--- a/src/ccpa/sourcepoint.test.js
+++ b/src/ccpa/sourcepoint.test.js
@@ -2,7 +2,7 @@
 import http from 'http';
 import url from 'url';
 import { init } from './sourcepoint';
-import { ACCOUNT_ID } from '../lib/accountId';
+import { ACCOUNT_ID } from '../lib/sourcepointConfig';
 
 jest.mock('../onConsentChange', () => ({
 	invokeCallbacks: jest.fn(),

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -3,7 +3,7 @@
 import { stub } from './stub';
 import { mark } from '../lib/mark';
 import { isGuardianDomain } from '../lib/domain';
-import { ACCOUNT_ID } from '../lib/accountId';
+import { ACCOUNT_ID } from '../lib/sourcepointConfig';
 import { invokeCallbacks } from '../onConsentChange';
 
 let resolveWillShowPrivacyMessage: Function | undefined;

--- a/src/lib/accountId.ts
+++ b/src/lib/accountId.ts
@@ -1,1 +1,0 @@
-export const ACCOUNT_ID = 1257;

--- a/src/lib/sourcepointConfig.ts
+++ b/src/lib/sourcepointConfig.ts
@@ -1,0 +1,3 @@
+export const ACCOUNT_ID = 1257;
+export const VENDOR_LIST_ID_CCPA = '5eba7ef78c167c47ca8b433d';
+export const CMP_ID_TCFV2 = 106842;

--- a/src/lib/sourcepointConfig.ts
+++ b/src/lib/sourcepointConfig.ts
@@ -1,3 +1,3 @@
 export const ACCOUNT_ID = 1257;
-export const VENDOR_LIST_ID_CCPA = '5eba7ef78c167c47ca8b433d';
-export const CMP_ID_TCFV2 = 106842;
+export const PRIVACY_MANAGER_CCPA = '5eba7ef78c167c47ca8b433d';
+export const PRIVACY_MANAGER_TCFV2 = 106842;

--- a/src/tcfv2/index.ts
+++ b/src/tcfv2/index.ts
@@ -2,7 +2,7 @@ import {
 	init as initSourcepoint,
 	willShowPrivacyMessage as sourcepointWillShowPrivacyMessage,
 } from './sourcepoint';
-import { CMP_ID_TCFV2 } from '../lib/sourcepointConfig';
+import { PRIVACY_MANAGER_TCFV2 } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
 
 const init = () => {
@@ -14,7 +14,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_?.loadPrivacyManagerModal?.(CMP_ID_TCFV2);
+	window._sp_?.loadPrivacyManagerModal?.(PRIVACY_MANAGER_TCFV2);
 }
 
 export const TCFv2: SourcepointImplementation = {

--- a/src/tcfv2/index.ts
+++ b/src/tcfv2/index.ts
@@ -2,9 +2,8 @@ import {
 	init as initSourcepoint,
 	willShowPrivacyMessage as sourcepointWillShowPrivacyMessage,
 } from './sourcepoint';
+import { CMP_ID_TCFV2 } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
-
-const SOURCEPOINT_CMP_ID = 106842;
 
 const init = () => {
 	mark('cmp-tcfv2-init');
@@ -15,7 +14,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_?.loadPrivacyManagerModal?.(SOURCEPOINT_CMP_ID);
+	window._sp_?.loadPrivacyManagerModal?.(CMP_ID_TCFV2);
 }
 
 export const TCFv2: SourcepointImplementation = {

--- a/src/tcfv2/index.ts
+++ b/src/tcfv2/index.ts
@@ -4,6 +4,8 @@ import {
 } from './sourcepoint';
 import { mark } from '../lib/mark';
 
+const SOURCEPOINT_CMP_ID = 106842;
+
 const init = () => {
 	mark('cmp-tcfv2-init');
 	initSourcepoint();
@@ -13,7 +15,7 @@ const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;
 
 function showPrivacyManager() {
 	// eslint-disable-next-line no-underscore-dangle
-	window._sp_?.loadPrivacyManagerModal?.(106842);
+	window._sp_?.loadPrivacyManagerModal?.(SOURCEPOINT_CMP_ID);
 }
 
 export const TCFv2: SourcepointImplementation = {

--- a/src/tcfv2/sourcepoint.test.js
+++ b/src/tcfv2/sourcepoint.test.js
@@ -2,7 +2,7 @@
 import http from 'http';
 import url from 'url';
 import { init } from './sourcepoint';
-import { ACCOUNT_ID } from '../lib/accountId';
+import { ACCOUNT_ID } from '../lib/sourcepointConfig';
 
 describe('Sourcepoint TCF', () => {
 	afterEach(() => {

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -2,7 +2,7 @@
 
 import { stub } from './stub';
 import { mark } from '../lib/mark';
-import { ACCOUNT_ID } from '../lib/accountId';
+import { ACCOUNT_ID } from '../lib/sourcepointConfig';
 import { isGuardianDomain } from '../lib/domain';
 import { invokeCallbacks } from '../onConsentChange';
 


### PR DESCRIPTION
## What does this change?

Update Sourcepoint ID so they pointing to the right privacy managers and vendor lists.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

On PROD / CODE, a place in the US should be able to see the privacy manager when clicking "Do Not Sell My Data"
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We should be able to see the privacy manager in CCPA (US).

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Yes: Sourcepoint needs to work!

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

n/a
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
