### PR TITLE
TCFv2 Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,19 @@ Reports the user's privacy preferences.
 
 type: `Object` or `undefined`
 
-Reports the user's preferences for each of the TCFv2 purposes, the last CMP event status and custom vendor consents. If the user is in the USA, it will be `undefined`.
+Reports the user's preferences for each of the TCFv2 purposes, the last CMP
+event status and custom vendor consents. If the user is in the USA, it will
+be `undefined`. Unlike the original `__tcfapi`, all ten consents will have a set
+boolean value, defaulting to `false` where no explicit consent was given.
 
 ```js
 {
     consents: {
         1: Boolean,
         2: Boolean,
-        // etc.
+        /* … */
+        9: Boolean,
+        10: Boolean,
     },
     eventStatus: String, // 'tcloaded' | 'cmpuishown' | 'useractioncomplete'
     vendorConsents: {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 > Consent management for `*.theguardian.com`.
 
-The Guardian CMP handles applying the CCPA to users in the USA, and TCFv2 to everyone else.
+The Guardian CMP handles applying the CCPA to users in the USA,
+and TCFv2 to everyone else.
 
 ![Types](https://img.shields.io/npm/types/@guardian/consent-management-platform)
 [![Generic badge](https://img.shields.io/badge/google-chat-259082.svg)](https://chat.google.com/room/AAAAhlhgDTU)
@@ -17,7 +18,8 @@ import { cmp } from '@guardian/consent-management-platform';
 
 returns: `void`
 
-Adds the relevent privacy framework to the page. It must be called to enable privacy management.
+Adds the relevent privacy framework to the page. It must be called to enable
+privacy management.
 
 If necessary, it will also display the initial privacy message.
 
@@ -25,7 +27,8 @@ If necessary, it will also display the initial privacy message.
 
 type: `boolean`
 
-Declare whether your user is in the USA or not. Required – *throws an error if it's missing.*
+Declare whether your user is in the USA or not. Required – *throws an error if
+it's missing.*
 
 #### Example
 
@@ -37,7 +40,8 @@ cmp.init({ isInUsa: false });
 
 returns: `Promise<Boolean>`
 
-Returns a promise that resolves to `true` if the CMP will show the initial privacy message once it has initialised, or `false` if not.
+Returns a promise that resolves to `true` if the CMP will show the initial
+privacy message once it has initialised, or `false` if not.
 
 #### Example
 
@@ -56,7 +60,8 @@ cmp.willShowPrivacyMessage()
 
 ### cmp.showPrivacyManager()
 
-Displays an interface that allows users to manage their privacy settings at any time.
+Displays an interface that allows users to manage
+their privacy settings at any time.
 
 #### Example
 
@@ -79,7 +84,8 @@ An event listener that invokes callbacks whenever the consent state:
 -   is acquired (e.g. after initialising)
 -   changes (eg. if a user changes their privacy preferences)
 
-If the consent state has already been acquired when `onConsentChange` is called, the callback will be invoked immediately.
+If the consent state has already been acquired when `onConsentChange` is called,
+the callback will be invoked immediately.
 
 #### callback(result)
 
@@ -119,7 +125,8 @@ boolean value, defaulting to `false` where no explicit consent was given.
 
 type: `Object` or `undefined`
 
-Reports whether user has withdrawn consent to sell their data in the USA. If the user is not in the USA, it will be `undefined`.
+Reports whether user has withdrawn consent to sell their data in the USA.
+If the user is not in the USA, it will be `undefined`.
 
 ```js
 {
@@ -149,11 +156,19 @@ _These should not be used after 15 August 2020, and will be deleted shortly afte
 
 #### oldCmp.onGuConsentNotification
 
-This function takes 2 arguments, the first is the purpose name (a `string`) that is relevant to the code you're running eg. "functional" OR "performance", and the second is a callback (a `function`).
+This function takes 2 arguments, the first is the purpose name (a `string`)
+that is relevant to the code you're running eg. "functional" OR "performance",
+and the second is a callback (a `function`).
 
-When `oldCmp.onGuConsentNotification` is called it will execute the callback immediately, passing it a single argument (a `boolean` or `null`) which indicates the user's consent state at that time for the given purpose name.
+When `oldCmp.onGuConsentNotification` is called it will execute the callback
+immediately, passing it a single argument (a `boolean` or `null`) which
+indicates the user's consent state at that time for the given purpose name.
 
-The `cmp` module also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument (a `boolean` or `null`) which inidicates the user's updated consent state for the given purpose name.
+The `cmp` module also listens for subsequent changes to the user's consent state
+(eg. if a user saves an update to their consent via the CMP modal), if this
+happens it will re-execute the callback, passing it a single argument
+(a `boolean` or `null`) which inidicates the user's updated consent state
+for the given purpose name.
 
 **Example:**
 
@@ -169,7 +184,9 @@ oldCmp.onGuConsentNotification('functional', (functionalConsentState) => {
 
 This function takes 1 argument, a callback (a `function`).
 
-When `oldCmp.onIabConsentNotification` is called it will execute the callback immediately, passing it a single argument, an object which reflects the consent granted to the IAB purposes. The signature for this object will be:
+When `oldCmp.onIabConsentNotification` is called it will execute the callback
+immediately, passing it a single argument, an object which reflects the consent
+granted to the IAB purposes. The signature for this object will be:
 
 ```
 {
@@ -177,9 +194,14 @@ When `oldCmp.onIabConsentNotification` is called it will execute the callback im
 }
 ```
 
-The keys in this object will match the IAB purpose IDs from the [IAB vendor list](https://vendorlist.consensu.org/vendorlist.json).
+The keys in this object will match the IAB purpose IDs from the
+[IAB vendor list](https://vendorlist.consensu.org/vendorlist.json).
 
-The `oldCmp` module will also listens for subsequent changes to the user's consent state (eg. if a user saves an update to their consent via the CMP modal), if this happens it will re-execute the callback, passing it a single argument, an object which reflects the latest consent granted to the IAB purposes.
+The `oldCmp` module will also listens for subsequent changes to the user's
+consent state (eg. if a user saves an update to their consent via
+the CMP modal), if this happens it will re-execute the callback, passing it
+a single argument, an object which reflects the latest consent granted to
+the IAB purposes.
 
 **Example:**
 
@@ -193,11 +215,17 @@ oldCmp.onIabConsentNotification((iabConsentState) => {
 
 ### TCFv1 UI
 
-The TCFv1 library exports a React component that can be imported into your React applications as well as a `shouldShow` function that indicates whether the user should be shown the CMP.
+The TCFv1 library exports a React component that can be imported into your
+React applications as well as a `shouldShow` function that indicates whether
+the user should be shown the CMP.
 
 #### oldCmp.shouldShow
 
-The `oldCmp.shouldShow` function returns a boolean, it will be `true` if the user does not have the appropriate consent cookies saved and `false` if they do. It takes an optional boolean `shouldRepermission`. If this is set to true it will only check for the existence of the IAB cookie, otherwise it will check for both IAB and GU_TK cookies.
+The `oldCmp.shouldShow` function returns a boolean, it will be `true` if
+the user does not have the appropriate consent cookies saved and `false`
+if they do. It takes an optional boolean `shouldRepermission`.
+If this is set to true it will only check for the existence of the IAB cookie,
+otherwise it will check for both IAB and GU_TK cookies.
 
 **Example:**
 
@@ -209,27 +237,47 @@ oldCmp.shouldShow(); // true || false
 
 #### `oldCmp.ConsentManagementPlatform` React Component
 
-The properties the `oldCmp.ConsentManagementPlatform` component takes are listed below along with their Typescript definitions:
+The properties the `oldCmp.ConsentManagementPlatform` component takes are listed
+below along with their Typescript definitions:
 
 ##### onClose: () => void
 
-The `onClose` property accepts a function, this will be executed once the user has submitted their consent, either via the clicking "I'm OK with that" button in the banner, or opening the options modal selecting their choices and clicking the "Save and close" button. You can add whatever logic you want in this function. Because the `oldCmp.ConsentManagementPlatform` component doesn't close itself a typical example of the logic that would be included in this function might be the updating of state to hide the `oldCmp.ConsentManagementPlatform` component.
+The `onClose` property accepts a function, this will be executed once the user
+has submitted their consent, either via the clicking "I'm OK with that" button
+in the banner, or opening the options modal selecting their choices and clicking
+the "Save and close" button. You can add whatever logic you want in this
+function. Because the `oldCmp.ConsentManagementPlatform` component doesn't close
+itself a typical example of the logic that would be included in this function
+might be the updating of state to hide the `oldCmp.ConsentManagementPlatform`
+component.
 
 ##### source?: string
 
-The `source` property accepts an optional string. The value passed to this will be sent to the consent logs once a user has submitted their consent. The value should indicate the site on which the CMP has been seen: eg. 'manage' for 'manage.theguardian.com'. The default value passed to the logs will be 'www'.
+The `source` property accepts an optional string. The value passed to this will
+be sent to the consent logs once a user has submitted their consent. The value
+should indicate the site on which the CMP has been seen: eg. 'manage' for
+'manage.theguardian.com'. The default value passed to the logs will be 'www'.
 
 ##### variant?: string
 
-The `variant` property accepts an optional string. If a value is passed to this it will be sent to the consent logs to indicate whether the user is within an a/b test related to the CMP. Typically the format for this string should follow: `${testName}-${variantName}`. We can also use the value of this property if we want to a/b test different layouts.
+The `variant` property accepts an optional string. If a value is passed to this
+it will be sent to the consent logs to indicate whether the user is within
+an a/b test related to the CMP. Typically the format for this string should
+follow: `${testName}-${variantName}`. We can also use the value of this property
+if we want to a/b test different layouts.
 
 ##### fontFamilies?: { headlineSerif: string; bodySerif: string; bodySans: string; }
 
-The `fontFamilies` property accepts an optional object. If passed this object must match the definition used above. The values of `headlineSerif`, `bodySerif` and `bodySans` should be strings that match the `font-family` value in your sites `@font-face` definitions for The Guardian's custom webfonts.
+The `fontFamilies` property accepts an optional object. If passed this object
+must match the definition used above. The values of `headlineSerif`, `bodySerif`
+and `bodySans` should be strings that match the `font-family` value in your
+sites `@font-face` definitions for The Guardian's custom webfonts.
 
 ##### forceModal?: boolean
 
-The `forceModal` property accepts an optional boolean. If the value passed is `true` then the component will render the modal without the banner. This should be used when resurfacing the user's consent selections.
+The `forceModal` property accepts an optional boolean. If the value passed
+is `true` then the component will render the modal without the banner.
+This should be used when resurfacing the user's consent selections.
 
 **Example**
 


### PR DESCRIPTION
## What does this change?

Follow up on #190, making the returned `tcfv2.consents` explicit in the [README.md][].

[README.md]: https://github.com/guardian/consent-management-platform/blob/tcfv2-return-all-states/README.md

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?

More explicit README