### PR TITLE
feat!: Remove deprecated parameter `isInUsa`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ Optional value identifying the unique pageview associated with this instance of 
 
 Will be used to link back to a `browserId` for further reporting; if possible this should be available via the pageview table.
 
-#### ~~`options.isInUsa`~~
-
-**DEPRECATED**
-
-Will be removed in next major version. Use `options.country` instead.
-
 #### Example
 
 ```js

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -204,21 +204,3 @@ describe('cmp.showPrivacyManager', () => {
 		);
 	});
 });
-
-describe('Old API parameter `isInUsa`', () => {
-	it('Should handle `{ isInUsa: true }`', () => {
-		cmp.init({ isInUsa: true });
-		expect(CCPA.init).toHaveBeenCalledTimes(1);
-	});
-
-	it('Should handle `{ isInUsa: false }`', () => {
-		cmp.init({ isInUsa: false });
-		expect(TCFv2.init).toHaveBeenCalledTimes(1);
-	});
-
-	it('Should throw an error if neither is passed', () => {
-		expect(() => {
-			cmp.init({});
-		}).toThrow('required');
-	});
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,7 @@ const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
-const init: InitCMP = ({
-	pubData,
-	country
-}) => {
+const init: InitCMP = ({ pubData, country }) => {
 	if (isDisabled()) return;
 
 	if (window.guCmpHotFix.initialised) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ const initialised = new Promise((resolve) => {
 
 const init: InitCMP = ({
 	pubData,
-	country,
-	isInUsa, // DEPRECATED: Will be removed in next major version
+	country
 }) => {
 	if (isDisabled()) return;
 
@@ -48,14 +47,6 @@ const init: InitCMP = ({
 	// prevent another instance of CMP initialising, so we set this true asap.
 	// initComplete is set true once we have _finished_ initialising
 	window.guCmpHotFix.initialised = true;
-
-	if (typeof isInUsa !== 'undefined') {
-		country = isInUsa ? 'US' : 'GB';
-
-		console.warn(
-			'`isInUsa` will soon be deprecated. Prefer using `country` instead.',
-		);
-	}
 
 	if (typeof country === 'undefined') {
 		throw new Error(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,10 +17,7 @@ export type CMP = {
 	__enable: () => void;
 };
 
-export type InitCMP = (arg0: {
-	pubData?: PubData;
-	country?: Country;
-}) => void;
+export type InitCMP = (arg0: { pubData?: PubData; country?: Country }) => void;
 
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,6 @@ export type CMP = {
 export type InitCMP = (arg0: {
 	pubData?: PubData;
 	country?: Country;
-	isInUsa?: boolean;
 }) => void;
 
 export interface ConsentState {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Remove deprecated paramter `isInUsa` from paramters of `cmp.init`

## Why?
The parameter has been deprecated in favour of `country`
