### PR TITLE
feat: Make initialising the CMP server-safe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,13 @@ import type {
 } from './types';
 import type { Country } from './types/countries';
 
+const isServerSide = typeof window === 'undefined';
+
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
-window.guCmpHotFix ||= {};
+if (!isServerSide) {
+	window.guCmpHotFix ||= {};
+}
 
 let frameworkCMP: SourcepointImplementation | undefined;
 
@@ -26,12 +30,13 @@ let _willShowPrivacyMessage: undefined | boolean;
 let initComplete = false;
 
 let resolveInitialised: (value?: unknown) => void;
+
 const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
 const init: InitCMP = ({ pubData, country }) => {
-	if (isDisabled()) return;
+	if (isDisabled() || isServerSide) return;
 
 	if (window.guCmpHotFix.initialised) {
 		if (window.guCmpHotFix.cmp?.version !== __PACKAGE_VERSION__)
@@ -106,39 +111,50 @@ const showPrivacyManager = () => {
 	void initialised.then(frameworkCMP?.showPrivacyManager);
 };
 
-export const cmp: CMP = (window.guCmpHotFix.cmp ||=
-	// On the server return a CMP object
-	typeof window === 'undefined'
-		? {
-				init: (_: { pubData?: PubData; country?: Country }) => void 0,
-				showPrivacyManager: () => {
-					void 0;
-				},
-				willShowPrivacyMessage: () => new Promise(() => false),
-				willShowPrivacyMessageSync: () => false,
-				hasInitialised: () => true,
-				version: __PACKAGE_VERSION__,
+export const cmp: CMP = (() => {
+	if (isServerSide) {
+		return {
+			init: (_: { pubData?: PubData; country?: Country }) => void 0,
+			showPrivacyManager: () => {
+				void 0;
+			},
+			willShowPrivacyMessage: () => new Promise(() => false),
+			willShowPrivacyMessageSync: () => false,
+			hasInitialised: () => true,
+			version: __PACKAGE_VERSION__,
 
-				// special helper methods for disabling CMP
-				__isDisabled: isDisabled,
-				__enable: enable,
-				__disable: disable,
-		  }
-		: {
-				init,
-				willShowPrivacyMessage,
-				willShowPrivacyMessageSync,
-				hasInitialised,
-				showPrivacyManager,
-				version: __PACKAGE_VERSION__,
+			// special helper methods for disabling CMP
+			__isDisabled: isDisabled,
+			__enable: enable,
+			__disable: disable,
+		} as CMP;
+	}
 
-				// special helper methods for disabling CMP
-				__isDisabled: isDisabled,
-				__enable: enable,
-				__disable: disable,
-		  });
+	return (window.guCmpHotFix.cmp ||= {
+		init,
+		willShowPrivacyMessage,
+		willShowPrivacyMessageSync,
+		hasInitialised,
+		showPrivacyManager,
+		version: __PACKAGE_VERSION__,
 
-export const onConsentChange = (window.guCmpHotFix.onConsentChange ||=
-	actualOnConsentChange);
-export const getConsentFor = (window.guCmpHotFix.getConsentFor ||=
-	actualGetConsentFor);
+		// special helper methods for disabling CMP
+		__isDisabled: isDisabled,
+		__enable: enable,
+		__disable: disable,
+	});
+})();
+
+export const onConsentChange = (() => {
+	if (isServerSide) {
+		return () => void 0;
+	}
+	return (window.guCmpHotFix.onConsentChange ||= actualOnConsentChange);
+})();
+
+export const getConsentFor = (() => {
+	if (isServerSide) {
+		actualGetConsentFor;
+	}
+	return (window.guCmpHotFix.getConsentFor ||= actualGetConsentFor);
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,9 @@ import { TCFv2 } from './tcfv2';
 import type {
 	CMP,
 	InitCMP,
-	PubData,
 	SourcepointImplementation,
 	WillShowPrivacyMessage,
 } from './types';
-import type { Country } from './types/countries';
 
 const isServerSide = typeof window === 'undefined';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export const onConsentChange = (() => {
 
 export const getConsentFor = (() => {
 	if (isServerSide) {
-		actualGetConsentFor;
+		return actualGetConsentFor;
 	}
 	return (window.guCmpHotFix.getConsentFor ||= actualGetConsentFor);
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const showPrivacyManager = () => {
 export const cmp: CMP = (() => {
 	if (isServerSide) {
 		return {
-			init: (_: { pubData?: PubData; country?: Country }) => void 0,
+			init: () => void 0,
 			showPrivacyManager: () => void 0,
 			willShowPrivacyMessage: () => new Promise(() => false),
 			willShowPrivacyMessageSync: () => false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,9 +115,7 @@ export const cmp: CMP = (() => {
 	if (isServerSide) {
 		return {
 			init: (_: { pubData?: PubData; country?: Country }) => void 0,
-			showPrivacyManager: () => {
-				void 0;
-			},
+			showPrivacyManager: () => void 0,
 			willShowPrivacyMessage: () => new Promise(() => false),
 			willShowPrivacyMessageSync: () => false,
 			hasInitialised: () => true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,11 @@ import { TCFv2 } from './tcfv2';
 import type {
 	CMP,
 	InitCMP,
+	PubData,
 	SourcepointImplementation,
 	WillShowPrivacyMessage,
 } from './types';
+import type { Country } from './types/countries';
 
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
@@ -104,19 +106,37 @@ const showPrivacyManager = () => {
 	void initialised.then(frameworkCMP?.showPrivacyManager);
 };
 
-export const cmp: CMP = (window.guCmpHotFix.cmp ||= {
-	init,
-	willShowPrivacyMessage,
-	willShowPrivacyMessageSync,
-	hasInitialised,
-	showPrivacyManager,
-	version: __PACKAGE_VERSION__,
+export const cmp: CMP = (window.guCmpHotFix.cmp ||=
+	// On the server return a CMP object
+	typeof window === 'undefined'
+		? {
+				init: (_: { pubData?: PubData; country?: Country }) => void 0,
+				showPrivacyManager: () => {
+					void 0;
+				},
+				willShowPrivacyMessage: () => new Promise(() => false),
+				willShowPrivacyMessageSync: () => false,
+				hasInitialised: () => true,
+				version: __PACKAGE_VERSION__,
 
-	// special helper methods for disabling CMP
-	__isDisabled: isDisabled,
-	__enable: enable,
-	__disable: disable,
-});
+				// special helper methods for disabling CMP
+				__isDisabled: isDisabled,
+				__enable: enable,
+				__disable: disable,
+		  }
+		: {
+				init,
+				willShowPrivacyMessage,
+				willShowPrivacyMessageSync,
+				hasInitialised,
+				showPrivacyManager,
+				version: __PACKAGE_VERSION__,
+
+				// special helper methods for disabling CMP
+				__isDisabled: isDisabled,
+				__enable: enable,
+				__disable: disable,
+		  });
 
 export const onConsentChange = (window.guCmpHotFix.onConsentChange ||=
 	actualOnConsentChange);

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,7 +1,16 @@
 let isGuardian: boolean | undefined;
 
+const isServerSide = typeof window === 'undefined';
+
 export const isGuardianDomain = (): boolean => {
-	if (typeof isGuardian === 'undefined')
-		isGuardian = window.location.host.endsWith('.theguardian.com');
+	if (typeof isGuardian === 'undefined') {
+		// If this code is running server-side set isGuardian to a sensible default
+		if (isServerSide) {
+			isGuardian = true;
+		} else {
+			isGuardian = window.location.host.endsWith('.theguardian.com');
+		}
+	}
+
 	return isGuardian;
 };


### PR DESCRIPTION
## What does this change?

This PR attempts to make initialising the CMP in a server environment (where there is no `window`) safe to do.

## Why?

From the suggestion in to https://github.com/guardian/dotcom-rendering/pull/3925 
