### PR TITLE
fix: await __uspapi

### DIFF
--- a/src/aus/api.test.js
+++ b/src/aus/api.test.js
@@ -1,7 +1,7 @@
 import { getCustomVendorRejects } from './api';
 
 jest.mock('./sourcepoint', () => ({
-	loaded: Promise.resolve(),
+	sourcepointLibraryLoaded: Promise.resolve(),
 }));
 
 it('throws an error on missing window.__uspapi', async () => {

--- a/src/aus/api.ts
+++ b/src/aus/api.ts
@@ -1,18 +1,20 @@
 import type { CustomVendorRejects } from '../types/aus';
-import { loaded } from './sourcepoint';
+import { sourcepointLibraryLoaded } from './sourcepoint';
 
 type Command = 'getCustomVendorRejects';
 
 const api = (command: Command) =>
 	new Promise(
 		(resolve, reject) =>
-			void loaded.then(() => {
+			void sourcepointLibraryLoaded.then(() => {
 				if (window.__uspapi) {
 					window.__uspapi(command, 1, (result, success) =>
 						success
 							? resolve(result)
 							: /* istanbul ignore next */
-							  reject(new Error('Unable to get uspapi data')),
+							  reject(
+									new Error(`Unable to get ${command} data`),
+							  ),
 					);
 				} else {
 					reject(new Error('No __uspapi found on window'));

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -67,8 +67,10 @@ export const init = (pubData = {}): void => {
 				},
 
 				onMessageReceiveData: (data) => {
-					void resolveSourcepointLibraryLoaded();
 					void resolveWillShowPrivacyMessage(data.msg_id !== 0);
+
+					// this event always fires, so we can use it announce that the library has loaded
+					void resolveSourcepointLibraryLoaded();
 				},
 
 				onMessageChoiceSelect: (_, choiceTypeID) => {

--- a/src/ccpa/api.ts
+++ b/src/ccpa/api.ts
@@ -9,7 +9,7 @@ const api = (command: Command) =>
 				success
 					? resolve(result)
 					: /* istanbul ignore next */
-					  reject(new Error('Unable to get uspapi data')),
+					  reject(new Error(`Unable to get ${command} data`)),
 			);
 		} else {
 			reject(new Error('No __uspapi found on window'));

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -7,7 +7,7 @@ import customVendorConsents from './tcfv2/__fixtures__/api.getCustomVendorConsen
 import tcData from './tcfv2/__fixtures__/api.getTCData.json';
 
 jest.mock('./aus/sourcepoint', () => ({
-	loaded: Promise.resolve(),
+	sourcepointLibraryLoaded: Promise.resolve(),
 }));
 
 beforeEach(() => {

--- a/src/tcfv2/api.ts
+++ b/src/tcfv2/api.ts
@@ -15,7 +15,7 @@ const api = (command: Command) =>
 				success
 					? resolve(result)
 					: /* istanbul ignore next */
-					  reject(new Error('Unable to get tcfapi data')),
+					  reject(new Error(`Unable to get ${command} data`)),
 			);
 		} else {
 			reject(new Error('No __tcfapi found on window'));


### PR DESCRIPTION
## What does this change?

More robust checks for when SP library has loaded. Any callback events now triggers the `getCustomVendorRejects` call. Follow-up on #354. 

- Renamed promise to `sourcepointLibraryLoaded`

## Why?

`onConsentReady` does not fire when a user gets the banner show and clicks “Continue”. Using the `willShowPrivacyMessage` is more robust, and always fires once the SP library is loaded.