### PR TITLE
Restore old CMP

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,5 +43,5 @@
 			}
 		}
 	],
-	"ignorePatterns": ["dist", ".*"]
+	"ignorePatterns": ["dist", ".*", "coverage"]
 }

--- a/README.md
+++ b/README.md
@@ -155,6 +155,176 @@ onConsentChange(({ tcfv2, ccpa }) => {
 });
 ```
 
+## TCFv1 (deprecated)
+
+_These should not be used after 15 August 2020, and will be deleted shortly afterwards._
+
+#### oldCmp.onGuConsentNotification
+
+This function takes 2 arguments, the first is the purpose name (a `string`)
+that is relevant to the code you're running eg. "functional" OR "performance",
+and the second is a callback (a `function`).
+
+When `oldCmp.onGuConsentNotification` is called it will execute the callback
+immediately, passing it a single argument (a `boolean` or `null`) which
+indicates the user's consent state at that time for the given purpose name.
+
+The `cmp` module also listens for subsequent changes to the user's consent state
+(eg. if a user saves an update to their consent via the CMP modal), if this
+happens it will re-execute the callback, passing it a single argument
+(a `boolean` or `null`) which inidicates the user's updated consent state
+for the given purpose name.
+
+**Example:**
+
+```js
+import { oldCmp } from '@guardian/consent-management-platform';
+
+oldCmp.onGuConsentNotification('functional', (functionalConsentState) => {
+    console.log(functionalConsentState); // true || false || null
+});
+```
+
+#### oldCmp.onIabConsentNotification
+
+This function takes 1 argument, a callback (a `function`).
+
+When `oldCmp.onIabConsentNotification` is called it will execute the callback
+immediately, passing it a single argument, an object which reflects the consent
+granted to the IAB purposes. The signature for this object will be:
+
+```
+{
+    [key: number]: boolean | null;
+}
+```
+
+The keys in this object will match the IAB purpose IDs from the
+[IAB vendor list](https://vendorlist.consensu.org/vendorlist.json).
+
+The `oldCmp` module will also listens for subsequent changes to the user's
+consent state (eg. if a user saves an update to their consent via
+the CMP modal), if this happens it will re-execute the callback, passing it
+a single argument, an object which reflects the latest consent granted to
+the IAB purposes.
+
+**Example:**
+
+```js
+import { oldCmp } from '@guardian/consent-management-platform';
+
+oldCmp.onIabConsentNotification((iabConsentState) => {
+    console.log(iabConsentState); // { 0: true || false || null, 1: true || false || null, ... }
+});
+```
+
+### TCFv1 UI
+
+The TCFv1 library exports a React component that can be imported into your
+React applications as well as a `shouldShow` function that indicates whether
+the user should be shown the CMP.
+
+#### oldCmp.shouldShow
+
+The `oldCmp.shouldShow` function returns a boolean, it will be `true` if
+the user does not have the appropriate consent cookies saved and `false`
+if they do. It takes an optional boolean `shouldRepermission`.
+If this is set to true it will only check for the existence of the IAB cookie,
+otherwise it will check for both IAB and GU_TK cookies.
+
+**Example:**
+
+```js
+import { oldCmp } from '@guardian/consent-management-platform';
+
+oldCmp.shouldShow(); // true || false
+```
+
+#### `oldCmp.ConsentManagementPlatform` React Component
+
+The properties the `oldCmp.ConsentManagementPlatform` component takes are listed
+below along with their Typescript definitions:
+
+##### onClose: () => void
+
+The `onClose` property accepts a function, this will be executed once the user
+has submitted their consent, either via the clicking "I'm OK with that" button
+in the banner, or opening the options modal selecting their choices and clicking
+the "Save and close" button. You can add whatever logic you want in this
+function. Because the `oldCmp.ConsentManagementPlatform` component doesn't close
+itself a typical example of the logic that would be included in this function
+might be the updating of state to hide the `oldCmp.ConsentManagementPlatform`
+component.
+
+##### source?: string
+
+The `source` property accepts an optional string. The value passed to this will
+be sent to the consent logs once a user has submitted their consent. The value
+should indicate the site on which the CMP has been seen: eg. 'manage' for
+'manage.theguardian.com'. The default value passed to the logs will be 'www'.
+
+##### variant?: string
+
+The `variant` property accepts an optional string. If a value is passed to this
+it will be sent to the consent logs to indicate whether the user is within
+an a/b test related to the CMP. Typically the format for this string should
+follow: `${testName}-${variantName}`. We can also use the value of this property
+if we want to a/b test different layouts.
+
+##### fontFamilies?: { headlineSerif: string; bodySerif: string; bodySans: string; }
+
+The `fontFamilies` property accepts an optional object. If passed this object
+must match the definition used above. The values of `headlineSerif`, `bodySerif`
+and `bodySans` should be strings that match the `font-family` value in your
+sites `@font-face` definitions for The Guardian's custom webfonts.
+
+##### forceModal?: boolean
+
+The `forceModal` property accepts an optional boolean. If the value passed
+is `true` then the component will render the modal without the banner.
+This should be used when resurfacing the user's consent selections.
+
+**Example**
+
+```js
+import { oldCmp } from '@guardian/consent-management-platform';
+
+export class App {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showCmp: false,
+        };
+    }
+
+    public componentDidMount() {
+        if (oldCmp.shouldShow()) {
+            this.setState({ showCmp: true });
+        }
+    }
+
+    public render() {
+        const { showCmp } = this.state;
+
+        const props = {
+            source: 'manage',
+            onClose: () => {
+                this.setState({ showCmp: false });
+            },
+            fontFamilies: {
+                headlineSerif: 'GH Guardian Headline, Georgia, serif',
+                bodySerif: 'GuardianTextEgyptian, Georgia, serif',
+                bodySans:
+                    'GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
+            },
+        };
+
+        return (<>{showCmp && <oldCmp.ConsentManagementPlatform {...props} />}</>);
+    }
+}
+```
+
 ## Development
 
 See the [developer docs](docs/01-development-instructions.md).

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ onConsentChange(({ tcfv2, ccpa }) => {
 
 ## TCFv1 (deprecated)
 
-_These should not be used after 15 August 2020, and will be deleted shortly afterwards._
+_Since 15 August 2020, TCFv1 is deprecated and `oldCmp` should not be used._
 
 #### oldCmp.onGuConsentNotification
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
 		"types": "tsc --project ./tsconfig.build.json",
 		"validate": "npm-run-all --parallel tsc lint 'test --onlyChanged'"
 	},
+	"dependencies": {
+		"@guardian/old-cmp": "npm:@guardian/consent-management-platform@^3.4.10"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.9.6",
 		"@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -35,6 +38,8 @@
 		"@rollup/plugin-html": "^0.2.0",
 		"@rollup/plugin-strip": "^2.0.0",
 		"@types/jest": "^26.0.0",
+		"@types/react": "^16.9.47",
+		"@types/react-dom": "^16.9.8",
 		"@typescript-eslint/eslint-plugin": "^2.1.0",
 		"@typescript-eslint/parser": "^2.1.0",
 		"eslint": "^6.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,10 @@ module.exports = {
 			format: 'esm',
 		},
 	],
+	external: [
+		'@guardian/old-cmp',
+		'@guardian/old-cmp/dist/ConsentManagementPlatform',
+	],
 	plugins: [
 		babel({ extensions }),
 		resolve({ extensions }),

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,6 +3,11 @@ import { cmp } from '.';
 import { CCPA } from './ccpa';
 import { TCFv2 } from './tcfv2';
 
+// just stop Jest erroring on these
+// can be deleted when olde cmp is removed
+jest.mock('@guardian/old-cmp', () => ({}));
+jest.mock('@guardian/old-cmp/dist/ConsentManagementPlatform', () => ({}));
+
 jest.mock('./ccpa', () => ({
 	CCPA: {
 		init: jest.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,3 +79,5 @@ if (window) {
 export const { cmp, onConsentChange } =
 	(window?.guCmpHotFix as typeof actualExports) || actualExports;
 // *************** END commercial.dcr.js hotfix ***************
+
+export { oldCmp } from './oldCmp';

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,4 +80,4 @@ export const { cmp, onConsentChange } =
 	(window?.guCmpHotFix as typeof actualExports) || actualExports;
 // *************** END commercial.dcr.js hotfix ***************
 
-export { oldCmp } from './oldCmp';
+export { oldCmp } from './oldCmp'; // DEPRECATED: will be tree-shaken out

--- a/src/oldCmp.ts
+++ b/src/oldCmp.ts
@@ -1,0 +1,21 @@
+import {
+	init,
+	onGuConsentNotification,
+	onIabConsentNotification,
+	checkWillShowUi,
+	shouldShow,
+	showPrivacyManager,
+	setErrorHandler,
+} from '@guardian/old-cmp';
+import { ConsentManagementPlatform } from '@guardian/old-cmp/dist/ConsentManagementPlatform';
+
+export const oldCmp = {
+	init,
+	onGuConsentNotification,
+	onIabConsentNotification,
+	checkWillShowUi,
+	shouldShow,
+	showPrivacyManager,
+	setErrorHandler,
+	ConsentManagementPlatform,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,6 +853,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.10.tgz#604e71d27c6bfa4664c83c55578a8aa73ff09d82"
+  integrity sha512-P3dTf9EqYhpH7JQ+Bg9MNoIQ08U4yD5j+s5epO9mNTaIBiX1BeOF3RcI3KNj/dBxSggaut0rBdQ82GN54Bg4jA==
+  dependencies:
+    consent-string "1.5.2"
+    js-cookie "2.2.1"
+    whatwg-fetch "3.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1270,6 +1279,26 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
   integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
+
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.9.47":
+  version "16.9.47"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.47.tgz#fb092936f0b56425f874d0ff1b08051fdf70c1ba"
+  integrity sha512-dAJO4VbrjYqTUwFiQqAKjLyHHl4RSTNnRyPdX3p16MPbDKvow51wxATUPxoe2QsiXNMEYrOjc2S6s92VjG+1VQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1700,6 +1729,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
 base@^0.11.1:
   version "0.11.2"
@@ -2178,6 +2212,13 @@ confusing-browser-globals@^1.0.9:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
 
+consent-string@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.2.tgz#cd3615f406a1d7649ebc9722960b5e451cf6a685"
+  integrity sha512-xzfHnFzHQSupiamNY93UGn8FggPajHYExI45pzadhVpXVaj3ztnhnA7lYjKXl09pKRQKCT4hvjytt+2eoH7Jaw==
+  dependencies:
+    base-64 "^0.1.0"
+
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
@@ -2274,6 +2315,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
+  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4216,6 +4262,11 @@ jest@^26.0.1:
     "@jest/core" "^26.1.0"
     import-local "^3.0.2"
     jest-cli "^26.1.0"
+
+js-cookie@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6909,6 +6960,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## What does this change?

adds `oldCmp` back so we can proceed with improvements to CMP while working out how to remove old cmp from dotcom

cc @ripecosta – back from the grave!