### PR TITLE
fix: Trigger callbacks when consent is ready

### DIFF
--- a/src/ccpa/sourcepoint.ts
+++ b/src/ccpa/sourcepoint.ts
@@ -46,6 +46,9 @@ export const init = (pubData = {}): void => {
 			events: {
 				onConsentReady: () => {
 					mark('cmp-ccpa-got-consent');
+
+					// onConsentReady is triggered before SP update the consent settings :(
+					setTimeout(invokeCallbacks, 0);
 				},
 
 				onMessageReady: () => {

--- a/src/tcfv2/sourcepoint.ts
+++ b/src/tcfv2/sourcepoint.ts
@@ -44,6 +44,9 @@ export const init = (pubData = {}): void => {
 			events: {
 				onConsentReady: () => {
 					mark('cmp-tcfv2-got-consent');
+
+					// onConsentReady is triggered before SP update the consent settings :(
+					setTimeout(invokeCallbacks, 0);
 				},
 
 				onMessageReady: () => {

--- a/src/tcfv2/stub.js
+++ b/src/tcfv2/stub.js
@@ -1,7 +1,7 @@
 /* eslint-disable -- this is third party code */
 /* istanbul ignore file */
 
-// https://documentation.sourcepoint.com/web-implementation/sourcepoint-gdpr-and-tcf-v2-support-beta/gdpr-and-tcf-v2-setup-and-configuration#1-two-step-process-to-implement-the-gdpr-and-tcf-v2-code-snippet
+// https://documentation.sourcepoint.com/web-implementation/web-implementation/sourcepoint-gdpr-and-tcf-v2-support/gdpr-and-tcf-v2-setup-and-configuration_v1.1.3
 
 export const stub = () => {
 	var e = function () {


### PR DESCRIPTION
## What does this change?

`onConsentReady` is when consent is really ready. We used `onMessageChoiceSelect`, but it’s not as reliable.

Shortly, we should simply add an event listener to the `__tcfapi`.

## Why?

New visits did not get a consented state and end-to-end tests are failing.