### PR TITLE
chore: enable beta releases via semantic release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": "main",
+  "branches": ["main", { "name": "beta", "prerelease": true }],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## What does this change?

enables `beta` releases by merging to the new [`beta`](https://github.com/guardian/consent-management-platform/tree/beta) branch instead of `main`

https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches

## Why?

enables us to test pre-release versions