### PR TITLE
willShowPrivacyMessage should never resolve undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@
 
 import { CCPA } from './ccpa';
 import { TCFv2 } from './tcfv2';
-import { SourcepointImplementation, PubData } from './types';
+import {
+	SourcepointImplementation,
+	PubData,
+	WillShowPrivacyMessage,
+} from './types';
 
 // *************** START commercial.dcr.js hotfix ***************
 import { onConsentChange as actualOnConsentChange } from './onConsentChange';
@@ -40,8 +44,8 @@ function init({ pubData, isInUsa }: { pubData?: PubData; isInUsa: boolean }) {
 	resolveInitialised?.();
 }
 
-const willShowPrivacyMessage = () =>
-	initialised.then(() => CMP?.willShowPrivacyMessage());
+const willShowPrivacyMessage: WillShowPrivacyMessage = () =>
+	initialised.then(() => CMP?.willShowPrivacyMessage() || false);
 
 function showPrivacyManager() {
 	if (!CMP)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,14 @@
 export interface PubData {
 	browserId?: string;
 }
+
 export interface SourcepointImplementation {
 	init: (pubData?: PubData) => void;
-	willShowPrivacyMessage: () => Promise<boolean>;
+	willShowPrivacyMessage: WillShowPrivacyMessage;
 	showPrivacyManager: () => void;
 }
+
+export type WillShowPrivacyMessage = () => Promise<boolean>;
 
 export type SourcePointChoiceType =
 	| 1


### PR DESCRIPTION
## What does this change?

makes sure `willShowPrivacyMessage` will resolve a boolean even if CMP has failed to mount