### PR TITLE
Reuse PubData type

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -63,9 +63,7 @@ interface Window {
 			targetingParams: {
 				framework: 'tcfv2';
 			};
-			pubData: {
-				browserId?: string;
-			};
+			pubData: PubData;
 			events?: {
 				onConsentReady: () => void;
 				onMessageReady: () => void;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,8 @@
 declare module '@iabtcf/stub';
 
+interface PubData {
+	browserId?: string;
+}
 interface SourcepointImplementation {
 	init: (pubData?: PubData) => void;
 	willShowPrivacyMessage: () => Promise<boolean>;
@@ -21,10 +24,6 @@ type SourcePointChoiceType =
 	| 13
 	| 14
 	| 15;
-
-interface PubData {
-	browserId?: string;
-}
 
 // globals set on the window by the CMP library
 interface Window {


### PR DESCRIPTION
## What does this change?

Minor change to reuse the `PubData` type within the TCF `_sp_` object.

@guardian/commercial-dev @mxdvl 