### PR TITLE
chore!: conventional commit preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,5 +5,6 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
     "@semantic-release/github"
-  ]
+  ],
+  "preset": "conventionalcommits"
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/jest": "^26",
     "@typescript-eslint/eslint-plugin": "^4",
     "@typescript-eslint/parser": "^4",
+    "conventional-changelog-conventionalcommits": "^4.6.0",
     "cypress": "^8",
     "cypress-wait-until": "^1",
     "eslint": "^7",
@@ -91,7 +92,6 @@
     "wait-for-expect": "^3"
   },
   "dependencies": {
-    "@guardian/libs": "^1",
-    "conventional-changelog-conventionalcommits": "^4.6.0"
+    "@guardian/libs": "^1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "wait-for-expect": "^3"
   },
   "dependencies": {
-    "@guardian/libs": "^1"
+    "@guardian/libs": "^1",
+    "conventional-changelog-conventionalcommits": "^4.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,6 +3370,15 @@ conventional-changelog-angular@^5.0.0:
     compare-func "^2.0.0"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz#7fc17211dbca160acf24687bd2fdd5fd767750eb"
+  integrity sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-writer@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz#1ca7880b75aa28695ad33312a1f2366f4b12659f"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Add dependency [conventional-changelog-conventionalcommits](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits) and add preset conventionalcommits to `.releaserc`

## Why?
This allows the use inclusion of `!` in commit messages to trigger major releases. 
