### PR TITLE
chore(tests): Run TCFv2 in CI workflow

### DIFF
--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -1,4 +1,3 @@
-import { skipOn } from '@cypress/skip-test';
 import { ENDPOINT } from '../../src/lib/sourcepointConfig';
 import { loadPage } from '../utils';
 
@@ -36,97 +35,89 @@ describe('Document', () => {
 	});
 });
 
-// TODO: enable testing of TCFv2 on CI
-skipOn(Cypress.env('CI') === 'true', () => {
-	describe('Interaction', () => {
-		loadPage(url);
-		const buttonTitle = 'Yes, I’m happy';
+describe('Interaction', () => {
+	loadPage(url);
+	const buttonTitle = 'Yes, I’m happy';
 
-		beforeEach(() => {
-			cy.setCookie('ccpaApplies', 'false');
-			cy.setCookie('gdprApplies', 'true');
-			Cypress.Cookies.preserveOnce('consentUUID', 'euconsent-v2');
-		});
+	beforeEach(() => {
+		cy.setCookie('ccpaApplies', 'false');
+		cy.setCookie('gdprApplies', 'true');
+		Cypress.Cookies.preserveOnce('consentUUID', 'euconsent-v2');
+	});
 
-		it(`should give all consents when clicking "${buttonTitle}"`, () => {
-			cy.getIframeBody(iframeMessage)
-				.find(`button[title="${buttonTitle}"]`)
-				.click();
+	it(`should give all consents when clicking "${buttonTitle}"`, () => {
+		cy.getIframeBody(iframeMessage)
+			.find(`button[title="${buttonTitle}"]`)
+			.click();
 
-			// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-			cy.wait(1000);
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(1000);
 
-			[(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)].forEach((purpose) => {
-				cy.get(`[data-purpose="${purpose}"]`).should(
-					'have.data',
-					'consent',
-					true,
-				);
-			});
-		});
-		it(`should be able to only deactivate purpose 1`, () => {
-			cy.get('[data-cy=pm]').click();
-
-			cy.getIframeBody(iframePrivacyManager)
-				.find(
-					`label[aria-label="Store and/or access information on a device"]`,
-				)
-				.find('span.off')
-				.click();
-
-			cy.getIframeBody(iframePrivacyManager)
-				.find(`button[aria-label="Save and close"]`)
-				.click();
-
-			// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-			cy.wait(1000);
-
-			cy.get(`[data-purpose="1"]`)
-				.should('have.data', 'consent')
-				.should('equal', false);
-
-			[2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((purpose) => {
-				cy.get(`[data-purpose="${purpose}"]`)
-					.should('have.data', 'consent')
-					.should('equal', true);
-			});
-		});
-
-		it(`should be able to refuse all but purpose 1`, () => {
-			cy.get('[data-cy=pm]').click();
-
-			cy.getIframeBody(iframePrivacyManager)
-				.find(
-					`label[aria-label="Store and/or access information on a device"]`,
-				)
-				.find('span.on')
-				.click();
-
-			cy.getIframeBody(iframePrivacyManager)
-				.find(`div.stack-toggles`)
-				.click();
-
-			cy.getIframeBody(iframePrivacyManager)
-				.find(`button[aria-label="Save and close"]`)
-				.click();
-
-			// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-			cy.wait(1000);
-
-			cy.get(`[data-purpose="1"]`)
-				.should('have.data', 'consent')
-				.should('equal', false);
-
-			[2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((purpose) => {
-				cy.get(`[data-purpose="${purpose}"]`)
-					.should('have.data', 'consent')
-					.should('equal', true);
-			});
+		[(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)].forEach((purpose) => {
+			cy.get(`[data-purpose="${purpose}"]`).should(
+				'have.data',
+				'consent',
+				true,
+			);
 		});
 	});
-});
-skipOn(Cypress.env('CI') !== 'true', () => {
-	describe('Skipped in CI', () => {
-		it('should skip TCFv2 in CI env, because of geolocation', () => true);
+	it(`should be able to only deactivate purpose 1`, () => {
+		cy.get('[data-cy=pm]').click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(
+				`label[aria-label="Store and/or access information on a device"]`,
+			)
+			.find('span.off')
+			.click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(`button[aria-label="Save and close"]`)
+			.click();
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(1000);
+
+		cy.get(`[data-purpose="1"]`)
+			.should('have.data', 'consent')
+			.should('equal', false);
+
+		[2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((purpose) => {
+			cy.get(`[data-purpose="${purpose}"]`)
+				.should('have.data', 'consent')
+				.should('equal', true);
+		});
+	});
+
+	it(`should be able to refuse all but purpose 1`, () => {
+		cy.get('[data-cy=pm]').click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(
+				`label[aria-label="Store and/or access information on a device"]`,
+			)
+			.find('span.on')
+			.click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(`div.stack-toggles`)
+			.click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(`button[aria-label="Save and close"]`)
+			.click();
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(1000);
+
+		cy.get(`[data-purpose="1"]`)
+			.should('have.data', 'consent')
+			.should('equal', false);
+
+		[2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((purpose) => {
+			cy.get(`[data-purpose="${purpose}"]`)
+				.should('have.data', 'consent')
+				.should('equal', true);
+		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/preset-env": "7.12.1",
     "@babel/preset-typescript": "7.12.1",
     "@babel/runtime": "7.12.5",
-    "@cypress/skip-test": "2.5.0",
     "@guardian/eslint-config": "0.4.0",
     "@guardian/eslint-config-typescript": "0.4.1",
     "@guardian/libs": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -95,5 +95,6 @@
   },
   "peerDependencies": {
     "@guardian/libs": "^1.6.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,9 +2792,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001135:
-  version "1.0.30001137"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz#6f0127b1d3788742561a25af3607a17fc778b803"
-  integrity sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==
+  version "1.0.30001207"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz"
+  integrity sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,11 +1074,6 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-"@cypress/skip-test@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.5.0.tgz#ba3fc8c441a9dda5fa410e783006107ff3b9d050"
-  integrity sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ==
-
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"


### PR DESCRIPTION
## What does this change?

Enables TCFv2 testing in continuous integration workflow.

## Why?

Sourcepoint now runs all frameworks globally, and it is the CMP’s job to make the right call on which framework to run. These tests were failing for a while, and it looks like #431 fixed them.