### PR TITLE
fix: add new types back to window object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,10 @@ import { getFramework } from './getFramework';
 import { onConsentChange as actualOnConsentChange } from './onConsentChange';
 import { TCFv2 } from './tcfv2';
 import {
-	PubData,
+	InitCmp,
 	SourcepointImplementation,
 	WillShowPrivacyMessage,
 } from './types';
-import { Country } from './types/countries';
 
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
@@ -30,11 +29,7 @@ function init({
 	pubData,
 	country,
 	isInUsa, // DEPRECATED: Will be removed in next major version
-}: {
-	pubData?: PubData;
-	country?: Country;
-	isInUsa?: boolean;
-}): void {
+}: InitCmp): void {
 	if (isDisabled() || window.guCmpHotFix.initialised) {
 		if (window.guCmpHotFix.cmp?.version !== __PACKAGE_VERSION__)
 			console.warn('Two different versions of the CMP are running:', [

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ const showPrivacyManager = () => {
 	initialised.then(CMP?.showPrivacyManager);
 };
 
+// keep the window.guCmpHotFix.cmp type in sync with this types/window.d.ts
 export const cmp = (window.guCmpHotFix.cmp ||= {
 	init,
 	willShowPrivacyMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getFramework } from './getFramework';
 import { onConsentChange as actualOnConsentChange } from './onConsentChange';
 import { TCFv2 } from './tcfv2';
 import {
-	InitCmp,
+	InitCMP,
 	SourcepointImplementation,
 	WillShowPrivacyMessage,
 } from './types';
@@ -25,11 +25,11 @@ const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
-function init({
+const init: InitCMP = ({
 	pubData,
 	country,
 	isInUsa, // DEPRECATED: Will be removed in next major version
-}: InitCmp): void {
+}) => {
 	if (isDisabled() || window.guCmpHotFix.initialised) {
 		if (window.guCmpHotFix.cmp?.version !== __PACKAGE_VERSION__)
 			console.warn('Two different versions of the CMP are running:', [
@@ -76,7 +76,7 @@ function init({
 
 	CMP?.init(pubData || {});
 	resolveInitialised?.();
-}
+};
 
 const willShowPrivacyMessage: WillShowPrivacyMessage = () =>
 	initialised.then(() => CMP?.willShowPrivacyMessage() || false);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,11 +5,7 @@ import { TCFv2ConsentState } from './tcfv2';
 
 export type Framework = 'tcfv2' | 'ccpa' | 'aus';
 
-export type InitCMP = ({
-	pubData,
-	country,
-	isInUsa, // DEPRECATED: Will be removed in next major version
-}: {
+export type InitCMP = (arg0: {
 	pubData?: PubData;
 	country?: Country;
 	isInUsa?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,11 +5,15 @@ import { TCFv2ConsentState } from './tcfv2';
 
 export type Framework = 'tcfv2' | 'ccpa' | 'aus';
 
-export interface InitCmp {
+export type InitCMP = ({
+	pubData,
+	country,
+	isInUsa, // DEPRECATED: Will be removed in next major version
+}: {
 	pubData?: PubData;
 	country?: Country;
 	isInUsa?: boolean;
-}
+}) => void;
 
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,7 @@ export interface ConsentState {
 export interface PubData {
 	browserId?: string;
 	pageViewId?: string;
-	[propName: string]: any;
+	[propName: string]: unknown;
 }
 export interface SourcepointImplementation {
 	init: (pubData?: PubData) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,15 @@
 import { CustomVendorRejects } from './aus';
 import { CCPAConsentState } from './ccpa';
+import { Country } from './countries';
 import { TCFv2ConsentState } from './tcfv2';
 
 export type Framework = 'tcfv2' | 'ccpa' | 'aus';
+
+export interface InitCmp {
+	pubData?: PubData;
+	country?: Country;
+	isInUsa?: boolean;
+}
 
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -19,9 +19,11 @@ declare global {
 				init: ({
 					pubData,
 					country,
+					isInUsa, // DEPRECATED: Will be removed in next major version
 				}: {
-					pubData?: PubData | undefined;
-					country: Country;
+					pubData?: PubData;
+					country?: Country;
+					isInUsa?: boolean;
 				}) => void;
 				willShowPrivacyMessage: WillShowPrivacyMessage;
 				showPrivacyManager: () => void;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,9 +1,8 @@
 import { getConsentFor } from '../getConsentFor';
 import { onConsentChange } from '../onConsentChange';
 import { CCPAData } from './ccpa';
-import { Country } from './countries';
 import { TCData } from './tcfv2/TCData';
-import { PubData, WillShowPrivacyMessage } from '.';
+import { InitCmp, PubData, WillShowPrivacyMessage } from '.';
 
 type OnMessageChoiceSelect = (
 	arg0: number,
@@ -15,17 +14,12 @@ declare global {
 		// *************** START commercial.dcr.js hotfix ***************
 		guCmpHotFix: {
 			initialised?: boolean;
-			// keep this in sync with the `cmp` export of ../index.ts
 			cmp?: {
 				init: ({
 					pubData,
 					country,
 					isInUsa, // DEPRECATED: Will be removed in next major version
-				}: {
-					pubData?: PubData;
-					country?: Country;
-					isInUsa?: boolean;
-				}) => void;
+				}: InitCmp) => void;
 				willShowPrivacyMessage: WillShowPrivacyMessage;
 				showPrivacyManager: () => void;
 				version: typeof __PACKAGE_VERSION__;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -15,6 +15,7 @@ declare global {
 		// *************** START commercial.dcr.js hotfix ***************
 		guCmpHotFix: {
 			initialised?: boolean;
+			// keep this in sync with the `cmp` export of ../index.ts
 			cmp?: {
 				init: ({
 					pubData,

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -2,7 +2,7 @@ import { getConsentFor } from '../getConsentFor';
 import { onConsentChange } from '../onConsentChange';
 import { CCPAData } from './ccpa';
 import { TCData } from './tcfv2/TCData';
-import { InitCmp, PubData, WillShowPrivacyMessage } from '.';
+import { InitCMP, PubData, WillShowPrivacyMessage } from '.';
 
 type OnMessageChoiceSelect = (
 	arg0: number,
@@ -15,11 +15,7 @@ declare global {
 		guCmpHotFix: {
 			initialised?: boolean;
 			cmp?: {
-				init: ({
-					pubData,
-					country,
-					isInUsa, // DEPRECATED: Will be removed in next major version
-				}: InitCmp) => void;
+				init: InitCMP;
 				willShowPrivacyMessage: WillShowPrivacyMessage;
 				showPrivacyManager: () => void;
 				version: typeof __PACKAGE_VERSION__;


### PR DESCRIPTION
## What does this change?

restores old types to init interface

## Why?

missed in #322 