### PR TITLE
chore: use guardian/actions-setup-node

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,15 +12,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -44,15 +37,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -66,15 +52,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -88,15 +67,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -110,15 +82,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -144,15 +109,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -110,7 +110,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,9 +10,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node.js
-        shell: bash -l {0}
-        run: nvm install
+      - name: Setup node
+        uses: guardian/actions-setup-node
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## What does this change?

uses guardian/actions-setup-node

## Why?

cleaner