### PR TITLE
feat: use @guardian/libs logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-typescript": "7.12.1",
     "@babel/runtime": "7.12.5",
     "@cypress/skip-test": "2.5.0",
+    "@guardian/libs": "1.6.1",
     "@guardian/eslint-config": "0.4.0",
     "@guardian/eslint-config-typescript": "0.4.1",
     "@guardian/prettier": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@cypress/skip-test": "2.5.0",
     "@guardian/eslint-config": "0.4.0",
     "@guardian/eslint-config-typescript": "0.4.1",
+    "@guardian/libs": "^1.6.2",
     "@guardian/prettier": "0.4.1",
     "@rollup/plugin-babel": "5.2.1",
     "@rollup/plugin-commonjs": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@babel/preset-typescript": "7.12.1",
     "@babel/runtime": "7.12.5",
     "@cypress/skip-test": "2.5.0",
-    "@guardian/libs": "1.6.1",
     "@guardian/eslint-config": "0.4.0",
     "@guardian/eslint-config-typescript": "0.4.1",
     "@guardian/prettier": "0.4.1",
@@ -93,5 +92,8 @@
     "tslib": "2.0.3",
     "typescript": "4.0.5",
     "wait-for-expect": "3.0.2"
+  },
+  "peerDependencies": {
+    "@guardian/libs": "^1.6.2"
   }
 }

--- a/src/getCurrentFramework.ts
+++ b/src/getCurrentFramework.ts
@@ -1,8 +1,10 @@
+import { log } from '@guardian/libs';
 import type { Framework } from './types';
 
 let currentFramework: Framework | undefined;
 
 export const setCurrentFramework = (framework: Framework): void => {
+	log('cmp', `Framework set to ${framework}`);
 	currentFramework = framework;
 };
 export const getCurrentFramework = (): Framework | undefined =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { AUS } from './aus';
 import { CCPA } from './ccpa';
 import { disable, enable, isDisabled } from './disable';
@@ -85,6 +86,7 @@ const init: InitCMP = ({
 	void frameworkCMP.willShowPrivacyMessage().then((willShowValue) => {
 		_willShowPrivacyMessage = willShowValue;
 		initComplete = true;
+		log('cmp', 'initComplete');
 	});
 
 	resolveInitialised();

--- a/src/lib/mark.ts
+++ b/src/lib/mark.ts
@@ -1,10 +1,11 @@
 /* istanbul ignore file */
+import { log } from '@guardian/libs';
 
 export const mark = (label: string): void => {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- typescript is too futuristic for some browsers
 	window.performance?.mark?.(label);
 
 	if (process.env.NODE_ENV !== 'test') {
-		console.log(`%c[event] %c${label}`, 'color: deepskyblue; ', '');
+		log('cmp', '[event]', label);
 	}
 };

--- a/test-page/App.svelte
+++ b/test-page/App.svelte
@@ -1,6 +1,7 @@
 <script>
 	// always use the dist version
 	import { cmp, onConsentChange } from '../';
+	import { log } from '@guardian/libs';
 	import { onMount } from 'svelte';
 
 	switch (window.location.hash) {
@@ -32,14 +33,7 @@
 
 	function logEvent(event) {
 		eventsList = [...eventsList, event];
-		console.log(
-			`%c@guardian%c %cCMP%c [event]`,
-			'background: #052962; color: white; padding: 2px; border-radius:3px',
-			'',
-			'background: deeppink; color: white; padding: 2px; border-radius:3px',
-			'color: deepskyblue; ',
-			event,
-		);
+		log('cmp', event);
 	}
 
 	let clearPreferences = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.4.0.tgz#1a0a40176f7115849351a3fd0d05028b33e17d42"
   integrity sha512-B4P84JFTG5JlpgIiOFUPNJ5w9a/VpDfKftWFYaIMdkCRpgDXOhxiZfaBMiP5/D1RsRMSvi2bg3JemS5ueGlOcg==
 
+"@guardian/libs@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.6.2.tgz#12036d397df6a0bca6a641f49dee6646750f9d91"
+  integrity sha512-8GDcTRcrdZcGARucW25i08NW7nYcdXaLKvrD4v6H9rhm70HOvwlxlTZdfRj3u+x2gHN63A+Iu8XaX61TLtXblw==
+
 "@guardian/prettier@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.1.tgz#b1af81aa24723951892cd5f41f006609d2392380"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.4.0.tgz#1a0a40176f7115849351a3fd0d05028b33e17d42"
   integrity sha512-B4P84JFTG5JlpgIiOFUPNJ5w9a/VpDfKftWFYaIMdkCRpgDXOhxiZfaBMiP5/D1RsRMSvi2bg3JemS5ueGlOcg==
 
+"@guardian/libs@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.6.1.tgz#dd310b561cd019a229ea8a7c93d48c2c9c94bdd2"
+  integrity sha512-8UzrD3X66fYYT7LOOwgjXXHTDAF7rj8l+mBMyiW3DnH73VsSk+OW/gFHSm+AKVZYSl0JU6L1B04KMnG9htU4dA==
+
 "@guardian/prettier@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.1.tgz#b1af81aa24723951892cd5f41f006609d2392380"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,11 +1115,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.4.0.tgz#1a0a40176f7115849351a3fd0d05028b33e17d42"
   integrity sha512-B4P84JFTG5JlpgIiOFUPNJ5w9a/VpDfKftWFYaIMdkCRpgDXOhxiZfaBMiP5/D1RsRMSvi2bg3JemS5ueGlOcg==
 
-"@guardian/libs@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.6.1.tgz#dd310b561cd019a229ea8a7c93d48c2c9c94bdd2"
-  integrity sha512-8UzrD3X66fYYT7LOOwgjXXHTDAF7rj8l+mBMyiW3DnH73VsSk+OW/gFHSm+AKVZYSl0JU6L1B04KMnG9htU4dA==
-
 "@guardian/prettier@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.1.tgz#b1af81aa24723951892cd5f41f006609d2392380"


### PR DESCRIPTION
## What does this change?

Uses the new and shiny `log` from `@guardian/libs`.

## Why?

We can log more to the console, without polluting.
