### PR TITLE
style: Add code spell checker extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "wix.vscode-import-cost",
     "orta.vscode-jest",
     "editorconfig.editorconfig",
+    "streetsidesoftware.code-spell-checker",
     "dbaeumer.vscode-eslint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": [
+	"Sourcepoint",
+	"ccpa",
+	"tcfapi",
+	"tcfv",
+	"uspapi"
+]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,10 +11,27 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": [
-	"Sourcepoint",
+	"SP’s",
+	"acast",
 	"ccpa",
+	"cmpuishown",
+	"comscore",
+	"googletag",
+	"inizio",
+	"ipsos",
+	"lotame",
+	"ophan",
+	"permutive",
+	"redplanet",
+	"remarketing",
+	"sourcepoint",
 	"tcfapi",
 	"tcfv",
-	"uspapi"
+	"tcloaded",
+	"teads",
+	"theguardian",
+	"useractioncomplete",
+	"uspapi",
+	"youtube"
 ]
 }

--- a/README.md
+++ b/README.md
@@ -14,24 +14,24 @@ and TCFv2 to everyone else.
 
 <!-- toc -->
 
-- [Installation](#installation)
-  * [Bundling](#bundling)
-- [Managing Consent](#managing-consent)
-  * [`cmp.init(options)`](#cmpinitoptions)
-  * [`cmp.hasInitialised()`](#cmphasinitialised)
-  * [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
-  * [`cmp.willShowPrivacyMessageSync()`](#cmpwillshowprivacymessagesync)
-  * [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
-- [Using Consent](#using-consent)
-  * [`onConsentChange(callback)`](#onconsentchangecallback)
-  * [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
-- [Disabling Consent](#disabling-consent)
-  * [`cmp.__disable()`](#cmp__disable)
-  * [`cmp.__enable()`](#cmp__enable)
-  * [`cmp.__isDisabled()`](#cmp__isdisabled)
-  * [Manually](#manually)
-  * [Using Cypress](#using-cypress)
-- [Development](#development)
+-   [Installation](#installation)
+    -   [Bundling](#bundling)
+-   [Managing Consent](#managing-consent)
+    -   [`cmp.init(options)`](#cmpinitoptions)
+    -   [`cmp.hasInitialised()`](#cmphasinitialised)
+    -   [`cmp.willShowPrivacyMessage()`](#cmpwillshowprivacymessage)
+    -   [`cmp.willShowPrivacyMessageSync()`](#cmpwillshowprivacymessagesync)
+    -   [`cmp.showPrivacyManager()`](#cmpshowprivacymanager)
+-   [Using Consent](#using-consent)
+    -   [`onConsentChange(callback)`](#onconsentchangecallback)
+    -   [`getConsentFor(vendor, consentState)`](#getconsentforvendor-consentstate)
+-   [Disabling Consent](#disabling-consent)
+    -   [`cmp.__disable()`](#cmp__disable)
+    -   [`cmp.__enable()`](#cmp__enable)
+    -   [`cmp.__isDisabled()`](#cmp__isdisabled)
+    -   [Manually](#manually)
+    -   [Using Cypress](#using-cypress)
+-   [Development](#development)
 
 <!-- tocstop -->
 
@@ -91,7 +91,7 @@ Optional value identifying the unique pageview associated with this instance of 
 
 Will be used to link back to a `browserId` for further reporting; if possible this should be available via the pageview table.
 
-#### ~~`options.isInUsa`~~ 
+#### ~~`options.isInUsa`~~
 
 **DEPRECATED**
 
@@ -247,7 +247,7 @@ If the user is not in the USA, it will be `undefined`.
 
 type: `Object` or `undefined`
 
-Reports whether user has withdrawn consent to personalised adversising
+Reports whether user has withdrawn consent to personalised advertising
 in Australia.
 
 If the user is not in Australia, it will be `undefined`.

--- a/src/aus/getConsentState.ts
+++ b/src/aus/getConsentState.ts
@@ -1,7 +1,7 @@
 import type { AUSConsentState } from '../types/aus';
 import { getUSPData } from './api';
 
-// get the current constent state using the official IAB method
+// get the current consent state using the official IAB method
 export const getConsentState: () => Promise<AUSConsentState> = async () => {
 	const uspData = await getUSPData();
 

--- a/src/aus/sourcepoint.ts
+++ b/src/aus/sourcepoint.ts
@@ -9,8 +9,8 @@ export const willShowPrivacyMessage = new Promise<boolean>((resolve) => {
 	resolveWillShowPrivacyMessage = resolve as typeof Promise.resolve;
 });
 
-// the 'getCustomVendorRejects' option of SP's implementation of __uspapi
-// is a custom extension. It hits SP's servers, but unlike the rest of the
+// the 'getCustomVendorRejects' option of SP’s implementation of __uspapi
+// is a custom extension. It hits SP’s servers, but unlike the rest of the
 // __uspapi, it doesn't implement a queue.
 // the only way we can be sure it has become available is to wait for a
 // SP event to fire, so we resolve this when we know it has loaded

--- a/src/ccpa/getConsentState.ts
+++ b/src/ccpa/getConsentState.ts
@@ -1,7 +1,7 @@
 import type { CCPAConsentState } from '../types/ccpa';
 import { getUSPData } from './api';
 
-// get the current constent state using the official IAB method
+// get the current consent state using the official IAB method
 export const getConsentState: () => Promise<CCPAConsentState> = async () => {
 	const uspData = await getUSPData();
 

--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -1,3 +1,5 @@
+// cSpell:ignore doesnotexist
+
 import { getConsentFor } from './getConsentFor';
 
 const googleAnalytics = '5e542b3a4cd8884eb41b5a72';

--- a/src/getFramework.test.js
+++ b/src/getFramework.test.js
@@ -1,5 +1,6 @@
 import { getFramework } from './getFramework';
 
+/* cSpell:disable */
 const countries = {
 	ccpa: [['UnitedStates', 'US']],
 	aus: [['Australia', 'AU']],
@@ -253,6 +254,7 @@ const countries = {
 		['Zimbabwe', 'ZW'],
 	],
 };
+/* cSpell:enable */
 
 describe('Match countries and framework', () => {
 	describe.each([
@@ -267,7 +269,7 @@ describe('Match countries and framework', () => {
 			},
 		);
 	});
-	describe('Unkown country gets TCFv2', () => {
+	describe('Unknown country gets TCFv2', () => {
 		it('should default to TCFv2 on ZZ', () =>
 			expect(getFramework('ZZ')).toEqual('tcfv2'));
 


### PR DESCRIPTION
## What does this change?

Adds a spell checker extension. Sets a few IAB and consent-specific keywords to the dictionary:

- Sourcepoint
- ccpa
- tcfv (the 2 is ignored)
- tcfapi
- uspapi 
- _etc._

## Why?

We all have MacBooks with butterfly keyboards.
