### PR TITLE
fix: Invoke callbacks instantly in TCFv2

### DIFF
--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -28,10 +28,6 @@ const properties = {
 export const init = (pubData = {}): void => {
 	stub();
 
-	// invoke callbacks ASAP in AUS
-	// TODO this causes an error
-	invokeCallbacks();
-
 	// make sure nothing else on the page has accidentally
 	// used the _sp_* name as well
 	if (window._sp_ccpa) {
@@ -39,6 +35,9 @@ export const init = (pubData = {}): void => {
 			'Sourcepoint CCPA global (window._sp_ccpa) is already defined!',
 		);
 	}
+
+	// invoke callbacks before we receive Sourcepoint events
+	setTimeout(invokeCallbacks, 0);
 
 	/* istanbul ignore next */
 	window._sp_ccpa = {

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -54,7 +54,7 @@ export const init = (pubData = {}): void => {
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
 
 			events: {
-				onConsentReady() {
+				onConsentReady: () => {
 					mark('cmp-aus-got-consent');
 
 					// onConsentReady is triggered before SP update the consent settings :(

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -37,7 +37,7 @@ export const init = (pubData = {}): void => {
 	}
 
 	// invoke callbacks before we receive Sourcepoint events
-	setTimeout(invokeCallbacks, 0);
+	invokeCallbacks();
 
 	/* istanbul ignore next */
 	window._sp_ccpa = {

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -18,9 +18,6 @@ const properties = {
 export const init = (pubData = {}): void => {
 	stub();
 
-	// invoke callbacks ASAP in USA
-	invokeCallbacks();
-
 	// make sure nothing else on the page has accidentally
 	// used the _sp_* name as well
 	if (window._sp_ccpa) {
@@ -28,6 +25,9 @@ export const init = (pubData = {}): void => {
 			'Sourcepoint CCPA global (window._sp_ccpa) is already defined!',
 		);
 	}
+
+	// invoke callbacks before we receive Sourcepoint events
+	setTimeout(invokeCallbacks, 0);
 
 	/* istanbul ignore next */
 	window._sp_ccpa = {
@@ -46,8 +46,6 @@ export const init = (pubData = {}): void => {
 			events: {
 				onConsentReady() {
 					mark('cmp-ccpa-got-consent');
-					// onConsentReady is triggered before SP update the consent settings :(
-					setTimeout(invokeCallbacks, 0);
 				},
 
 				onMessageReady: () => {

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -27,7 +27,7 @@ export const init = (pubData = {}): void => {
 	}
 
 	// invoke callbacks before we receive Sourcepoint events
-	setTimeout(invokeCallbacks, 0);
+	invokeCallbacks();
 
 	/* istanbul ignore next */
 	window._sp_ccpa = {

--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -44,7 +44,7 @@ export const init = (pubData = {}): void => {
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
 
 			events: {
-				onConsentReady() {
+				onConsentReady: () => {
 					mark('cmp-ccpa-got-consent');
 				},
 

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -27,7 +27,7 @@ export const init = (pubData = {}): void => {
 	}
 
 	// invoke callbacks before we receive Sourcepoint events
-	setTimeout(invokeCallbacks, 0);
+	invokeCallbacks();
 
 	/* istanbul ignore next */
 	window._sp_ = {

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -42,7 +42,7 @@ export const init = (pubData = {}): void => {
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
 
 			events: {
-				onConsentReady() {
+				onConsentReady: () => {
 					mark('cmp-tcfv2-got-consent');
 				},
 

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -26,6 +26,9 @@ export const init = (pubData = {}): void => {
 		);
 	}
 
+	// invoke callbacks before we receive Sourcepoint events
+	setTimeout(invokeCallbacks, 0);
+
 	/* istanbul ignore next */
 	window._sp_ = {
 		config: {
@@ -41,8 +44,6 @@ export const init = (pubData = {}): void => {
 			events: {
 				onConsentReady() {
 					mark('cmp-tcfv2-got-consent');
-					// onConsentReady is triggered before SP update the consent settings :(
-					setTimeout(invokeCallbacks, 0);
 				},
 
 				onMessageReady: () => {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Returns a state with no consent as soon as possible, before a new user interacts with the banner.

## Why?

We don’t need to wait for SP events. Closing #382 