### PR TITLE
test: add end-to-end tests for aus

### DIFF
--- a/cypress/integration/sourcepoint-aus.spec.js
+++ b/cypress/integration/sourcepoint-aus.spec.js
@@ -1,0 +1,85 @@
+import 'cypress-wait-until';
+import { ACCOUNT_ID, ENDPOINT } from '../../src/lib/sourcepointConfig';
+import { loadPage } from '../utils';
+
+const iframeMessage = `[id^="sp_message_iframe_"]`;
+const iframePrivacyManager = '#sp_privacy_manager_iframe';
+const url = '/#aus';
+
+const personalisedAdvertisingIs = (boolean) => {
+	cy.get('[data-personalised-advertising]')
+		.should('have.length', 1)
+		.should('contain', boolean.toString());
+};
+
+
+describe('Window', () => {
+	loadPage(url);
+	it('has the guCmpHotFix object', () => {
+		cy.window().should('have.property', 'guCmpHotFix');
+	});
+	it('has correct config params', () => {
+		cy.window()
+			.its('_sp_ccpa.config')
+			.then((spConfig) => {
+				expect(spConfig.accountId).equal(ACCOUNT_ID);
+				expect(spConfig.baseEndpoint).equal(ENDPOINT);
+			});
+	});
+});
+
+describe('Document', () => {
+	loadPage(url);
+	// The banner/message iframe only appears in Australia (including VPN)
+	// TODO: check scenarios on Sourcepoint config
+	it.skip('should have the Sourcepoint iframe', () => {
+		cy.get('iframe').should('be.visible').get(iframeMessage);
+	});
+
+	it('should have the correct script URL', () => {
+		cy.get('script#sourcepoint-aus-lib').should(
+			'have.attr',
+			'src',
+			`${ENDPOINT}/ccpa.js`,
+		);
+	});
+});
+
+describe('Interaction', () => {
+	loadPage(url);
+	const buttonTitle = 'Do not sell my personal information';
+
+	beforeEach(() => {
+		cy.setCookie('ccpaApplies', 'true');
+		Cypress.Cookies.preserveOnce(
+			'ccpaUUID',
+			'ccpaReject',
+			'ccpaConsentAll',
+			'consentStatus',
+		);
+	});
+
+	it('should have personalised advertising set to true by default', () => {
+		personalisedAdvertisingIs(true);
+	});
+
+	it.skip('Interaction with the banner to retract consent.');
+
+	it(`should be able to retract consent`, () => {
+		cy.get('[data-cy=pm]').click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find(
+				`#tab-pan_5ff468ee2517312b60214b15 div.right`,
+			) /* ¯\_(ツ)_/¯ */
+			.click();
+
+		cy.getIframeBody(iframePrivacyManager)
+			.find('#tab-saveandexit')
+			.should('be.visible')
+			.click();
+
+		// ccpaRejectCookieIs(true);
+		personalisedAdvertisingIs(true);
+	});
+});

--- a/cypress/integration/sourcepoint-aus.spec.js
+++ b/cypress/integration/sourcepoint-aus.spec.js
@@ -12,7 +12,6 @@ const personalisedAdvertisingIs = (boolean) => {
 		.should('contain', boolean.toString());
 };
 
-
 describe('Window', () => {
 	loadPage(url);
 	it('has the guCmpHotFix object', () => {

--- a/cypress/integration/sourcepoint-aus.spec.js
+++ b/cypress/integration/sourcepoint-aus.spec.js
@@ -29,8 +29,7 @@ describe('Window', () => {
 
 describe('Document', () => {
 	loadPage(url);
-	// The banner/message iframe only appears in Australia (including VPN)
-	// TODO: check scenarios on Sourcepoint config
+
 	it('should have the Sourcepoint iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
@@ -46,7 +45,17 @@ describe('Document', () => {
 
 describe('Interaction', () => {
 	loadPage(url);
-	// const buttonTitle = 'Do not sell my personal information';
+
+	// Cookies need to be kept for consent to be passed from one test to the next
+	beforeEach(() => {
+		cy.setCookie('ccpaApplies', 'true');
+		Cypress.Cookies.preserveOnce(
+			'ccpaUUID',
+			'ccpaReject',
+			'ccpaConsentAll',
+			'consentStatus',
+		);
+	});
 
 	it('should have personalised advertising set to true by default', () => {
 		personalisedAdvertisingIs(true);
@@ -72,7 +81,6 @@ describe('Interaction', () => {
 			.should('be.visible')
 			.click();
 
-		// ccpaRejectCookieIs(true);
-		personalisedAdvertisingIs(true);
+		personalisedAdvertisingIs(false);
 	});
 });

--- a/cypress/integration/sourcepoint-aus.spec.js
+++ b/cypress/integration/sourcepoint-aus.spec.js
@@ -31,7 +31,7 @@ describe('Document', () => {
 	loadPage(url);
 	// The banner/message iframe only appears in Australia (including VPN)
 	// TODO: check scenarios on Sourcepoint config
-	it.skip('should have the Sourcepoint iframe', () => {
+	it('should have the Sourcepoint iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
 
@@ -48,21 +48,15 @@ describe('Interaction', () => {
 	loadPage(url);
 	// const buttonTitle = 'Do not sell my personal information';
 
-	beforeEach(() => {
-		cy.setCookie('ccpaApplies', 'true');
-		Cypress.Cookies.preserveOnce(
-			'ccpaUUID',
-			'ccpaReject',
-			'ccpaConsentAll',
-			'consentStatus',
-		);
-	});
-
 	it('should have personalised advertising set to true by default', () => {
 		personalisedAdvertisingIs(true);
 	});
 
-	it.skip('Interaction with the banner to retract consent.');
+	it('Should click continue to dismiss the banner', () => {
+		cy.getIframeBody(iframeMessage)
+			.find(`button[title="Continue"]`)
+			.click();
+	});
 
 	it(`should be able to retract consent`, () => {
 		cy.get('[data-cy=pm]').click();

--- a/cypress/integration/sourcepoint-aus.spec.js
+++ b/cypress/integration/sourcepoint-aus.spec.js
@@ -47,7 +47,7 @@ describe('Document', () => {
 
 describe('Interaction', () => {
 	loadPage(url);
-	const buttonTitle = 'Do not sell my personal information';
+	// const buttonTitle = 'Do not sell my personal information';
 
 	beforeEach(() => {
 		cy.setCookie('ccpaApplies', 'true');

--- a/cypress/integration/sourcepoint-ccpa.spec.js
+++ b/cypress/integration/sourcepoint-ccpa.spec.js
@@ -72,8 +72,6 @@ describe('Interaction', () => {
 		doNotSellIs(false);
 	});
 
-	// TODO: fix this bug!
-	// currently `onConsentChange` is not called when clicking the button
 	it(`should retract consent when clicking "${buttonTitle}"`, () => {
 		cy.getIframeBody(iframeMessage)
 			.find(`button[title="${buttonTitle}"]`)
@@ -83,8 +81,6 @@ describe('Interaction', () => {
 		doNotSellIs(true);
 	});
 
-	// TODO: clicking "save and exit" does not actually save,
-	// but does dismiss the PM
 	it(`should be able to retract consent`, () => {
 		cy.get('[data-cy=pm]').click();
 

--- a/test-page/App.svelte
+++ b/test-page/App.svelte
@@ -275,6 +275,7 @@
 		{:else if consentState.aus}
 			<h2>aus.personalisedAdvertising</h2>
 			<span
+				data-personalised-advertising={consentState.aus.personalisedAdvertising}
 				class={consentState.aus.personalisedAdvertising ? 'yes' : 'no'}>{consentState.aus.personalisedAdvertising}</span>
 		{:else}
 			<h2>¯\_(ツ)_/¯</h2>


### PR DESCRIPTION
Co-Authored-By: Max Duval <max.duval@theguardian.com>

## What does this change?
This adds end-to-end tests for Australia.

## Why?
They didn't exist before. We now have global geolocation enabled.
