### PR TITLE
TCFv2 return all states

### DIFF
--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import waitForExpect from 'wait-for-expect';
-import { onConsentChange, invokeCallbacks } from './onConsentChange';
+import { onConsentChange, invokeCallbacks, _ } from './onConsentChange';
 
 const uspData = {
 	version: 1,
@@ -62,20 +62,12 @@ describe('onConsentChange', () => {
 	});
 
 	it('returns all 10 TCF purposes even if they are false', () => {
-		const consents = {
-			'1': false,
-			'2': false,
-			'3': false,
-			'4': false,
-			'5': false,
-			'6': false,
-			'7': false,
-			'8': false,
-			'9': false,
-			'10': false,
-			...tcfData.purposes.consents,
-		};
+		const consents = _.fillAllConsents(tcfData.purposes.consents);
 
 		expect(Object.keys(consents)).toHaveLength(10);
+		expect(consents[1]).toEqual(true);
+		expect(consents[3]).toEqual(true);
+		expect(consents[9]).toEqual(false);
+		expect(consents[10]).toBeDefined();
 	});
 });

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -9,6 +9,15 @@ const uspData = {
 window.__uspapi = jest.fn((a, b, callback) => {
 	callback(uspData, true);
 });
+const tcfData = {
+	purposes: {
+		consents: {
+			1: true,
+			2: false,
+			3: true,
+		},
+	},
+};
 
 describe('onConsentChange', () => {
 	it('invokes callbacks correctly', () => {
@@ -50,5 +59,23 @@ describe('onConsentChange', () => {
 					expect(callback).toHaveBeenCalledTimes(2);
 				}),
 			);
+	});
+
+	it('returns all 10 TCF purposes even if they are false', () => {
+		const consents = {
+			'1': false,
+			'2': false,
+			'3': false,
+			'4': false,
+			'5': false,
+			'6': false,
+			'7': false,
+			'8': false,
+			'9': false,
+			'10': false,
+			...tcfData.purposes.consents,
+		};
+
+		expect(Object.keys(consents)).toHaveLength(10);
 	});
 });

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -77,9 +77,6 @@ const getConsentState: () => Promise<ComparedConsentState> = () => {
 				},
 			);
 
-			setTimeout(() => {
-				console.log({ getTCDataPromise, getCustomVendorConsentsPromise });
-			}, 100);
 			Promise.all([getTCDataPromise, getCustomVendorConsentsPromise])
 				.then((data) => {
 					const consents = fillAllConsents(

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 
+interface ConsentVector {
+	[key: string]: boolean;
+}
+
 interface ConsentState {
 	tcfv2?: {
-		consents: {
-			[key: number]: boolean;
-		};
+		consents: ConsentVector;
 		eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';
-		vendorConsents: {
-			[key: string]: boolean;
-		};
+		vendorConsents: ConsentVector;
 	};
 	ccpa?: {
 		doNotSell: boolean;
@@ -77,21 +77,14 @@ const getConsentState: () => Promise<ComparedConsentState> = () => {
 				},
 			);
 
+			setTimeout(() => {
+				console.log({ getTCDataPromise, getCustomVendorConsentsPromise });
+			}, 100);
 			Promise.all([getTCDataPromise, getCustomVendorConsentsPromise])
 				.then((data) => {
-					const consents = {
-						'1': false,
-						'2': false,
-						'3': false,
-						'4': false,
-						'5': false,
-						'6': false,
-						'7': false,
-						'8': false,
-						'9': false,
-						'10': false,
-						...(data[0] as TCFData).purpose.consents,
-					};
+					const consents = fillAllConsents(
+						(data[0] as TCFData).purpose.consents,
+					);
 					const { eventStatus } = data[0] as TCFData;
 					const { grants } = data[1] as VendorConsents;
 					const vendorConsents = Object.keys(grants)
@@ -116,6 +109,24 @@ const getConsentState: () => Promise<ComparedConsentState> = () => {
 			reject(new Error('no IAB consent framework found on the page'));
 		}
 	});
+};
+
+type ConsentObject = (consentVector: ConsentVector) => ConsentVector;
+
+const fillAllConsents: ConsentObject = (consentVector) => {
+	return {
+		'1': false,
+		'2': false,
+		'3': false,
+		'4': false,
+		'5': false,
+		'6': false,
+		'7': false,
+		'8': false,
+		'9': false,
+		'10': false,
+		...consentVector,
+	};
 };
 
 // cache current consent state as a JSON for quick comparison
@@ -149,4 +160,4 @@ export const onConsentChange = (callBack: Callback) => {
 		});
 };
 
-export const _ = { getConsentState };
+export const _ = { getConsentState, fillAllConsents };

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -79,7 +79,19 @@ const getConsentState: () => Promise<ComparedConsentState> = () => {
 
 			Promise.all([getTCDataPromise, getCustomVendorConsentsPromise])
 				.then((data) => {
-					const { consents } = (data[0] as TCFData).purpose;
+					const consents = {
+						'1': false,
+						'2': false,
+						'3': false,
+						'4': false,
+						'5': false,
+						'6': false,
+						'7': false,
+						'8': false,
+						'9': false,
+						'10': false,
+						...(data[0] as TCFData).purpose.consents,
+					};
 					const { eventStatus } = data[0] as TCFData;
 					const { grants } = data[1] as VendorConsents;
 					const vendorConsents = Object.keys(grants)


### PR DESCRIPTION
## What does this change?

This PR returns a consistent `TCData.purpose.consents` object, where all purposes (1 to 10) are set to a boolean.

The native IAB implementation would return an empty object `{}` in case all purposes are false. This is due to their implementation using a [Boolean Vector]. In practice, this would mean that previously:

- consented purposes: `[]` -> consent object: `{}`
- consented purposes: `[2]` -> consent object: `{ '1': false, '2': true }`
- consented purposes: `[2,5]` -> consent object: `{'1': false, '2':true, '3': false, '4': false, '5': true }`

The new behaviour is now more explicit:

- consented purposes: `[]` -> consent object: `{'1': false, '2': false, '3': false, … , '9': false, '10': false}`
- consented purposes: `[2]` -> consent object: `{ '1': false, '2': true, '3': false, … , '9': false, '10': false }`
- consented purposes: `[2,9]` -> consent object: `{'1': false, '2': true, '3': false, … , '9': true, '10': false }`

[Boolean Vector]: https://github.com/InteractiveAdvertisingBureau/iabtcf-es/blob/fd137351359c346ce2eb45ecc4408909bebf8c41/modules/cmpapi/src/response/TCData.ts#L171

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Less errors when checking consent. For example through `consents.every(Boolean)`.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This should help reduce bugs.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
