### PR TITLE
fix: Wait for user action to trigger callbacks in TCFv2

### DIFF
--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -186,4 +186,33 @@ describe('under TCFv2', () => {
 			expect(callback).toHaveBeenCalledTimes(2);
 		});
 	});
+
+	it('invokes callbacks only if there is a user action', async () => {
+		const callback = jest.fn();
+
+		tcData.eventStatus = 'cmpuishown';
+
+		onConsentChange(callback);
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(0);
+		});
+
+		tcData.eventStatus = 'useractioncomplete';
+
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		});
+
+		tcData.eventStatus = 'tcloaded';
+
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -8,6 +8,11 @@ import type { Callback, CallbackQueueItem, ConsentState } from './types';
 const callBackQueue: CallbackQueueItem[] = [];
 
 const invokeCallback = (callback: CallbackQueueItem, state: ConsentState) => {
+	// In TCFv2, Don’t only invoke callbacks if event status is either:
+	// - useractioncomplete
+	// - cmpuishown
+	if (state.tcfv2?.eventStatus === 'cmpuishown') return;
+
 	const stateString = JSON.stringify(state);
 
 	// only invoke callback if the consent state has changed

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -7,7 +7,17 @@ import type { Callback, CallbackQueueItem, ConsentState } from './types';
 // callbacks cache
 const callBackQueue: CallbackQueueItem[] = [];
 
+/**
+ * In TCFv2, check whether the event status anything but `cmpuishown`, i.e.:
+ * - `useractioncomplete`
+ * - `tcloaded`
+ */
+const awaitingUserInteractionInTCFv2 = (state: ConsentState): boolean =>
+	state.tcfv2?.eventStatus === 'cmpuishown';
+
 const invokeCallback = (callback: CallbackQueueItem, state: ConsentState) => {
+	if (awaitingUserInteractionInTCFv2(state)) return;
+
 	const stateString = JSON.stringify(state);
 
 	// only invoke callback if the consent state has changed
@@ -34,10 +44,7 @@ const getConsentState: () => Promise<ConsentState> = async () => {
 export const invokeCallbacks = (): void => {
 	if (callBackQueue.length === 0) return;
 	void getConsentState().then((state) => {
-		// In TCFv2, Don’t only invoke callbacks if event status is either:
-		// - useractioncomplete
-		// - cmpuishown
-		if (state.tcfv2?.eventStatus === 'cmpuishown') return;
+		if (awaitingUserInteractionInTCFv2(state)) return;
 
 		callBackQueue.forEach((callback) => invokeCallback(callback, state));
 	});
@@ -49,7 +56,7 @@ export const onConsentChange: (fn: Callback) => void = (callBack) => {
 	callBackQueue.push(newCallback);
 
 	// if consentState is already available, invoke callback immediately
-	getConsentState()
+	void getConsentState()
 		.then((consentState) => {
 			invokeCallback(newCallback, consentState);
 		})

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -8,11 +8,6 @@ import type { Callback, CallbackQueueItem, ConsentState } from './types';
 const callBackQueue: CallbackQueueItem[] = [];
 
 const invokeCallback = (callback: CallbackQueueItem, state: ConsentState) => {
-	// In TCFv2, Don’t only invoke callbacks if event status is either:
-	// - useractioncomplete
-	// - cmpuishown
-	if (state.tcfv2?.eventStatus === 'cmpuishown') return;
-
 	const stateString = JSON.stringify(state);
 
 	// only invoke callback if the consent state has changed
@@ -39,6 +34,11 @@ const getConsentState: () => Promise<ConsentState> = async () => {
 export const invokeCallbacks = (): void => {
 	if (callBackQueue.length === 0) return;
 	void getConsentState().then((state) => {
+		// In TCFv2, Don’t only invoke callbacks if event status is either:
+		// - useractioncomplete
+		// - cmpuishown
+		if (state.tcfv2?.eventStatus === 'cmpuishown') return;
+
 		callBackQueue.forEach((callback) => invokeCallback(callback, state));
 	});
 };


### PR DESCRIPTION
## What does this change?

Wait for user action to trigger callbacks in TCFv2. If `eventStatus` is `'cmpuishown'`, don’t trigger the callbacks.

## Why?

Otherwise, we always get a state similar to “Reject All” as the first state, very shortly followed by the actual one chosen by the user.
