### PR TITLE
fix: validate single commits

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true


### PR DESCRIPTION
## What does this change?

Forces single commits to be worded properly, because squash and merge does not use the PR title if you have only one commit.

## Why?

Whoops #467

Enabled in https://github.com/guardian/commercial-core/pull/191