### PR TITLE
fix: accept more compatible @guardian/libs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "wait-for-expect": "^3"
   },
   "dependencies": {
-    "@guardian/libs": "1.x.x - 3.x.x"
+    "@guardian/libs": "1.6.1 - 3.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
-"@guardian/libs@^1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
-  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
+"@guardian/libs@1.6.1 - 3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
+  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
 "@guardian/prettier@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What does this change?

Allows v2 and v3 of @guardian/libs to be used in consuming packages.

## Why?

I saw https://github.com/guardian/commercial-core/pull/397/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR487