### PR TITLE
fix: wait for sourcepoint library to load in aus

### DIFF
--- a/cypress/integration/sourcepoint-ccpa.spec.js
+++ b/cypress/integration/sourcepoint-ccpa.spec.js
@@ -4,6 +4,10 @@ import { ENDPOINT } from '../../src/lib/sourcepointConfig';
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_privacy_manager_iframe';
 const loadPage = () => {
+	// undocumented fix for cookies from non-localhost domains
+	// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
+	cy.clearCookies({ domain: null });
+
 	it('should load the CCPA page', () => cy.visit('/#ccpa'));
 };
 const doNotSellIs = (boolean) => {

--- a/cypress/integration/sourcepoint-ccpa.spec.js
+++ b/cypress/integration/sourcepoint-ccpa.spec.js
@@ -1,15 +1,11 @@
 import 'cypress-wait-until';
 import { ENDPOINT } from '../../src/lib/sourcepointConfig';
+import { loadPage } from '../utils';
 
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_privacy_manager_iframe';
-const loadPage = () => {
-	// undocumented fix for cookies from non-localhost domains
-	// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
-	cy.clearCookies({ domain: null });
+const url = '/#ccpa';
 
-	it('should load the CCPA page', () => cy.visit('/#ccpa'));
-};
 const doNotSellIs = (boolean) => {
 	cy.get('[data-donotsell]')
 		.should('have.length', 1)
@@ -29,7 +25,7 @@ const ccpaRejectCookieIs = (boolean) => {
 };
 
 describe('Window', () => {
-	loadPage();
+	loadPage(url);
 	it('has the guCmpHotFix object', () => {
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
@@ -44,7 +40,7 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	loadPage();
+	loadPage(url);
 	it('should have the SP iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
@@ -59,7 +55,7 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	loadPage();
+	loadPage(url);
 	const buttonTitle = 'Do not sell my personal information';
 
 	beforeEach(() => {

--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -1,18 +1,13 @@
 import { skipOn } from '@cypress/skip-test';
 import { ENDPOINT } from '../../src/lib/sourcepointConfig';
+import { loadPage } from '../utils';
 
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_message_iframe_106842';
-const loadPage = () => {
-	// undocumented fix for cookies from non-localhost domains
-	// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
-	cy.clearCookies({ domain: null });
-
-	it('should load the TCFv2 page', () => cy.visit('/#tcfv2'));
-};
+const url = '/#tcfv2';
 
 describe('Window', () => {
-	loadPage();
+	loadPage(url);
 	it('has the guCmpHotFix object', () => {
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
@@ -27,7 +22,7 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	loadPage();
+	loadPage(url);
 	it('should have the SP iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
@@ -44,7 +39,7 @@ describe('Document', () => {
 // TODO: enable testing of TCFv2 on CI
 skipOn(Cypress.env('CI') === 'true', () => {
 	describe('Interaction', () => {
-		loadPage();
+		loadPage(url);
 		const buttonTitle = 'Yes, I’m happy';
 
 		beforeEach(() => {

--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -4,6 +4,10 @@ import { ENDPOINT } from '../../src/lib/sourcepointConfig';
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_message_iframe_106842';
 const loadPage = () => {
+	// undocumented fix for cookies from non-localhost domains
+	// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
+	cy.clearCookies({ domain: null });
+
 	it('should load the TCFv2 page', () => cy.visit('/#tcfv2'));
 };
 

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,0 +1,9 @@
+export const loadPage = (url) => {
+	it(`should load the page: ${url}`, () => {
+		cy.visit(url);
+
+		// undocumented fix for cookies from non-localhost domains
+		// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
+		cy.clearCookies({ domain: null });
+	});
+};

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,9 +1,9 @@
 export const loadPage = (url) => {
 	it(`should load the page: ${url}`, () => {
-		cy.visit(url);
-
 		// undocumented fix for cookies from non-localhost domains
 		// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
 		cy.clearCookies({ domain: null });
+
+		cy.visit(url);
 	});
 };

--- a/src/aus/api.test.js
+++ b/src/aus/api.test.js
@@ -1,5 +1,9 @@
 import { getCustomVendorRejects } from './api';
 
+jest.mock('./sourcepoint', () => ({
+	loaded: Promise.resolve(),
+}));
+
 it('throws an error on missing window.__uspapi', async () => {
 	await expect(getCustomVendorRejects()).rejects.toThrow(
 		'No __uspapi found on window',

--- a/src/aus/api.ts
+++ b/src/aus/api.ts
@@ -1,20 +1,24 @@
 import type { CustomVendorRejects } from '../types/aus';
+import { loaded } from './sourcepoint';
 
 type Command = 'getCustomVendorRejects';
 
 const api = (command: Command) =>
-	new Promise((resolve, reject) => {
-		if (window.__uspapi) {
-			window.__uspapi(command, 1, (result, success) =>
-				success
-					? resolve(result)
-					: /* istanbul ignore next */
-					  reject(new Error('Unable to get uspapi data')),
-			);
-		} else {
-			reject(new Error('No __uspapi found on window'));
-		}
-	});
+	new Promise(
+		(resolve, reject) =>
+			void loaded.then(() => {
+				if (window.__uspapi) {
+					window.__uspapi(command, 1, (result, success) =>
+						success
+							? resolve(result)
+							: /* istanbul ignore next */
+							  reject(new Error('Unable to get uspapi data')),
+					);
+				} else {
+					reject(new Error('No __uspapi found on window'));
+				}
+			}),
+	);
 
 export const getCustomVendorRejects = (): Promise<CustomVendorRejects> =>
 	api('getCustomVendorRejects') as Promise<CustomVendorRejects>;

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -81,6 +81,7 @@ export const init = (pubData = {}): void => {
 	const ausLib = document.createElement('script');
 	ausLib.id = 'sourcepoint-aus-lib';
 	ausLib.src = `${ENDPOINT}/ccpa.js`;
-	ausLib.onload = resolveLoaded;
 	document.body.appendChild(ausLib);
+
+	window.__uspapi?.('getUSPData', 1, () => void resolveLoaded());
 };

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -52,6 +52,14 @@ export const init = (pubData = {}): void => {
 			events: {
 				onConsentReady() {
 					mark('cmp-aus-got-consent');
+
+					// the 'getCustomVendorRejects' option of SP's implementation of __uspapi
+					// is a custom extension. It hits SP's servers, but unlike the rest of the
+					// __uspapi, it doesn't implement a queue.
+					// the only way we can be sure it has become available is to wait for a
+					// SP event to fire, so we resolve this now so we can be sure its available elsewhere
+					void resolveLoaded();
+
 					// onConsentReady is triggered before SP update the consent settings :(
 					setTimeout(invokeCallbacks, 0);
 				},
@@ -82,6 +90,4 @@ export const init = (pubData = {}): void => {
 	ausLib.id = 'sourcepoint-aus-lib';
 	ausLib.src = `${ENDPOINT}/ccpa.js`;
 	document.body.appendChild(ausLib);
-
-	window.__uspapi?.('getUSPData', 1, () => void resolveLoaded());
 };

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -9,6 +9,11 @@ export const willShowPrivacyMessage = new Promise<boolean>((resolve) => {
 	resolveWillShowPrivacyMessage = resolve as typeof Promise.resolve;
 });
 
+let resolveLoaded: typeof Promise.resolve;
+export const loaded = new Promise<void>((resolve) => {
+	resolveLoaded = resolve as typeof Promise.resolve;
+});
+
 // Sets the SP property and custom vendor list
 const properties = {
 	live: 'https://au.theguardian.com',
@@ -76,5 +81,6 @@ export const init = (pubData = {}): void => {
 	const ausLib = document.createElement('script');
 	ausLib.id = 'sourcepoint-aus-lib';
 	ausLib.src = `${ENDPOINT}/ccpa.js`;
+	ausLib.onload = resolveLoaded;
 	document.body.appendChild(ausLib);
 };

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -6,6 +6,10 @@ import { _, invokeCallbacks, onConsentChange } from './onConsentChange';
 import customVendorConsents from './tcfv2/__fixtures__/api.getCustomVendorConsents.json';
 import tcData from './tcfv2/__fixtures__/api.getTCData.json';
 
+jest.mock('./aus/sourcepoint', () => ({
+	loaded: Promise.resolve(),
+}));
+
 beforeEach(() => {
 	window.__uspapi = undefined;
 	window.__tcfapi = undefined;

--- a/src/rollup.config.js
+++ b/src/rollup.config.js
@@ -27,12 +27,13 @@ export default {
 			__PACKAGE_VERSION__: JSON.stringify(pkg.version),
 		}),
 		commonjs(),
-		strip({
-			include: ['**/*.{j,t}s?(x)'],
-			exclude: ['index.*'],
-			sourceMap: true,
-		}),
-	],
+		process.env.NODE_ENV === 'production' &&
+			strip({
+				include: ['**/*.{j,t}s?(x)'],
+				exclude: ['index.*'],
+				sourceMap: true,
+			}),
+	].filter(Boolean),
 	watch: {
 		clearScreen: false,
 	},


### PR DESCRIPTION
## What does this change?

delays calls to `uspapi` until the sourcepoint library has loaded in aus

## Why?

sourcepoint's custom `'getCustomVendorRejects'` extension to `__uspapi` doesn't implement the queue that the standard `__uspapi` options are required to. 

they suggested the following:

> wait until we have determined the siteID before calling __uspapi('getCustomVendorRejects');

this is an attempt but it doesn't seem to work...

