### PR TITLE
feat: Define and export type `VendorName`

### DIFF
--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -35,10 +35,10 @@ enum VendorIDs {
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
-export type Vendor = keyof typeof VendorIDs;
+export type VendorName = keyof typeof VendorIDs;
 
 export const getConsentFor = (
-	vendor: Vendor,
+	vendor: VendorName,
 	consent: ConsentState,
 ): boolean => {
 	const sourcepointId = VendorIDs[vendor];

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -35,8 +35,10 @@ enum VendorIDs {
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
+export type Vendor = keyof typeof VendorIDs;
+
 export const getConsentFor = (
-	vendor: keyof typeof VendorIDs,
+	vendor: Vendor,
 	consent: ConsentState,
 ): boolean => {
 	const sourcepointId = VendorIDs[vendor];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { Vendor } from '../getConsentFor';
 import type { AUSConsentState } from './aus';
 import type { CCPAConsentState } from './ccpa';
 import type { Country } from './countries';
@@ -49,3 +50,5 @@ export interface VendorConsents {
 		}
 	>;
 }
+
+export type { Vendor };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Vendor } from '../getConsentFor';
+import type { VendorName } from '../getConsentFor';
 import type { AUSConsentState } from './aus';
 import type { CCPAConsentState } from './ccpa';
 import type { Country } from './countries';
@@ -51,4 +51,4 @@ export interface VendorConsents {
 	>;
 }
 
-export type { Vendor };
+export type { VendorName };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
- Export type `VendorName`, an enum of the vendors supported by the CMP (`'a9' | 'acast' | 'braze' `, etc.)

## Why?
`VendorName` needs to be imported by consumers of `getConsentFor` so that they can be converted to TypeScript.
