### PR TITLE
Add pubData to SourcePoint config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ type: `boolean`
 Declare whether your user is in the USA or not. Required – *throws an error if
 it's missing.*
 
+#### options.pubData
+
+type: `Object`
+
+Pass additional parameters for for reporting. Optional.
+
 #### Example
 
 ```js

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pass additional parameters for for reporting. Optional.
 #### Example
 
 ```js
-cmp.init({ isInUsa: false });
+cmp.init({ browserId: 'gow59fnwohwmshz', isInUsa: false });
 ```
 
 ### cmp.willShowPrivacyMessage()

--- a/src/ccpa/index.ts
+++ b/src/ccpa/index.ts
@@ -5,9 +5,9 @@ import {
 import { PRIVACY_MANAGER_CCPA } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
 
-const init = () => {
+const init = (pubData?: PubData) => {
 	mark('cmp-ccpa-init');
-	initSourcepoint();
+	initSourcepoint(pubData);
 };
 
 const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;

--- a/src/ccpa/sourcepoint.test.js
+++ b/src/ccpa/sourcepoint.test.js
@@ -55,4 +55,14 @@ describe('Sourcepoint CCPA', () => {
 		);
 		req.end();
 	});
+
+	it('should accept pubData', () => {
+		init({ browserId: 'abc123' });
+		expect(window._sp_ccpa.config.pubData.browserId).toEqual('abc123');
+	});
+
+	it('should handle no pubData', () => {
+		init();
+		expect(window._sp_ccpa.config.pubData).toEqual({});
+	});
 });

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -11,7 +11,7 @@ export const willShowPrivacyMessage = new Promise<boolean>((resolve) => {
 	resolveWillShowPrivacyMessage = resolve;
 });
 
-export const init = () => {
+export const init = (pubData = {}) => {
 	stub();
 
 	// make sure nothing else on the page has accidentally
@@ -33,6 +33,8 @@ export const init = () => {
 			targetingParams: {
 				framework: 'ccpa',
 			},
+
+			pubData,
 
 			events: {
 				onConsentReady() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
-function init({ isInUsa }: { isInUsa: boolean }) {
+function init({ pubData, isInUsa }: { pubData: PubData; isInUsa: boolean }) {
 	if (typeof isInUsa === 'undefined') {
 		throw new Error(
 			'CMP initialised without `isInUsa` property. `isInUsa` is required.',
@@ -19,7 +19,7 @@ function init({ isInUsa }: { isInUsa: boolean }) {
 	}
 
 	CMP = isInUsa ? CCPA : TCFv2;
-	CMP.init();
+	CMP.init(pubData);
 	resolveInitialised?.();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
-function init({ pubData, isInUsa }: { pubData: PubData; isInUsa: boolean }) {
+function init({ pubData, isInUsa }: { pubData?: PubData; isInUsa: boolean }) {
 	if (typeof isInUsa === 'undefined') {
 		throw new Error(
 			'CMP initialised without `isInUsa` property. `isInUsa` is required.',

--- a/src/tcfv2/index.ts
+++ b/src/tcfv2/index.ts
@@ -5,9 +5,9 @@ import {
 import { PRIVACY_MANAGER_TCFV2 } from '../lib/sourcepointConfig';
 import { mark } from '../lib/mark';
 
-const init = () => {
+const init = (pubData?: PubData) => {
 	mark('cmp-tcfv2-init');
-	initSourcepoint();
+	initSourcepoint(pubData);
 };
 
 const willShowPrivacyMessage = () => sourcepointWillShowPrivacyMessage;

--- a/src/tcfv2/sourcepoint.test.js
+++ b/src/tcfv2/sourcepoint.test.js
@@ -48,4 +48,14 @@ describe('Sourcepoint TCF', () => {
 		);
 		req.end();
 	});
+
+	it('should accept pubData', () => {
+		init({ browserId: 'abc123' });
+		expect(window._sp_.config.pubData.browserId).toEqual('abc123');
+	});
+
+	it('should handle no pubData', () => {
+		init();
+		expect(window._sp_.config.pubData).toEqual({});
+	});
 });

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -11,7 +11,7 @@ export const willShowPrivacyMessage = new Promise<boolean>((resolve) => {
 	resolveWillShowPrivacyMessage = resolve;
 });
 
-export const init = () => {
+export const init = (pubData = {}) => {
 	stub();
 
 	// // make sure nothing else on the page has accidentally
@@ -29,6 +29,8 @@ export const init = () => {
 			targetingParams: {
 				framework: 'tcfv2',
 			},
+
+			pubData,
 
 			events: {
 				onConsentReady() {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 declare module '@iabtcf/stub';
 
 interface SourcepointImplementation {
-	init: () => void;
+	init: (pubData?: PubData) => void;
 	willShowPrivacyMessage: () => Promise<boolean>;
 	showPrivacyManager: () => void;
 }
@@ -22,6 +22,10 @@ type SourcePointChoiceType =
 	| 14
 	| 15;
 
+interface PubData {
+	browserId?: string;
+}
+
 // globals set on the window by the CMP library
 interface Window {
 	// sourcepoint's libraries - only one should be present at a time
@@ -36,6 +40,7 @@ interface Window {
 			targetingParams: {
 				framework: 'ccpa';
 			};
+			pubData: PubData;
 			events?: {
 				onConsentReady: () => void;
 				onMessageReady: () => void;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,6 +58,9 @@ interface Window {
 			targetingParams: {
 				framework: 'tcfv2';
 			};
+			pubData: {
+				browserId?: string;
+			};
 			events?: {
 				onConsentReady: () => void;
 				onMessageReady: () => void;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This adds a pubData type to the `window._sp_.config` type and also updates the `init` function so that we can pass along data to be used by SourcePoint. This will allow us on web to associate the current `browserId` with an impression/consent signal from the CMP.

The `pubData` is a free field where we can add anything; it will show up in the data that SourcePoint then send to us.

@guardian/commercial-dev 
