### PR TITLE
Allow multiple sourcepoint IDs for each vendor ID

### DIFF
--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -55,7 +55,7 @@ it('the vendor ids used must be a subset of those known by the IAB as our vendor
 		guardianVendorListUrl,
 	);
 
-	const vendorIds = Object.values(VendorIDs);
+	const vendorIds = Object.values(VendorIDs).flat();
 
 	const iabVendorIds = iabGuardianVendorListResponse.data['vendors'].map(
 		(vendor) => vendor['_id'],

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -1,36 +1,31 @@
 import type { ConsentState, GetConsentFor } from './types';
 
-/* eslint-disable @typescript-eslint/naming-convention
-   --
-   these are API names, and we want them like this
-*/
 export const VendorIDs = {
 	// keep the list in README.md up to date with these values
-	'a9': ['5f369a02b8e05c308701f829'],
-	'acast': ['5f203dcb1f0dea790562e20f'],
-	'braze': ['5ed8c49c4b8ce4571c7ad801'],
-	'comscore': ['5efefe25b8e05c06542b2a77'],
-	'fb': ['5e7e1298b8e05c54a85c52d2'],
+	a9: ['5f369a02b8e05c308701f829'],
+	acast: ['5f203dcb1f0dea790562e20f'],
+	braze: ['5ed8c49c4b8ce4571c7ad801'],
+	comscore: ['5efefe25b8e05c06542b2a77'],
+	fb: ['5e7e1298b8e05c54a85c52d2'],
 	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
 	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
 	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],
-	'googletag': ['5f1aada6b8e05c306c0597d7'],
-	'ias': ['5e7ced57b8e05c485246ccf3'],
-	'inizio': ['5e37fc3e56a5e6615502f9c9'],
-	'ipsos': ['5f745ab96f3aae0163740409'],
-	'lotame': ['5ed6aeb1b8e05c241a63c71f'],
-	'nielsen': ['5ef5c3a5b8e05c69980eaa5b'],
-	'ophan': ['5f203dbeeaaaa8768fd3226a'],
-	'permutive': ['5eff0d77969bfa03746427eb'],
-	'prebid': ['5f92a62aa22863685f4daa4c'],
-	'redplanet': ['5f199c302425a33f3f090f51'],
-	'remarketing': ['5ed0eb688a76503f1016578f'],
-	'sentry': ['5f0f39014effda6e8bbd2006'],
-	'teads': ['5eab3d5ab8e05c2bbe33f399'],
-	'twitter': ['5e71760b69966540e4554f01'],
+	googletag: ['5f1aada6b8e05c306c0597d7'],
+	ias: ['5e7ced57b8e05c485246ccf3'],
+	inizio: ['5e37fc3e56a5e6615502f9c9'],
+	ipsos: ['5f745ab96f3aae0163740409'],
+	lotame: ['5ed6aeb1b8e05c241a63c71f'],
+	nielsen: ['5ef5c3a5b8e05c69980eaa5b'],
+	ophan: ['5f203dbeeaaaa8768fd3226a'],
+	permutive: ['5eff0d77969bfa03746427eb'],
+	prebid: ['5f92a62aa22863685f4daa4c'],
+	redplanet: ['5f199c302425a33f3f090f51'],
+	remarketing: ['5ed0eb688a76503f1016578f'],
+	sentry: ['5f0f39014effda6e8bbd2006'],
+	teads: ['5eab3d5ab8e05c2bbe33f399'],
+	twitter: ['5e71760b69966540e4554f01'],
 	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
-}
-/* eslint-enable @typescript-eslint/naming-convention */
+};
 
 export type VendorName = keyof typeof VendorIDs;
 
@@ -43,7 +38,7 @@ export const getConsentFor: GetConsentFor = (
 	if (typeof sourcepointIds === 'undefined' || sourcepointIds === []) {
 		throw new Error(
 			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
-			'If it should be added, raise an issue at https://git.io/JUzVL',
+				'If it should be added, raise an issue at https://git.io/JUzVL',
 		);
 	}
 
@@ -58,8 +53,8 @@ export const getConsentFor: GetConsentFor = (
 	}
 
 	const foundSourcepointId = sourcepointIds.find(
-		id => typeof consent.tcfv2?.vendorConsents[id] !== 'undefined'
-	)
+		(id) => typeof consent.tcfv2?.vendorConsents[id] !== 'undefined',
+	);
 
 	if (typeof foundSourcepointId === 'undefined') {
 		console.warn(

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -1,4 +1,4 @@
-import type { ConsentState } from './types';
+import type { ConsentState, GetConsentFor } from './types';
 
 /* eslint-disable @typescript-eslint/naming-convention
    --
@@ -34,7 +34,7 @@ export enum VendorIDs {
 
 export type VendorName = keyof typeof VendorIDs;
 
-export const getConsentFor = (
+export const getConsentFor: GetConsentFor = (
 	vendor: VendorName,
 	consent: ConsentState,
 ): boolean => {

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -4,31 +4,31 @@ import type { ConsentState, GetConsentFor } from './types';
    --
    these are API names, and we want them like this
 */
-export enum VendorIDs {
+export const VendorIDs = {
 	// keep the list in README.md up to date with these values
-	'a9' = '5f369a02b8e05c308701f829',
-	'acast' = '5f203dcb1f0dea790562e20f',
-	'braze' = '5ed8c49c4b8ce4571c7ad801',
-	'comscore' = '5efefe25b8e05c06542b2a77',
-	'fb' = '5e7e1298b8e05c54a85c52d2',
-	'google-analytics' = '5e542b3a4cd8884eb41b5a72',
-	'google-mobile-ads' = '5f1aada6b8e05c306c0597d7',
-	'google-tag-manager' = '5e952f6107d9d20c88e7c975',
-	'googletag' = '5f1aada6b8e05c306c0597d7',
-	'ias' = '5e7ced57b8e05c485246ccf3',
-	'inizio' = '5e37fc3e56a5e6615502f9c9',
-	'ipsos' = '5f745ab96f3aae0163740409',
-	'lotame' = '5ed6aeb1b8e05c241a63c71f',
-	'nielsen' = '5ef5c3a5b8e05c69980eaa5b',
-	'ophan' = '5f203dbeeaaaa8768fd3226a',
-	'permutive' = '5eff0d77969bfa03746427eb',
-	'prebid' = '5f92a62aa22863685f4daa4c',
-	'redplanet' = '5f199c302425a33f3f090f51',
-	'remarketing' = '5ed0eb688a76503f1016578f',
-	'sentry' = '5f0f39014effda6e8bbd2006',
-	'teads' = '5eab3d5ab8e05c2bbe33f399',
-	'twitter' = '5e71760b69966540e4554f01',
-	'youtube-player' = '5e7ac3fae30e7d1bc1ebf5e8',
+	'a9': ['5f369a02b8e05c308701f829'],
+	'acast': ['5f203dcb1f0dea790562e20f'],
+	'braze': ['5ed8c49c4b8ce4571c7ad801'],
+	'comscore': ['5efefe25b8e05c06542b2a77'],
+	'fb': ['5e7e1298b8e05c54a85c52d2'],
+	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
+	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
+	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],
+	'googletag': ['5f1aada6b8e05c306c0597d7'],
+	'ias': ['5e7ced57b8e05c485246ccf3'],
+	'inizio': ['5e37fc3e56a5e6615502f9c9'],
+	'ipsos': ['5f745ab96f3aae0163740409'],
+	'lotame': ['5ed6aeb1b8e05c241a63c71f'],
+	'nielsen': ['5ef5c3a5b8e05c69980eaa5b'],
+	'ophan': ['5f203dbeeaaaa8768fd3226a'],
+	'permutive': ['5eff0d77969bfa03746427eb'],
+	'prebid': ['5f92a62aa22863685f4daa4c'],
+	'redplanet': ['5f199c302425a33f3f090f51'],
+	'remarketing': ['5ed0eb688a76503f1016578f'],
+	'sentry': ['5f0f39014effda6e8bbd2006'],
+	'teads': ['5eab3d5ab8e05c2bbe33f399'],
+	'twitter': ['5e71760b69966540e4554f01'],
+	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -38,10 +38,12 @@ export const getConsentFor: GetConsentFor = (
 	vendor: VendorName,
 	consent: ConsentState,
 ): boolean => {
-	const sourcepointId = VendorIDs[vendor];
-	if (typeof sourcepointId === 'undefined') {
+	const sourcepointIds = VendorIDs[vendor];
+
+	if (typeof sourcepointIds === 'undefined' || sourcepointIds === []) {
 		throw new Error(
-			`Vendor '${vendor}' not found. If it should be added, raise an issue at https://git.io/JUzVL`,
+			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
+			'If it should be added, raise an issue at https://git.io/JUzVL',
 		);
 	}
 
@@ -55,13 +57,26 @@ export const getConsentFor: GetConsentFor = (
 		return consent.aus.personalisedAdvertising;
 	}
 
+	const foundSourcepointId = sourcepointIds.find(
+		id => typeof consent.tcfv2?.vendorConsents[id] !== 'undefined'
+	)
+
+	if (typeof foundSourcepointId === 'undefined') {
+		console.warn(
+			`No consent returned from Sourcepoint for vendor: '${vendor}'`,
+		);
+		return false;
+	}
+
 	const tcfv2Consent: boolean | undefined =
-		consent.tcfv2?.vendorConsents[sourcepointId];
+		consent.tcfv2?.vendorConsents[foundSourcepointId];
+
 	if (typeof tcfv2Consent === 'undefined') {
 		console.warn(
 			`No consent returned from Sourcepoint for vendor: '${vendor}'`,
 		);
 		return false;
 	}
+
 	return tcfv2Consent;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,13 @@ import type {
 	WillShowPrivacyMessage,
 } from './types';
 
+const isServerSide = typeof window === 'undefined';
+
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
-window.guCmpHotFix ||= {};
+if (!isServerSide) {
+	window.guCmpHotFix ||= {};
+}
 
 let frameworkCMP: SourcepointImplementation | undefined;
 
@@ -24,12 +28,13 @@ let _willShowPrivacyMessage: undefined | boolean;
 let initComplete = false;
 
 let resolveInitialised: (value?: unknown) => void;
+
 const initialised = new Promise((resolve) => {
 	resolveInitialised = resolve;
 });
 
 const init: InitCMP = ({ pubData, country }) => {
-	if (isDisabled()) return;
+	if (isDisabled() || isServerSide) return;
 
 	if (window.guCmpHotFix.initialised) {
 		if (window.guCmpHotFix.cmp?.version !== __PACKAGE_VERSION__)
@@ -104,21 +109,48 @@ const showPrivacyManager = () => {
 	void initialised.then(frameworkCMP?.showPrivacyManager);
 };
 
-export const cmp: CMP = (window.guCmpHotFix.cmp ||= {
-	init,
-	willShowPrivacyMessage,
-	willShowPrivacyMessageSync,
-	hasInitialised,
-	showPrivacyManager,
-	version: __PACKAGE_VERSION__,
+export const cmp: CMP = (() => {
+	if (isServerSide) {
+		return {
+			init: () => void 0,
+			showPrivacyManager: () => void 0,
+			willShowPrivacyMessage: () => new Promise(() => false),
+			willShowPrivacyMessageSync: () => false,
+			hasInitialised: () => true,
+			version: __PACKAGE_VERSION__,
 
-	// special helper methods for disabling CMP
-	__isDisabled: isDisabled,
-	__enable: enable,
-	__disable: disable,
-});
+			// special helper methods for disabling CMP
+			__isDisabled: isDisabled,
+			__enable: enable,
+			__disable: disable,
+		} as CMP;
+	}
 
-export const onConsentChange = (window.guCmpHotFix.onConsentChange ||=
-	actualOnConsentChange);
-export const getConsentFor = (window.guCmpHotFix.getConsentFor ||=
-	actualGetConsentFor);
+	return (window.guCmpHotFix.cmp ||= {
+		init,
+		willShowPrivacyMessage,
+		willShowPrivacyMessageSync,
+		hasInitialised,
+		showPrivacyManager,
+		version: __PACKAGE_VERSION__,
+
+		// special helper methods for disabling CMP
+		__isDisabled: isDisabled,
+		__enable: enable,
+		__disable: disable,
+	});
+})();
+
+export const onConsentChange = (() => {
+	if (isServerSide) {
+		return () => void 0;
+	}
+	return (window.guCmpHotFix.onConsentChange ||= actualOnConsentChange);
+})();
+
+export const getConsentFor = (() => {
+	if (isServerSide) {
+		return actualGetConsentFor;
+	}
+	return (window.guCmpHotFix.getConsentFor ||= actualGetConsentFor);
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,16 @@ import { log } from '@guardian/libs';
 import { AUS } from './aus';
 import { CCPA } from './ccpa';
 import { disable, enable, isDisabled } from './disable';
-import { getConsentFor as actualGetConsentFor } from './getConsentFor';
+import { getConsentFor as clientGetConsentFor } from './getConsentFor';
 import { setCurrentFramework } from './getCurrentFramework';
 import { getFramework } from './getFramework';
-import { onConsentChange as actualOnConsentChange } from './onConsentChange';
+import { onConsentChange as clientOnConsentChange } from './onConsentChange';
+import {
+	isServerSide,
+	cmp as serverCmp,
+	getConsentFor as serverGetConsentFor,
+	onConsentChange as serverOnConsentChange,
+} from './server';
 import { TCFv2 } from './tcfv2';
 import type {
 	CMP,
@@ -13,8 +19,6 @@ import type {
 	SourcepointImplementation,
 	WillShowPrivacyMessage,
 } from './types';
-
-const isServerSide = typeof window === 'undefined';
 
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
@@ -109,48 +113,25 @@ const showPrivacyManager = () => {
 	void initialised.then(frameworkCMP?.showPrivacyManager);
 };
 
-export const cmp: CMP = (() => {
-	if (isServerSide) {
-		return {
-			init: () => void 0,
-			showPrivacyManager: () => void 0,
-			willShowPrivacyMessage: () => new Promise(() => false),
-			willShowPrivacyMessageSync: () => false,
-			hasInitialised: () => true,
+export const cmp: CMP = isServerSide
+	? serverCmp
+	: (window.guCmpHotFix.cmp ||= {
+			init,
+			willShowPrivacyMessage,
+			willShowPrivacyMessageSync,
+			hasInitialised,
+			showPrivacyManager,
 			version: __PACKAGE_VERSION__,
 
 			// special helper methods for disabling CMP
 			__isDisabled: isDisabled,
 			__enable: enable,
 			__disable: disable,
-		} as CMP;
-	}
+	  });
 
-	return (window.guCmpHotFix.cmp ||= {
-		init,
-		willShowPrivacyMessage,
-		willShowPrivacyMessageSync,
-		hasInitialised,
-		showPrivacyManager,
-		version: __PACKAGE_VERSION__,
-
-		// special helper methods for disabling CMP
-		__isDisabled: isDisabled,
-		__enable: enable,
-		__disable: disable,
-	});
-})();
-
-export const onConsentChange = (() => {
-	if (isServerSide) {
-		return () => void 0;
-	}
-	return (window.guCmpHotFix.onConsentChange ||= actualOnConsentChange);
-})();
-
-export const getConsentFor = (() => {
-	if (isServerSide) {
-		return actualGetConsentFor;
-	}
-	return (window.guCmpHotFix.getConsentFor ||= actualGetConsentFor);
-})();
+export const onConsentChange = isServerSide
+	? serverOnConsentChange
+	: (window.guCmpHotFix.onConsentChange ||= clientOnConsentChange);
+export const getConsentFor = isServerSide
+	? serverGetConsentFor
+	: (window.guCmpHotFix.getConsentFor ||= clientGetConsentFor);

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,6 +1,6 @@
-let isGuardian: boolean | undefined;
+import { isServerSide } from '../server';
 
-const isServerSide = typeof window === 'undefined';
+let isGuardian: boolean | undefined;
 
 export const isGuardianDomain = (): boolean => {
 	if (typeof isGuardian === 'undefined') {

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,7 +1,16 @@
 let isGuardian: boolean | undefined;
 
+const isServerSide = typeof window === 'undefined';
+
 export const isGuardianDomain = (): boolean => {
-	if (typeof isGuardian === 'undefined')
-		isGuardian = window.location.host.endsWith('.theguardian.com');
+	if (typeof isGuardian === 'undefined') {
+		// If this code is running server-side set isGuardian to a sensible default
+		if (isServerSide) {
+			isGuardian = true;
+		} else {
+			isGuardian = window.location.host.endsWith('.theguardian.com');
+		}
+	}
+
 	return isGuardian;
 };

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -185,4 +185,33 @@ describe('under TCFv2', () => {
 			expect(callback).toHaveBeenCalledTimes(2);
 		});
 	});
+
+	it('invokes callbacks only if there is a user action', async () => {
+		const callback = jest.fn();
+
+		tcData.eventStatus = 'cmpuishown';
+
+		onConsentChange(callback);
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(0);
+		});
+
+		tcData.eventStatus = 'useractioncomplete';
+
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(1);
+		});
+
+		tcData.eventStatus = 'tcloaded';
+
+		invokeCallbacks();
+
+		await waitForExpect(() => {
+			expect(callback).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -2,7 +2,7 @@ import { getConsentState as getAUSConsentState } from './aus/getConsentState';
 import { getConsentState as getCCPAConsentState } from './ccpa/getConsentState';
 import { getCurrentFramework } from './getCurrentFramework';
 import { getConsentState as getTCFv2ConsentState } from './tcfv2/getConsentState';
-import type { Callback, CallbackQueueItem, ConsentState } from './types';
+import type { CallbackQueueItem, ConsentState, OnConsentChange } from './types';
 
 // callbacks cache
 const callBackQueue: CallbackQueueItem[] = [];
@@ -53,7 +53,7 @@ export const invokeCallbacks = (): void => {
 	});
 };
 
-export const onConsentChange: (fn: Callback) => void = (callBack) => {
+export const onConsentChange: OnConsentChange = (callBack) => {
 	const newCallback: CallbackQueueItem = { fn: callBack };
 
 	callBackQueue.push(newCallback);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,57 @@
+import type {
+	CMP,
+	ConsentState,
+	GetConsentFor,
+	OnConsentChange,
+	VendorName,
+} from './types';
+
+export const isServerSide = typeof window === 'undefined';
+
+export const serverSideWarn = (): void => {
+	console.warn(
+		'This is a server-side version of the @guardian/consent-management-platform',
+		'No consent signals will be received.',
+	);
+};
+
+export const serverSideWarnAndReturn = <T extends unknown>(
+	arg: T,
+): (() => T) => {
+	return () => {
+		serverSideWarn();
+		return arg;
+	};
+};
+
+export const cmp: CMP = {
+	__disable: serverSideWarn,
+	__enable: serverSideWarnAndReturn(false),
+	__isDisabled: serverSideWarnAndReturn(false),
+
+	hasInitialised: serverSideWarnAndReturn(false),
+	init: serverSideWarn,
+	showPrivacyManager: serverSideWarn,
+	version: 'n/a',
+	willShowPrivacyMessage: serverSideWarnAndReturn(Promise.resolve(false)),
+	willShowPrivacyMessageSync: serverSideWarnAndReturn(false),
+};
+
+export const onConsentChange: OnConsentChange = () => {
+	return serverSideWarn();
+};
+
+export const getConsentFor: GetConsentFor = (
+	vendor: VendorName,
+	consent: ConsentState,
+) => {
+	console.log(
+		`Server-side call for getConsentFor(${vendor}, ${JSON.stringify(
+			consent,
+		)})`,
+		'getConsentFor will always return false server-side',
+	);
+	serverSideWarn();
+
+	return false;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,12 @@ export type CMP = {
 
 export type InitCMP = (arg0: { pubData?: PubData; country?: Country }) => void;
 
+export type OnConsentChange = (fn: Callback) => void;
+export type GetConsentFor = (
+	vendor: VendorName,
+	consent: ConsentState,
+) => boolean;
+
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;
 	ccpa?: CCPAConsentState;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Allow the library to specify multiple Sourcepoint IDs to be looked up for a vendor ID, and then check if those IDs are in the consent state.

## Why?

This is intended to allow "new" and "old" ids to be present in the CMP library when vendors move from custom to IAB status (or any other ID changing moving). So that the CMP can be deployed for a vendor list update and transition seamlessly to using the new ID.

For https://trello.com/c/loSA82Sy/597-add-a-mechanism-to-the-cmp-to-transition-from-old-to-new-ids-seamlessly-without-interruption-of-service-during-a-re-permission
