### PR TITLE
fix: Switch debug console to new Error

### DIFF
--- a/src/tcfv2/getConsentState.ts
+++ b/src/tcfv2/getConsentState.ts
@@ -26,7 +26,7 @@ export const getConsentState: () => Promise<TCFv2ConsentState> = async () => {
 		const currentFramework: string = getCurrentFramework() ?? 'undefined';
 		const guGeolocation: string =
 			window.localStorage.getItem('gu.geolocation') ?? 'undefined';
-		console.error(
+		throw new Error(
 			`No TC Data found with current framework: ${currentFramework} and location: ${guGeolocation}`,
 		);
 	}


### PR DESCRIPTION
## What does this change?

Switch debug console to throwing a new Error when tcdata is empty

## Why?
Hopefully this would get picked up by Sentry