### PR TITLE
 fix: Fix CCPA for Unified Implementation 

### DIFF
--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -32,6 +32,7 @@ const getConsentState: () => Promise<ConsentState> = async () => {
 
 // invokes all stored callbacks with the current consent state
 export const invokeCallbacks = (): void => {
+	if (callBackQueue.length == 0) return;
 	void getConsentState().then((state) => {
 		callBackQueue.forEach((callback) => invokeCallback(callback, state));
 	});

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -6,6 +6,10 @@ import { init } from './sourcepoint';
 const frameworks = ['tcfv2', 'ccpa', 'aus'];
 
 describe('Sourcepoint unified', () => {
+	beforeEach(() => {
+		window.__tcfapi = undefined;
+		window.__uspapi = undefined;
+	});
 	afterEach(() => {
 		window._sp_ = undefined;
 	});
@@ -30,27 +34,28 @@ describe('Sourcepoint unified', () => {
 			expect(typeof window._sp_.config.events.onMessageReceiveData).toBe(
 				'function',
 			);
+
 			if (framework == 'tcfv2') {
 				expect(
 					window._sp_.config.gdpr.targetingParams.framework,
 				).toEqual(framework);
-				expect(window._sp_.config.ccpa).toEqual(undefined);
+				expect(window._sp_.config.ccpa).toBeUndefined();
+				expect(window.__tcfapi).toBeDefined();
+				expect(window.__uspapi).toBeUndefined();
 			} else {
 				expect(
 					window._sp_.config.ccpa.targetingParams.framework,
 				).toEqual(framework);
-				expect(window._sp_.config.gdpr).toEqual(undefined);
+				expect(window._sp_.config.gdpr).toBeUndefined;
+				expect(window.__uspapi).toBeDefined();
+				expect(window.__tcfapi).toBeUndefined();
 			}
 		},
 	);
 
-	it.each(frameworks)('injects the lib', (framework) => {
-		init(framework);
-		expect(document.getElementById('sourcepoint-lib')).toBeTruthy();
-	});
-
 	it.each(frameworks)('points at a real file', (framework, done) => {
 		init(framework);
+		expect(document.getElementById('sourcepoint-lib')).toBeTruthy();
 		const src = document
 			.getElementById('sourcepoint-lib')
 			?.getAttribute('src');

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -33,11 +33,13 @@ describe('Sourcepoint unified', () => {
 			if (framework == 'tcfv2') {
 				expect(
 					window._sp_.config.gdpr.targetingParams.framework,
-				).toEqual('tcfv2');
+				).toEqual(framework);
+				expect(window._sp_.config.ccpa).toEqual(undefined);
 			} else {
 				expect(
 					window._sp_.config.ccpa.targetingParams.framework,
 				).toEqual(framework);
+				expect(window._sp_.config.gdpr).toEqual(undefined);
 			}
 		},
 	);

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -26,7 +26,7 @@ const getProperty = (framework: Framework): Property => {
 };
 
 export const init = (framework: Framework, pubData = {}): void => {
-	stub();
+	stub(framework);
 
 	// make sure nothing else on the page has accidentally
 	// used the `_sp_` name as well
@@ -55,6 +55,8 @@ export const init = (framework: Framework, pubData = {}): void => {
 				framework,
 			},
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
+
+			// ccpa or gdpr object added below
 
 			events: {
 				onConsentReady: (message_type, consentUUID, euconsent) => {
@@ -152,6 +154,10 @@ export const init = (framework: Framework, pubData = {}): void => {
 		},
 	};
 
+	// NOTE - Contrary to the SourcePoint documentation, it's important that we add EITHER gdpr OR ccpa
+	// to the _sp_ object. wrapperMessagingWithoutDetection.js uses the presence of these keys to attach
+	// __tcfapi or __uspapi to the window object respectively. If both of these functions appear on the window,
+	// advertisers seem to assume that __tcfapi is the one to use, breaking CCPA consent.
 	if (framework === 'tcfv2') {
 		window._sp_.config.gdpr = {
 			targetingParams: {

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -54,9 +54,6 @@ export const init = (framework: Framework, pubData = {}): void => {
 			targetingParams: {
 				framework,
 			},
-			ccpa: {},
-			gdpr: {},
-
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
 
 			events: {
@@ -156,12 +153,16 @@ export const init = (framework: Framework, pubData = {}): void => {
 	};
 
 	if (framework === 'tcfv2') {
-		window._sp_.config.gdpr.targetingParams = {
-			framework,
+		window._sp_.config.gdpr = {
+			targetingParams: {
+				framework,
+			},
 		};
 	} else {
-		window._sp_.config.ccpa.targetingParams = {
-			framework,
+		window._sp_.config.ccpa = {
+			targetingParams: {
+				framework,
+			},
 		};
 	}
 

--- a/src/stub.d.ts
+++ b/src/stub.d.ts
@@ -1,1 +1,3 @@
-export declare const stub: () => void;
+import type { Framework } from './types';
+
+export declare const stub: (framework: Framework) => void;

--- a/src/stub.js
+++ b/src/stub.js
@@ -4,7 +4,6 @@
 // documentation.sourcepoint.com/implementation/web-implementation/multi-campaign-web-implementation#stub-file
 
 const stub_tcfv2 = () => {
-	// tcfv2
 	!(function (t) {
 		var e = {};
 		function n(r) {
@@ -358,6 +357,5 @@ export const stub = (framework) => {
 	// for the framework currently in use. The presence of __tcfapi on the window object signals to GPT
 	// that it should take precedence over __uspapi
 	if (framework == 'tcfv2') stub_tcfv2();
-	// stub_tcfv2();
 	else stub_ccpa();
 };

--- a/src/stub.js
+++ b/src/stub.js
@@ -1,65 +1,9 @@
 /* eslint-disable -- this is third party code */
 /* istanbul ignore file */
 
-// https://documentation.sourcepoint.com/web-implementation/web-implementation/sourcepoint-gdpr-and-tcf-v2-support/gdpr-and-tcf-v2-setup-and-configuration_v1.1.3
+// documentation.sourcepoint.com/implementation/web-implementation/multi-campaign-web-implementation#stub-file
 
-export const stub = () => {
-	// ccpa
-	(function () {
-		var e = false;
-		var c = window;
-		var t = document;
-		function r() {
-			if (!c.frames['__uspapiLocator']) {
-				if (t.body) {
-					var a = t.body;
-					var e = t.createElement('iframe');
-					e.style.cssText = 'display:none';
-					e.name = '__uspapiLocator';
-					a.appendChild(e);
-				} else {
-					setTimeout(r, 5);
-				}
-			}
-		}
-		r();
-		function p() {
-			var a = arguments;
-			__uspapi.a = __uspapi.a || [];
-			if (!a.length) {
-				return __uspapi.a;
-			} else if (a[0] === 'ping') {
-				a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true);
-			} else {
-				__uspapi.a.push([].slice.apply(a));
-			}
-		}
-		function l(t) {
-			var r = typeof t.data === 'string';
-			try {
-				var a = r ? JSON.parse(t.data) : t.data;
-				if (a.__cmpCall) {
-					var n = a.__cmpCall;
-					c.__uspapi(n.command, n.parameter, function (a, e) {
-						var c = {
-							__cmpReturn: {
-								returnValue: a,
-								success: e,
-								callId: n.callId,
-							},
-						};
-						t.source.postMessage(r ? JSON.stringify(c) : c, '*');
-					});
-				}
-			} catch (a) {}
-		}
-		if (typeof __uspapi !== 'function') {
-			c.__uspapi = p;
-			__uspapi.msgHandler = l;
-			c.addEventListener('message', l, false);
-		}
-	})();
-
+const stub_tcfv2 = () => {
 	// tcfv2
 	!(function (t) {
 		var e = {};
@@ -350,4 +294,70 @@ export const stub = () => {
 			};
 		},
 	]);
+};
+
+const stub_ccpa = () => {
+	(function () {
+		var e = false;
+		var c = window;
+		var t = document;
+		function r() {
+			if (!c.frames['__uspapiLocator']) {
+				if (t.body) {
+					var a = t.body;
+					var e = t.createElement('iframe');
+					e.style.cssText = 'display:none';
+					e.name = '__uspapiLocator';
+					a.appendChild(e);
+				} else {
+					setTimeout(r, 5);
+				}
+			}
+		}
+		r();
+		function p() {
+			var a = arguments;
+			__uspapi.a = __uspapi.a || [];
+			if (!a.length) {
+				return __uspapi.a;
+			} else if (a[0] === 'ping') {
+				a[2]({ gdprAppliesGlobally: e, cmpLoaded: false }, true);
+			} else {
+				__uspapi.a.push([].slice.apply(a));
+			}
+		}
+		function l(t) {
+			var r = typeof t.data === 'string';
+			try {
+				var a = r ? JSON.parse(t.data) : t.data;
+				if (a.__cmpCall) {
+					var n = a.__cmpCall;
+					c.__uspapi(n.command, n.parameter, function (a, e) {
+						var c = {
+							__cmpReturn: {
+								returnValue: a,
+								success: e,
+								callId: n.callId,
+							},
+						};
+						t.source.postMessage(r ? JSON.stringify(c) : c, '*');
+					});
+				}
+			} catch (a) {}
+		}
+		if (typeof __uspapi !== 'function') {
+			c.__uspapi = p;
+			__uspapi.msgHandler = l;
+			c.addEventListener('message', l, false);
+		}
+	})();
+};
+
+export const stub = (framework) => {
+	// NOTE - Contrary to the SourcePoint documentation, it's important that we only run the stub file
+	// for the framework currently in use. The presence of __tcfapi on the window object signals to GPT
+	// that it should take precedence over __uspapi
+	if (framework == 'tcfv2') stub_tcfv2();
+	// stub_tcfv2();
+	else stub_ccpa();
 };

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -32,12 +32,12 @@ declare global {
 				targetingParams: {
 					framework: Framework;
 				};
-				ccpa: {
+				ccpa?: {
 					targetingParams?: {
 						framework: Framework;
 					};
 				};
-				gdpr: {
+				gdpr?: {
 					targetingParams?: {
 						framework: Framework;
 					};


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Fixes a regression introduced in version 9.0.0 which breaks advertising in CCPA regions by adding both __tcfapi and __uspapi functions to the window object. Advertisers assume that if __tcfapi is defined, it should take precedence over __uspapi.
This pull request fixes the issue by:
- Running either TCFv2 or CCPA stub file depending on framework so that before `wrapperMessagingWithoutDetection.js` is run, only one of the functions is defined.
- Adding either gdpr or ccpa object to _sp_ depending on framework. `wrapperMessagingWithoutDetection.js` uses the presence of these keys to determine which function to attach to `window`.
Note that neither of these changes is recommended by SourcePoint in their documentation. They are necessary because this consent management platform determines framework based on the country code passed to `init` rather than relying on SourcePoint's geolocation.
