### PR TITLE
feat: AUS handle old API params

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
--   [Installation](#installation)
-    -   [Bundling](#bundling)
--   [Managing Consent](#managing-consent)
-    -   [`cmp.init(options)`](#cmpinitoptions)
-    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
--   [Using Consent](#using-consent)
-    -   [`onConsentChange(callback)`](#onconsentchangecallback)
-    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
--   [Disabling Consent](#disabling-consent)
-    -   [`cmp.__disable()`](#cmp__disable)
-    -   [`cmp.__enable()`](#cmp__enable)
-    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
-    -   [Manually](#manually)
--   [Development](#development)
+- [Installation](#installation)
+  * [Bundling](#bundling)
+- [Managing Consent](#managing-consent)
+  * [`cmp.init(options)`](#cmpinitoptions)
+  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+- [Using Consent](#using-consent)
+  * [`onConsentChange(callback)`](#onconsentchangecallback)
+  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+- [Disabling Consent](#disabling-consent)
+  * [`cmp.__disable()`](#cmp__disable)
+  * [`cmp.__enable()`](#cmp__enable)
+  * [`cmp.__isDisabled()`](#cmp__isdisabled)
+  * [Manually](#manually)
+- [Development](#development)
 
 <!-- tocstop -->
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
-- [Installation](#installation)
-  * [Bundling](#bundling)
-- [Managing Consent](#managing-consent)
-  * [`cmp.init(options)`](#cmpinitoptions)
-  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
-- [Using Consent](#using-consent)
-  * [`onConsentChange(callback)`](#onconsentchangecallback)
-  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
-- [Disabling Consent](#disabling-consent)
-  * [`cmp.__disable()`](#cmp__disable)
-  * [`cmp.__enable()`](#cmp__enable)
-  * [`cmp.__isDisabled()`](#cmp__isdisabled)
-  * [Manually](#manually)
-- [Development](#development)
+-   [Installation](#installation)
+    -   [Bundling](#bundling)
+-   [Managing Consent](#managing-consent)
+    -   [`cmp.init(options)`](#cmpinitoptions)
+    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+-   [Using Consent](#using-consent)
+    -   [`onConsentChange(callback)`](#onconsentchangecallback)
+    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+-   [Disabling Consent](#disabling-consent)
+    -   [`cmp.__disable()`](#cmp__disable)
+    -   [`cmp.__enable()`](#cmp__enable)
+    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
+    -   [Manually](#manually)
+-   [Development](#development)
 
 <!-- tocstop -->
 
@@ -74,19 +74,17 @@ values: any [2-letter, ISO_3166-1 country code](https://en.wikipedia.org/wiki/IS
 Declare which country your user is in. Required – *throws an error if
 it's missing.*
 
-> N.B. you can omit `country` if isInUsa is set, but please update!
-
 #### `options.pubData`
 
 type: `Object`
 
 Pass additional parameters for for reporting. Optional.
 
-#### `options.isInUsa`
+#### `options.isInUsa` _(DEPRECATED)_
 
 type: `boolean`
 
-Old interface, prefer `options.country`. Optional. **Soon to be deprecated.**
+Deprecated, please use `options.country` instead. **Will be removed in next major version.**
 
 ##### Expected parameters
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
-- [Installation](#installation)
-  * [Bundling](#bundling)
-- [Managing Consent](#managing-consent)
-  * [`cmp.init(options)`](#cmpinitoptions)
-  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
-- [Using Consent](#using-consent)
-  * [`onConsentChange(callback)`](#onconsentchangecallback)
-  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
-- [Disabling Consent](#disabling-consent)
-  * [`cmp.__disable()`](#cmp__disable)
-  * [`cmp.__enable()`](#cmp__enable)
-  * [`cmp.__isDisabled()`](#cmp__isdisabled)
-  * [Manually](#manually)
-- [Development](#development)
+-   [Installation](#installation)
+    -   [Bundling](#bundling)
+-   [Managing Consent](#managing-consent)
+    -   [`cmp.init(options)`](#cmpinitoptions)
+    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+-   [Using Consent](#using-consent)
+    -   [`onConsentChange(callback)`](#onconsentchangecallback)
+    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+-   [Disabling Consent](#disabling-consent)
+    -   [`cmp.__disable()`](#cmp__disable)
+    -   [`cmp.__enable()`](#cmp__enable)
+    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
+    -   [Manually](#manually)
+-   [Development](#development)
 
 <!-- tocstop -->
 
@@ -74,11 +74,19 @@ values: any [2-letter, ISO_3166-1 country code](https://en.wikipedia.org/wiki/IS
 Declare which country your user is in. Required – *throws an error if
 it's missing.*
 
+> N.B. you can omit `country` if isInUsa is set, but please update!
+
 #### `options.pubData`
 
 type: `Object`
 
 Pass additional parameters for for reporting. Optional.
+
+#### `options.isInUsa`
+
+type: `boolean`
+
+Old interface, prefer `options.country`. Optional. **Soon to be deprecated.**
 
 ##### Expected parameters
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -158,3 +158,15 @@ describe('cmp.showPrivacyManager', () => {
 });
 
 it.todo('cmp.willShowPrivacyMessage');
+
+describe('Old API parameter `isInUsa`', () => {
+	it('Should handle `{ isInUsa: true }`', () => {
+		cmp.init({ isInUsa: true });
+		expect(CCPA.init).toHaveBeenCalledTimes(1);
+	});
+
+	it('Should handle `{ isInUsa: false }`', () => {
+		cmp.init({ isInUsa: false });
+		expect(TCFv2.init).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -169,4 +169,10 @@ describe('Old API parameter `isInUsa`', () => {
 		cmp.init({ isInUsa: false });
 		expect(TCFv2.init).toHaveBeenCalledTimes(1);
 	});
+
+	it('Should throw an error if neither is passed', () => {
+		expect(() => {
+			cmp.init({});
+		}).toThrow('required');
+	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,11 @@ const initialised = new Promise((resolve) => {
 function init({
 	pubData,
 	country,
+	isInUsa, // Will soon be deprected
 }: {
 	pubData?: PubData;
-	country: Country;
+	country?: Country;
+	isInUsa?: boolean;
 }): void {
 	if (isDisabled() || window.guCmpHotFix.initialised) {
 		if (window.guCmpHotFix.cmp?.version !== __PACKAGE_VERSION__)
@@ -40,6 +42,15 @@ function init({
 				window.guCmpHotFix.cmp?.version,
 			]);
 		return;
+	}
+
+	if (typeof isInUsa !== 'undefined') {
+		// eslint-disable-next-line no-param-reassign
+		country = isInUsa ? 'US' : 'GB';
+
+		console.warn(
+			'`isInUsa` will soon be deprecated. Prefer using `country` instead.',
+		);
 	}
 
 	if (typeof country === 'undefined') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const initialised = new Promise((resolve) => {
 function init({
 	pubData,
 	country,
-	isInUsa, // Will soon be deprected
+	isInUsa, // DEPRECATED: Will be removed in next major version
 }: {
 	pubData?: PubData;
 	country?: Country;


### PR DESCRIPTION
## What does this change?

Allow calling the API with `cmp.init({ isInUsa })`.

## Why?

Because we can never fully synchronise releases in DCR & frontend, we always need to support old API interfaces.