### PR TITLE
fix: add AUS getConsentFor

### DIFF
--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -19,6 +19,16 @@ const ccpaWithConsent = { ccpa: { doNotSell: false } };
 
 const ccpaWithoutConsent = { ccpa: { doNotSell: true } };
 
+const ausUnknownConsent = { aus: {} };
+
+const ausWithConsent = { aus: { rejectedVendors: [] } };
+
+const ausWithoutConsent = {
+	aus: {
+		rejectedVendors: [{ _id: googleAnalytics, name: 'Google Analytics' }],
+	},
+};
+
 it('throws an error if the vendor found ', () => {
 	expect(() => {
 		getConsentFor('doesnotexist', tcfv2ConsentFoundTrue);
@@ -26,11 +36,14 @@ it('throws an error if the vendor found ', () => {
 });
 
 test.each([
-	['tcfv2', false, 'google-analytics', tcfv2ConsentNotFound],
+	['tcfv2 (unknown)', false, 'google-analytics', tcfv2ConsentNotFound],
 	['tcfv2', true, 'google-analytics', tcfv2ConsentFoundTrue],
 	['tcfv2', false, 'google-analytics', tcfv2ConsentFoundFalse],
 	['ccpa', true, 'google-analytics', ccpaWithConsent],
 	['ccpa', false, 'google-analytics', ccpaWithoutConsent],
+	['aus (unknown)', true, 'google-analytics', ausUnknownConsent],
+	['aus', true, 'google-analytics', ausWithConsent],
+	['aus', false, 'google-analytics', ausWithoutConsent],
 ])(
 	`In %s mode, returns %s, for vendor %s`,
 	(cmpMode, expected, vendor, mock) => {

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -47,7 +47,8 @@ export const getConsentFor = (
 	if (consent.aus) {
 		if (typeof consent.aus.rejectedVendors === 'undefined') return true;
 		const rejected = consent.aus.rejectedVendors.filter(
-			(rejectedVendor) => rejectedVendor.[`_id`] === sourcepointId,
+			// eslint-disable-next-line no-underscore-dangle
+			(rejectedVendor) => rejectedVendor._id === sourcepointId,
 		);
 		return rejected.length === 0;
 	}

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -45,12 +45,12 @@ export const getConsentFor = (
 	}
 
 	if (consent.aus) {
-		const rejected =
-			consent.aus.rejectedVendors.filter(
-				// eslint-disable-next-line no-underscore-dangle
-				(rejectedVendor) => rejectedVendor._id === sourcepointId,
-			).length > 0;
-		return rejected;
+		if (typeof consent.aus.rejectedVendors === 'undefined') return true;
+		const rejected = consent.aus.rejectedVendors.filter(
+			// eslint-disable-next-line no-underscore-dangle
+			(rejectedVendor) => rejectedVendor._id === sourcepointId,
+		);
+		return rejected.length === 0;
 	}
 
 	const tcfv2Consent: boolean | undefined =

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -44,6 +44,15 @@ export const getConsentFor = (
 		return !consent.ccpa.doNotSell;
 	}
 
+	if (consent.aus) {
+		const rejected =
+			consent.aus.rejectedVendors.filter(
+				// eslint-disable-next-line no-underscore-dangle
+				(rejectedVendor) => rejectedVendor._id === sourcepointId,
+			).length > 0;
+		return rejected;
+	}
+
 	const tcfv2Consent: boolean | undefined =
 		consent.tcfv2?.vendorConsents[sourcepointId];
 	if (typeof tcfv2Consent === 'undefined') {

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -47,8 +47,7 @@ export const getConsentFor = (
 	if (consent.aus) {
 		if (typeof consent.aus.rejectedVendors === 'undefined') return true;
 		const rejected = consent.aus.rejectedVendors.filter(
-			// eslint-disable-next-line no-underscore-dangle
-			(rejectedVendor) => rejectedVendor._id === sourcepointId,
+			(rejectedVendor) => rejectedVendor.[`_id`] === sourcepointId,
 		);
 		return rejected.length === 0;
 	}


### PR DESCRIPTION
## What does this change?

The `getConsentFor` method did not support the AUS framework.

## Why?

This needed to be updated before it could be used in production.

## Potential Further work

It might be worth changing the shape of the AUS consent state to make it easier to handle.
