### PR TITLE
fix: make `@guardian/libs` a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@babel/runtime": "^7",
     "@guardian/eslint-config": "^0.5.0",
     "@guardian/eslint-config-typescript": "^0.5.0",
-    "@guardian/libs": "^1",
     "@guardian/prettier": "^0.5.0",
     "@rollup/plugin-babel": "^5",
     "@rollup/plugin-commonjs": "^19",
@@ -94,8 +93,7 @@
     "typescript": "^4",
     "wait-for-expect": "^3"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@guardian/libs": "^1"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
## What does this change?

It’s used in the code, and therefore is a regular dependency.

## Why?

Peer dependency is the wrong concept, and makes consumer applications (i.e. `frontend`) complain if we use v2 of the libs.
