### PR TITLE
Make CMP disableable and enableable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ cmp.__disable(); // CMP won't run even if you try
 
 returns: `void`
 
-Enables Guardian consent management in the current browser.
-
 #### Example
 
 ```js

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and TCFv2 to everyone else.
 import { cmp } from '@guardian/consent-management-platform';
 ```
 
-### cmp.init(options)
+### `cmp.init(options)`
 
 returns: `void`
 
@@ -22,14 +22,14 @@ Adds the relevent privacy framework to the page. It must be called to enable
 privacy management.
 If necessary, it will also display the initial privacy message.
 
-#### options.isInUsa
+#### `options.isInUsa`
 
 type: `boolean`
 
 Declare whether your user is in the USA or not. Required – *throws an error if
 it's missing.*
 
-#### options.pubData
+#### `options.pubData`
 
 type: `Object`
 
@@ -41,7 +41,7 @@ Pass additional parameters for for reporting. Optional.
 cmp.init({ pubData: { browserId: 'gow59fnwohwmshz' }, isInUsa: false });
 ```
 
-### cmp.willShowPrivacyMessage()
+### `cmp.willShowPrivacyMessage()`
 
 returns: `Promise<Boolean>`
 
@@ -63,7 +63,7 @@ cmp.willShowPrivacyMessage()
     );
 ```
 
-### cmp.showPrivacyManager()
+### `cmp.showPrivacyManager()`
 
 Displays an interface that allows users to manage
 their privacy settings at any time.
@@ -80,7 +80,7 @@ cmp.showPrivacyManager();
 import { onConsentChange } from '@guardian/consent-management-platform';
 ```
 
-### onConsentChange(callback)
+### `onConsentChange(callback)`
 
 returns: `void`
 
@@ -92,13 +92,13 @@ An event listener that invokes callbacks whenever the consent state:
 If the consent state has already been acquired when `onConsentChange` is called,
 the callback will be invoked immediately.
 
-#### callback(result)
+#### `callback(result)`
 
 type: `function`
 
 Reports the user's privacy preferences.
 
-##### result.tcfv2
+##### `result.tcfv2`
 
 type: `Object` or `undefined`
 
@@ -126,7 +126,7 @@ boolean value, defaulting to `false` where no explicit consent was given.
 }
 ```
 
-##### result.ccpa
+##### `result.ccpa`
 
 type: `Object` or `undefined`
 
@@ -154,6 +154,48 @@ onConsentChange(({ tcfv2, ccpa }) => {
     }
 });
 ```
+
+## Disabling the CMP
+
+It is possible to disable the CMP entirely in the current browser, which can be useful for testing host applications.
+
+### `cmp.__disable()`
+
+returns: `void`
+
+#### Example
+
+```js
+cmp.__disable(); // CMP won't run even if you try
+```
+
+### `cmp.__enable()`
+
+returns: `void`
+
+Enables Guardian consent management in the current browser.
+
+#### Example
+
+```js
+cmp.__enable(); // CMP will work as normal
+```
+
+### `cmp.__isDisabled()`
+
+returns: `boolean`
+
+#### Example
+
+```js
+cmp.__isDisabled(); // => true/false
+```
+
+### Manually
+
+Set a `gu-cmp-disabled=true` cookie. This is the same as running `cmp.__disable()`.
+
+Removing it is the same as running `cmp.__enable()`.
 
 ## Development
 

--- a/src/disable.test.js
+++ b/src/disable.test.js
@@ -1,0 +1,19 @@
+import { disable, enable, isDisabled } from './disable';
+
+describe('Disabling consent management', () => {
+	it('should be enabled by default', () => {
+		expect(isDisabled()).toBe(false);
+	});
+	it('should disable consent management', () => {
+		disable();
+		enable();
+		disable();
+		expect(isDisabled()).toBe(true);
+	});
+	it('should enable consent management', () => {
+		enable();
+		disable();
+		enable();
+		expect(isDisabled()).toBe(false);
+	});
+});

--- a/src/disable.ts
+++ b/src/disable.ts
@@ -1,0 +1,12 @@
+const COOKIE_NAME = 'gu-cmp-disabled';
+
+export const disable = () => {
+	document.cookie = `${COOKIE_NAME}=true`;
+};
+
+export const enable = () => {
+	document.cookie = `${COOKIE_NAME}=false`;
+};
+
+export const isDisabled = () =>
+	new RegExp(`${COOKIE_NAME}=true(\\W+|$)`).test(document.cookie);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 	PubData,
 	WillShowPrivacyMessage,
 } from './types';
+import { isDisabled, enable, disable } from './disable';
 
 // *************** START commercial.dcr.js hotfix ***************
 import { onConsentChange as actualOnConsentChange } from './onConsentChange';
@@ -20,6 +21,9 @@ const initialised = new Promise((resolve) => {
 });
 
 function init({ pubData, isInUsa }: { pubData?: PubData; isInUsa: boolean }) {
+	// provide a way to disable consent for test envs
+	if (isDisabled()) return;
+
 	// *************** START commercial.dcr.js hotfix ***************
 	if (window?.guCmpHotFix?.initialised) {
 		return;
@@ -65,7 +69,16 @@ function showPrivacyManager() {
 // export { onConsentChange } from './onConsentChange';
 
 const actualExports = {
-	cmp: { init, willShowPrivacyMessage, showPrivacyManager },
+	cmp: {
+		init,
+		willShowPrivacyMessage,
+		showPrivacyManager,
+
+		// special helper methods for disabling CMP
+		__isDisabled: isDisabled,
+		__enable: enable,
+		__disable: disable,
+	},
 	onConsentChange: actualOnConsentChange,
 };
 


### PR DESCRIPTION
## What does this change?

Adds helper exports to disable the CMP entirely in the current browser – other teams need this in their tests:

- `cmp.__enable()`
- `cmp.__disable()`
- `cmp.__isDisabled()`

The same can be achieved manually by setting/removing a cookie:

- `gu-cmp-disabled=true` 

cc @paulmr @rtyley @gtrufitt @coldlink 