### PR TITLE
fix: Simplify server side implementation

### DIFF
--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -1,4 +1,4 @@
-import type { ConsentState } from './types';
+import type { ConsentState, GetConsentFor } from './types';
 
 /* eslint-disable @typescript-eslint/naming-convention
    --
@@ -34,7 +34,7 @@ export enum VendorIDs {
 
 export type VendorName = keyof typeof VendorIDs;
 
-export const getConsentFor = (
+export const getConsentFor: GetConsentFor = (
 	vendor: VendorName,
 	consent: ConsentState,
 ): boolean => {

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,6 +1,6 @@
-let isGuardian: boolean | undefined;
+import { isServerSide } from '../server';
 
-const isServerSide = typeof window === 'undefined';
+let isGuardian: boolean | undefined;
 
 export const isGuardianDomain = (): boolean => {
 	if (typeof isGuardian === 'undefined') {

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -2,7 +2,7 @@ import { getConsentState as getAUSConsentState } from './aus/getConsentState';
 import { getConsentState as getCCPAConsentState } from './ccpa/getConsentState';
 import { getCurrentFramework } from './getCurrentFramework';
 import { getConsentState as getTCFv2ConsentState } from './tcfv2/getConsentState';
-import type { Callback, CallbackQueueItem, ConsentState } from './types';
+import type { CallbackQueueItem, ConsentState, OnConsentChange } from './types';
 
 // callbacks cache
 const callBackQueue: CallbackQueueItem[] = [];
@@ -41,7 +41,7 @@ export const invokeCallbacks = (): void => {
 	});
 };
 
-export const onConsentChange: (fn: Callback) => void = (callBack) => {
+export const onConsentChange: OnConsentChange = (callBack) => {
 	const newCallback: CallbackQueueItem = { fn: callBack };
 
 	callBackQueue.push(newCallback);

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,7 @@ export const serverSideWarnAndReturn = <T extends unknown>(
 	return () => {
 		serverSideWarn();
 		return arg;
-	}
+	};
 };
 
 export const cmp: CMP = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,55 @@
+import type {
+	CMP,
+	ConsentState,
+	GetConsentFor,
+	OnConsentChange,
+	VendorName,
+} from './types';
+
+export const isServerSide = typeof window === 'undefined';
+
+export const serverSideWarn = (): void => {
+	console.warn(
+		'This is a server-side version of the @guardian/consent-management-platform',
+		'No consent signals will be received.',
+	);
+};
+
+export const serverSideWarnAndReturn = <T extends unknown>(
+	arg: T,
+): (() => T) => {
+	serverSideWarn();
+	return () => arg;
+};
+
+export const cmp: CMP = {
+	__disable: serverSideWarn,
+	__enable: serverSideWarnAndReturn(false),
+	__isDisabled: serverSideWarnAndReturn(false),
+
+	hasInitialised: serverSideWarnAndReturn(false),
+	init: serverSideWarn,
+	showPrivacyManager: serverSideWarn,
+	version: 'n/a',
+	willShowPrivacyMessage: serverSideWarnAndReturn(Promise.resolve(false)),
+	willShowPrivacyMessageSync: serverSideWarnAndReturn(false),
+};
+
+export const onConsentChange: OnConsentChange = () => {
+	return serverSideWarn();
+};
+
+export const getConsentFor: GetConsentFor = (
+	vendor: VendorName,
+	consent: ConsentState,
+) => {
+	console.log(
+		`Server-side call for getConsentFor(${vendor}, ${JSON.stringify(
+			consent,
+		)})`,
+		'getConsentFor will always return true server-side',
+	);
+	serverSideWarn();
+
+	return true;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,8 +18,10 @@ export const serverSideWarn = (): void => {
 export const serverSideWarnAndReturn = <T extends unknown>(
 	arg: T,
 ): (() => T) => {
-	serverSideWarn();
-	return () => arg;
+	return () => {
+		serverSideWarn();
+		return arg;
+	}
 };
 
 export const cmp: CMP = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,9 +47,9 @@ export const getConsentFor: GetConsentFor = (
 		`Server-side call for getConsentFor(${vendor}, ${JSON.stringify(
 			consent,
 		)})`,
-		'getConsentFor will always return true server-side',
+		'getConsentFor will always return false server-side',
 	);
 	serverSideWarn();
 
-	return true;
+	return false;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,12 @@ export type CMP = {
 
 export type InitCMP = (arg0: { pubData?: PubData; country?: Country }) => void;
 
+export type OnConsentChange = (fn: Callback) => void;
+export type GetConsentFor = (
+	vendor: VendorName,
+	consent: ConsentState,
+) => boolean;
+
 export interface ConsentState {
 	tcfv2?: TCFv2ConsentState;
 	ccpa?: CCPAConsentState;


### PR DESCRIPTION
## What does this change?

Incorporate changes from https://github.com/guardian/dotcom-rendering/pull/4106

## Why?

This change makes it clear the CMP is not to be used server-side and warns in console to that effect.
