### PR TITLE
fix: change type of version to string

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export type CMP = {
 	willShowPrivacyMessageSync: () => boolean;
 	hasInitialised: () => boolean;
 	showPrivacyManager: () => void;
-	version: typeof __PACKAGE_VERSION__;
+	version: string;
 	__isDisabled: () => boolean;
 	__disable: () => void;
 	__enable: () => void;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Attempt to fix the below error when importing latest version to DCR which uses typescript:

```
node_modules/@guardian/consent-management-platform/dist/types/index.d.ts:12:21 - error TS2304: Cannot find name '__PACKAGE_VERSION__'.

12     version: typeof __PACKAGE_VERSION__;
```

## Why?
It should allow updating latest cmp version to DCR
