### PR TITLE
fix: use CCPA getUSPData API in AUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
-- [Installation](#installation)
-  * [Bundling](#bundling)
-- [Managing Consent](#managing-consent)
-  * [`cmp.init(options)`](#cmpinitoptions)
-  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
-- [Using Consent](#using-consent)
-  * [`onConsentChange(callback)`](#onconsentchangecallback)
-  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
-- [Disabling Consent](#disabling-consent)
-  * [`cmp.__disable()`](#cmp__disable)
-  * [`cmp.__enable()`](#cmp__enable)
-  * [`cmp.__isDisabled()`](#cmp__isdisabled)
-  * [Manually](#manually)
-  * [Using Cypress](#using-cypress)
-- [Development](#development)
+-   [Installation](#installation)
+    -   [Bundling](#bundling)
+-   [Managing Consent](#managing-consent)
+    -   [`cmp.init(options)`](#cmpinitoptions)
+    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+-   [Using Consent](#using-consent)
+    -   [`onConsentChange(callback)`](#onconsentchangecallback)
+    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+-   [Disabling Consent](#disabling-consent)
+    -   [`cmp.__disable()`](#cmp__disable)
+    -   [`cmp.__enable()`](#cmp__enable)
+    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
+    -   [Manually](#manually)
+    -   [Using Cypress](#using-cypress)
+-   [Development](#development)
 
 <!-- tocstop -->
 
@@ -216,15 +216,14 @@ If the user is not in the USA, it will be `undefined`.
 
 type: `Object` or `undefined`
 
-Reports whether user has withdrawn consent to sell their data in Australia.
+Reports whether user has withdrawn consent to personalised adversising
+in Australia.
 
 If the user is not in Australia, it will be `undefined`.
 
 ```js
 {
-    "rejectedCategories": Array, // Empty by default
-	"rejectedVendors": Array, // Empty by default
-	"ccpaApplies": Boolean | undefined // true — AUS applies, false — it does not
+    personalisedAdvertising: Boolean, // True by default
 }
 ```
 
@@ -243,7 +242,7 @@ onConsentChange(({ tcfv2, ccpa, aus }) => {
     }
 
     if (aus) {
-        console.log(aus); // { rejectedCategories: [], ... }
+        console.log(aus); // { personalisedAdvertising: true || false }
     }
 });
 ```

--- a/src/aus/__fixtures__/api.getUSPData.json
+++ b/src/aus/__fixtures__/api.getUSPData.json
@@ -1,0 +1,4 @@
+{
+	"version": 1,
+	"uspString": "1YYN"
+}

--- a/src/aus/api.test.js
+++ b/src/aus/api.test.js
@@ -1,13 +1,11 @@
-import { getCustomVendorRejects } from './api';
+import { getUSPData } from './api';
 
 jest.mock('./sourcepoint', () => ({
 	sourcepointLibraryLoaded: Promise.resolve(),
 }));
 
 it('throws an error on missing window.__uspapi', async () => {
-	await expect(getCustomVendorRejects()).rejects.toThrow(
-		'No __uspapi found on window',
-	);
+	await expect(getUSPData()).rejects.toThrow('No __uspapi found on window');
 });
 
 it('calls the modified IAB api with the correct methods', async () => {
@@ -15,10 +13,10 @@ it('calls the modified IAB api with the correct methods', async () => {
 		cb({}, true);
 	});
 
-	await getCustomVendorRejects();
+	await getUSPData();
 
 	expect(window.__uspapi).toHaveBeenCalledWith(
-		'getCustomVendorRejects',
+		'getUSPData',
 		expect.any(Number),
 		expect.any(Function),
 	);

--- a/src/aus/api.ts
+++ b/src/aus/api.ts
@@ -1,26 +1,20 @@
-import type { CustomVendorRejects } from '../types/aus';
-import { sourcepointLibraryLoaded } from './sourcepoint';
+import type { CCPAData } from '../types/ccpa';
 
-type Command = 'getCustomVendorRejects';
+type Command = 'getUSPData';
 
 const api = (command: Command) =>
-	new Promise(
-		(resolve, reject) =>
-			void sourcepointLibraryLoaded.then(() => {
-				if (window.__uspapi) {
-					window.__uspapi(command, 1, (result, success) =>
-						success
-							? resolve(result)
-							: /* istanbul ignore next */
-							  reject(
-									new Error(`Unable to get ${command} data`),
-							  ),
-					);
-				} else {
-					reject(new Error('No __uspapi found on window'));
-				}
-			}),
-	);
+	new Promise((resolve, reject) => {
+		if (window.__uspapi) {
+			window.__uspapi(command, 1, (result, success) =>
+				success
+					? resolve(result)
+					: /* istanbul ignore next */
+					  reject(new Error(`Unable to get ${command} data`)),
+			);
+		} else {
+			reject(new Error('No __uspapi found on window'));
+		}
+	});
 
-export const getCustomVendorRejects = (): Promise<CustomVendorRejects> =>
-	api('getCustomVendorRejects') as Promise<CustomVendorRejects>;
+export const getUSPData = (): Promise<CCPAData> =>
+	api('getUSPData') as Promise<CCPAData>;

--- a/src/aus/getConsentState.test.js
+++ b/src/aus/getConsentState.test.js
@@ -1,16 +1,15 @@
-import ausData from './__fixtures__/api.getCustomVendorRejects.json';
-import { getCustomVendorRejects } from './api';
+import ausData from './__fixtures__/api.getUSPData.json';
+import { getUSPData } from './api';
 import { getConsentState } from './getConsentState';
 
 jest.mock('./api');
-getCustomVendorRejects.mockResolvedValue(ausData);
+getUSPData.mockResolvedValue(ausData);
 
 describe('getConsentState', () => {
 	it('gets the consent state correctly', async () => {
-		const { ccpaApplies, rejectedVendors } = await getConsentState();
+		const { personalisedAdvertising } = await getConsentState();
 
-		expect(getCustomVendorRejects).toHaveBeenCalledTimes(1);
-		expect(ccpaApplies).toBeTruthy();
-		expect(rejectedVendors.length).toBe(0);
+		expect(getUSPData).toHaveBeenCalledTimes(1);
+		expect(personalisedAdvertising).toBe(true);
 	});
 });

--- a/src/aus/getConsentState.ts
+++ b/src/aus/getConsentState.ts
@@ -1,9 +1,11 @@
-import type { CustomVendorRejects } from '../types/aus';
-import { getCustomVendorRejects } from './api';
+import type { AUSConsentState } from '../types/aus';
+import { getUSPData } from './api';
 
 // get the current constent state using the official IAB method
-export const getConsentState: () => Promise<CustomVendorRejects> = async () => {
-	const customVendorRejects = await getCustomVendorRejects();
+export const getConsentState: () => Promise<AUSConsentState> = async () => {
+	const uspData = await getUSPData();
 
-	return customVendorRejects;
+	return {
+		personalisedAdvertising: uspData.uspString.charAt(2) === 'Y',
+	};
 };

--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -1,7 +1,6 @@
 import { getConsentFor } from './getConsentFor';
 
 const googleAnalytics = '5e542b3a4cd8884eb41b5a72';
-const advertising = '5f859c3420e4ec3e476c7006';
 
 const tcfv2ConsentNotFound = {
 	tcfv2: { vendorConsents: { doesnotexist: true } },
@@ -19,15 +18,9 @@ const ccpaWithConsent = { ccpa: { doNotSell: false } };
 
 const ccpaWithoutConsent = { ccpa: { doNotSell: true } };
 
-const ausUnknownConsent = { aus: {} };
+const ausWithConsent = { aus: { personalisedAdvertising: true } };
 
-const ausWithConsent = { aus: { rejectedCategories: [] } };
-
-const ausWithoutConsent = {
-	aus: {
-		rejectedCategories: [{ _id: advertising, name: 'Advertising' }],
-	},
-};
+const ausWithoutConsent = { aus: { personalisedAdvertising: false } };
 
 it('throws an error if the vendor found ', () => {
 	expect(() => {
@@ -41,7 +34,6 @@ test.each([
 	['tcfv2', false, 'google-analytics', tcfv2ConsentFoundFalse],
 	['ccpa', true, 'google-analytics', ccpaWithConsent],
 	['ccpa', false, 'google-analytics', ccpaWithoutConsent],
-	['aus (unknown)', true, 'google-analytics', ausUnknownConsent],
 	['aus', true, 'google-analytics', ausWithConsent],
 	['aus', false, 'google-analytics', ausWithoutConsent],
 ])(

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -8,7 +8,6 @@ enum VendorIDs {
 	// keep the list in README.md up to date with these values
 	'a9' = '5f369a02b8e05c308701f829',
 	'acast' = '5f203dcb1f0dea790562e20f',
-	'aus-advertising' = '5f859c3420e4ec3e476c7006',
 	'braze' = '5ed8c49c4b8ce4571c7ad801',
 	'comscore' = '5efefe25b8e05c06542b2a77',
 	'facebook-mobile' = '5e716fc09a0b5040d575080f',
@@ -48,16 +47,13 @@ export const getConsentFor = (
 	}
 
 	if (consent.ccpa) {
+		// doNotSell = false means we have consent
 		return !consent.ccpa.doNotSell;
 	}
 
 	if (consent.aus) {
-		if (typeof consent.aus.rejectedCategories === 'undefined') return true;
-		const rejected = consent.aus.rejectedCategories.filter(
-			(rejectedCategory) =>
-				rejectedCategory._id === VendorIDs['aus-advertising'],
-		);
-		return rejected.length === 0;
+		// personalisedAdvertising = true means we have consent
+		return consent.aus.personalisedAdvertising;
 	}
 
 	const tcfv2Consent: boolean | undefined =

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,14 +1,10 @@
 import waitForExpect from 'wait-for-expect';
-import ausData from './aus/__fixtures__/api.getCustomVendorRejects.json';
+import ausData from './aus/__fixtures__/api.getUSPData.json';
 import uspData from './ccpa/__fixtures__/api.getUSPData.json';
 import { setCurrentFramework } from './getCurrentFramework';
 import { _, invokeCallbacks, onConsentChange } from './onConsentChange';
 import customVendorConsents from './tcfv2/__fixtures__/api.getCustomVendorConsents.json';
 import tcData from './tcfv2/__fixtures__/api.getTCData.json';
-
-jest.mock('./aus/sourcepoint', () => ({
-	sourcepointLibraryLoaded: Promise.resolve(),
-}));
 
 beforeEach(() => {
 	window.__uspapi = undefined;
@@ -81,7 +77,7 @@ describe('under CCPA', () => {
 describe('under AUS', () => {
 	beforeEach(() => {
 		window.__uspapi = jest.fn((command, b, callback) => {
-			if (command === 'getCustomVendorRejects') callback(ausData, true);
+			if (command === 'getUSPData') callback(ausData, true);
 		});
 
 		// needed to distinguish from US
@@ -126,7 +122,7 @@ describe('under AUS', () => {
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
 
-		ausData.ccpaApplies = 'false';
+		ausData.uspString = '1YNN';
 		invokeCallbacks();
 
 		await waitForExpect(() => {

--- a/src/types/aus.ts
+++ b/src/types/aus.ts
@@ -1,14 +1,3 @@
-export interface CustomVendorRejects {
-	rejectedCategories: Array<{
-		_id: string;
-		name: string;
-	}>;
-
-	rejectedVendors: Array<{
-		_id: string;
-		name: string;
-		vendorType: string;
-	}>;
-
-	ccpaApplies: true;
+export interface AUSConsentState {
+	personalisedAdvertising: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { CustomVendorRejects } from './aus';
+import type { AUSConsentState } from './aus';
 import type { CCPAConsentState } from './ccpa';
 import type { Country } from './countries';
 import type { TCFv2ConsentState } from './tcfv2';
@@ -14,7 +14,7 @@ export type InitCMP = (arg0: {
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;
 	ccpa?: CCPAConsentState;
-	aus?: CustomVendorRejects;
+	aus?: AUSConsentState;
 }
 export interface PubData {
 	browserId?: string;


### PR DESCRIPTION
## What does this change?

Just rely on good old `getUSPData` in AUS.

## Why?

We're not using the granularity of `getCustomVendorRejects`, and it's a half-baked solution that causes a plethora of errors everywhere.