### PR TITLE
test: Maintenance

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -106,7 +106,28 @@ describe('hotfix cmp.init', () => {
 		expect(getCurrentFramework()).toEqual(framework);
 	});
 
-	it.todo('uses window.guCmpHotFix instances if they exist');
+	it('uses window.guCmpHotFix instances if they exist', () => {
+		const mockCmp = {
+			init: () => undefined,
+			willShowPrivacyMessage: () => true,
+			willShowPrivacyMessageSync: () => true,
+			hasInitialised: () => true,
+			mocked: 'mocked',
+		};
+
+		window.guCmpHotFix = {
+			cmp: mockCmp,
+		};
+
+		jest.resetModules();
+		import('.').then((module) => {
+			expect(module.cmp).toEqual(mockCmp);
+
+			delete window.guCmpHotFix;
+			jest.resetModules();
+			import('.');
+		});
+	});
 });
 // *************** END commercial.dcr.js hotfix ***************
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -132,7 +132,7 @@ describe('hotfix cmp.init', () => {
 // *************** END commercial.dcr.js hotfix ***************
 
 describe('cmp.willShowPrivacyMessage', () => {
-	it.skip('resolves regardless of when the cmp is initialised', () => {
+	it('resolves regardless of when the cmp is initialised', () => {
 		// This should be tested in e2e test to be meaningful
 		const willShowPrivacyMessage1 = cmp.willShowPrivacyMessage();
 
@@ -140,9 +140,11 @@ describe('cmp.willShowPrivacyMessage', () => {
 
 		const willShowPrivacyMessage2 = cmp.willShowPrivacyMessage();
 
-		return expect(
-			Promise.all([willShowPrivacyMessage1, willShowPrivacyMessage2]),
-		).resolves.toEqual(['iwillshowit', 'iwillshowit']);
+		cmp.willShowPrivacyMessage().then(() => {
+			expect(
+				Promise.all([willShowPrivacyMessage1, willShowPrivacyMessage2]),
+			).resolves.toEqual([true, true]);
+		});
 	});
 });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -184,8 +184,6 @@ describe('cmp.showPrivacyManager', () => {
 	});
 });
 
-it.todo('cmp.willShowPrivacyMessage');
-
 describe('Old API parameter `isInUsa`', () => {
 	it('Should handle `{ isInUsa: true }`', () => {
 		cmp.init({ isInUsa: true });


### PR DESCRIPTION
## What does this change?

Fix tests that were marked as `todo` or skipped.

- [stop skipping `cmp.willShowPrivacyMessage()`](https://github.com/guardian/consent-management-platform/pull/389/files#diff-38a2b85ac1b61b44eb1945e128241cb5ef01e5646cf06b586f5c0114b153fa0eL114), introduced in #263
- Actually tests [this](https://github.com/guardian/consent-management-platform/commit/3de44275d93348d34fc66cb704d25b0cf0286c29) from 3de44275

## Why?

Better coverage, better testing, better code health.
