### PR TITLE
fix: update README on `consentState.aus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
-- [Installation](#installation)
-  * [Bundling](#bundling)
-- [Managing Consent](#managing-consent)
-  * [`cmp.init(options)`](#cmpinitoptions)
-  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
-- [Using Consent](#using-consent)
-  * [`onConsentChange(callback)`](#onconsentchangecallback)
-  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
-- [Disabling Consent](#disabling-consent)
-  * [`cmp.__disable()`](#cmp__disable)
-  * [`cmp.__enable()`](#cmp__enable)
-  * [`cmp.__isDisabled()`](#cmp__isdisabled)
-  * [Manually](#manually)
-- [Development](#development)
+-   [Installation](#installation)
+    -   [Bundling](#bundling)
+-   [Managing Consent](#managing-consent)
+    -   [`cmp.init(options)`](#cmpinitoptions)
+    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+-   [Using Consent](#using-consent)
+    -   [`onConsentChange(callback)`](#onconsentchangecallback)
+    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+-   [Disabling Consent](#disabling-consent)
+    -   [`cmp.__disable()`](#cmp__disable)
+    -   [`cmp.__enable()`](#cmp__enable)
+    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
+    -   [Manually](#manually)
+-   [Development](#development)
 
 <!-- tocstop -->
 
@@ -163,7 +163,7 @@ type: `Object` or `undefined`
 Reports the user's preferences for each of the TCFv2 purposes, the last CMP
 event status, custom vendor consents, flag if GDPR applies, the TC string and addtlConsent string.
 
-If the user is in the USA, it will be `undefined`.
+If the user is neither in the USA or Australia, it will be `undefined`.
 
 Unlike the [`__tcfapi`](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-does-the-cmp-provide-the-api), all ten consents will have a set
 boolean value, defaulting to `false` where no explicit consent was given.
@@ -205,18 +205,38 @@ If the user is not in the USA, it will be `undefined`.
 }
 ```
 
+##### `consentState.aus`
+
+type: `Object` or `undefined`
+
+Reports whether user has withdrawn consent to sell their data in Australia.
+
+If the user is not in Australia, it will be `undefined`.
+
+```js
+{
+    "rejectedCategories": Array, // Empty by default
+	"rejectedVendors": Array, // Empty by default
+	"ccpaApplies": Boolean | undefined // true — AUS applies, false — it does not
+}
+```
+
 #### Example
 
 ```js
 import { onConsentChange } from '@guardian/consent-management-platform';
 
-onConsentChange(({ tcfv2, ccpa }) => {
+onConsentChange(({ tcfv2, ccpa, aus }) => {
     if (tcfv2) {
         console.log(tcfv2); // { 1: true || false, 1: true || false, ... }
     }
 
     if (ccpa) {
         console.log(ccpa); // { doNotSell: true || false }
+    }
+
+    if (aus) {
+        console.log(aus); // { rejectedCategories: [], ... }
     }
 });
 ```


### PR DESCRIPTION
## What does this change?

This should probably trigger a release, even though it’s only `docs`.

## Why?

There is a lack of details on the shape of the `consentState.aus` object 
