### PR TITLE
ReadMe: use toggle for vendor IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Gets the consent for a given vendor.
 
 type: `string`
 
-<details><summary>Click to view the full list of available vendors:</summary>
+<details><summary>Supported vendors</summary>
 
 <!-- keep this list up to date with the VendorIDs in src/getConsentFor.ts -->
 
@@ -250,9 +250,9 @@ type: `string`
 -   `"twitter"`
 -   `"youtube-player"`
 
-If the vendor you need is missing, please [raise an issue](https://git.io/JUzVL) (or a PR!).
 
 </details>
+If the vendor you need is missing, please [raise an issue](https://git.io/JUzVL) (or a PR!).
 
 #### `consentState`
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Gets the consent for a given vendor.
 
 type: `string`
 
-The following vendors are available:
+<details><summary>Click to view the full list of available vendors:</summary>
 
 <!-- keep this list up to date with the VendorIDs in src/getConsentFor.ts -->
 
@@ -251,6 +251,8 @@ The following vendors are available:
 -   `"youtube-player"`
 
 If the vendor you need is missing, please [raise an issue](https://git.io/JUzVL) (or a PR!).
+
+</details>
 
 #### `consentState`
 


### PR DESCRIPTION
## What does this change?

Makes the README a little shorter.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->