### PR TITLE
fix: accept `string` as a country (for now)

### DIFF
--- a/src/types/countries.ts
+++ b/src/types/countries.ts
@@ -253,4 +253,5 @@ type Countries = {
 	Zimbabwe: 'ZW';
 };
 
-export type Country = Countries[keyof Countries];
+// temporarily accept any string to integrate into DCR
+export type Country = Countries[keyof Countries] | string;


### PR DESCRIPTION
## What does this change?

- allows `string` types for country

## Why?

- DCR `countryCode` type is string, so this is a quick fix for Aus release

## Then...
- we could pull [the geo stuff out of DCR](https://github.com/guardian/dotcom-rendering/blob/main/src/web/lib/getCountryCode.ts) into https://github.com/guardian/libs and set the correct ISO type in there (cc @gtrufitt @liywjl)
- we could then revert this PR

## Then 2...
- that also opens up the possibility of not needing to pass location in, we can use the lib ourselves