### PR TITLE
fix: only test against advertising category

### DIFF
--- a/cypress/integration/sourcepoint-ccpa.spec.js
+++ b/cypress/integration/sourcepoint-ccpa.spec.js
@@ -2,7 +2,7 @@
 
 import 'cypress-wait-until';
 
-const iframeMessage = `#sp_message_iframe_${343253}`;
+const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_privacy_manager_iframe';
 const loadPage = () => {
 	it('should load the CCPA page', () => cy.visit('/#ccpa'));

--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -2,7 +2,7 @@
 
 import { skipOn } from '@cypress/skip-test';
 
-const iframeMessage = `#sp_message_iframe_${343252}`;
+const iframeMessage = `#sp_message_iframe_${379541}`; // changes on reconsent
 const iframePrivacyManager = '#sp_message_iframe_106842';
 const loadPage = () => {
 	it('should load the TCFv2 page', () => cy.visit('/#tcfv2'));

--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -2,7 +2,7 @@
 
 import { skipOn } from '@cypress/skip-test';
 
-const iframeMessage = `#sp_message_iframe_${379541}`; // changes on reconsent
+const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_message_iframe_106842';
 const loadPage = () => {
 	it('should load the TCFv2 page', () => cy.visit('/#tcfv2'));

--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -2,6 +2,7 @@
 import { getConsentFor } from './getConsentFor';
 
 const googleAnalytics = '5e542b3a4cd8884eb41b5a72';
+const advertising = '5f859c3420e4ec3e476c7006';
 
 const tcfv2ConsentNotFound = {
 	tcfv2: { vendorConsents: { doesnotexist: true } },
@@ -21,11 +22,11 @@ const ccpaWithoutConsent = { ccpa: { doNotSell: true } };
 
 const ausUnknownConsent = { aus: {} };
 
-const ausWithConsent = { aus: { rejectedVendors: [] } };
+const ausWithConsent = { aus: { rejectedCategories: [] } };
 
 const ausWithoutConsent = {
 	aus: {
-		rejectedVendors: [{ _id: googleAnalytics, name: 'Google Analytics' }],
+		rejectedCategories: [{ _id: advertising, name: 'Advertising' }],
 	},
 };
 

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -46,10 +46,11 @@ export const getConsentFor = (
 	}
 
 	if (consent.aus) {
-		if (typeof consent.aus.rejectedVendors === 'undefined') return true;
-		const rejected = consent.aus.rejectedVendors.filter(
+		if (typeof consent.aus.rejectedCategories === 'undefined') return true;
+		const advertising = '5f859c3420e4ec3e476c7006';
+		const rejected = consent.aus.rejectedCategories.filter(
 			// eslint-disable-next-line no-underscore-dangle
-			(rejectedVendor) => rejectedVendor._id === sourcepointId,
+			(rejectedCategory) => rejectedCategory._id === advertising,
 		);
 		return rejected.length === 0;
 	}


### PR DESCRIPTION
## What does this change?

In AUS, Instead of testing agains specific custom vendors, check for the “Advertising” category.

## Why?

This decision has been clarified as being the expected behaviour.
