### PR TITLE
Fix (hopefully) ads in USA

### DIFF
--- a/dev/app.tsx
+++ b/dev/app.tsx
@@ -2,6 +2,8 @@
 
 import { cmp, onConsentChange } from '../src/index';
 
+/* ************** debug tools ************** */
+
 const logCall = (title: string, ...rest: unknown[]) =>
 	// eslint-disable-next-line no-console
 	console.info.apply(null, [`%c${title}()`, 'color: deeppink;', ...rest]);
@@ -15,24 +17,39 @@ const logResponse = (title: string, ...rest: unknown[]) =>
 		...rest,
 	]);
 
-logCall('cmp.willShowPrivacyMessage');
+/* ************** library usage ************** */
+
+// Mimic behaviour of real-world usage.
+// We call everything more than once to make sure that doesn't break anything.
+
+logCall('cmp.willShowPrivacyMessage 1');
 cmp.willShowPrivacyMessage().then((willShow) => {
-	logResponse('cmp.willShowPrivacyMessage', { willShow });
+	logResponse('cmp.willShowPrivacyMessage 1', { willShow });
 });
 
-logCall('onConsentChange');
+logCall('onConsentChange 1');
 onConsentChange((response) => {
-	logResponse('onConsentChange', response);
+	logResponse('onConsentChange 1', response);
 });
 
 const isInUsa = localStorage.getItem('inUSA') === 'true';
+logCall('cmp.init 1', { isInUsa });
 cmp.init({ isInUsa });
-logCall('cmp.init', { isInUsa });
 
-// *************** START commercial.dcr.js hotfix ***************
-// init again to check hotfix
+logCall('onConsentChange 2');
+onConsentChange((response) => {
+	logResponse('onConsentChange 2', response);
+});
+
+logCall('cmp.init 2', { isInUsa });
 cmp.init({ isInUsa });
-// *************** END commercial.dcr.js hotfix ***************
+
+logCall('cmp.willShowPrivacyMessage 2');
+cmp.willShowPrivacyMessage().then((willShow) => {
+	logResponse('cmp.willShowPrivacyMessage 2', { willShow });
+});
+
+/* ************** test page controls ************** */
 
 const locationLabel = document.createElement('label');
 locationLabel.innerHTML = 'in USA';

--- a/src/ccpa/sourcepoint.test.js
+++ b/src/ccpa/sourcepoint.test.js
@@ -31,10 +31,6 @@ describe('Sourcepoint CCPA', () => {
 		expect(typeof window._sp_ccpa.config.events.onConsentReady).toBe(
 			'function',
 		);
-
-		expect(typeof window._sp_ccpa.config.events.onMessageReceiveData).toBe(
-			'function',
-		);
 	});
 
 	it('injects the lib', () => {

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -14,6 +14,9 @@ export const willShowPrivacyMessage = new Promise<boolean>((resolve) => {
 export const init = (pubData = {}) => {
 	stub();
 
+	// invoke callbacks ASAP in USA
+	invokeCallbacks();
+
 	// make sure nothing else on the page has accidentally
 	// used the _sp_* name as well
 	if (window._sp_ccpa) {
@@ -47,16 +50,6 @@ export const init = (pubData = {}) => {
 				},
 				onMessageReceiveData: (data) => {
 					resolveWillShowPrivacyMessage?.(data.msg_id !== 0);
-				},
-				onMessageChoiceSelect: (_choiceId, choiceTypeID) => {
-					if (
-						// https://documentation.sourcepoint.com/web-implementation/sourcepoint-set-up-and-configuration-v2/optional-callbacks#choice-type-id-descriptions
-						choiceTypeID === 11 ||
-						choiceTypeID === 13 ||
-						choiceTypeID === 15
-					) {
-						setTimeout(invokeCallbacks, 0);
-					}
 				},
 			},
 		},

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -151,7 +151,7 @@ export const onConsentChange = (callBack: Callback) => {
 			}
 		})
 		.catch(() => {
-			// do nothing - callback will be added the list anyway
+			// do nothing - callback will be added the list anyway and executed when consent changes
 		});
 };
 

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -43,10 +43,6 @@ declare global {
 					onConsentReady: () => void;
 					onMessageReady: () => void;
 					onMessageReceiveData: (data: { msg_id: 0 | string }) => void;
-					onMessageChoiceSelect: (
-						arg0: number,
-						arg1: SourcePointChoiceType,
-					) => void;
 				};
 			};
 			loadPrivacyManagerModal?: (unknown: unknown, id: string) => {}; // this function is undocumented


### PR DESCRIPTION
After good sleuthing by @jeteve, we noticed that if `onConsentChange` is called _while_ `cmp.init` is being run, callbacks that have already been added may never be invoked 😱…

## What does this change?

- use a per-callback state comparison, rather than a global one
- moves the first `invokeCallbacks` for CCPA to immediately after the `uspapi` is available