### PR TITLE
test: Update Cypress tests to reflect Sourcepoint updates

### DIFF
--- a/cypress/integration/sourcepoint-tcfv2.spec.js
+++ b/cypress/integration/sourcepoint-tcfv2.spec.js
@@ -66,9 +66,7 @@ describe('Interaction', () => {
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager)
-			.find(
-				`div[title="Store and/or access information on a device"]`,
-			)
+			.find(`div[title="Store and/or access information on a device"]`)
 			.find('span.off')
 			.click();
 
@@ -94,9 +92,7 @@ describe('Interaction', () => {
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager)
-			.find(
-				`div[title="Store and/or access information on a device"]`,
-			)
+			.find(`div[title="Store and/or access information on a device"]`)
 			.find('span.on')
 			.click();
 


### PR DESCRIPTION
## What does this change?

This change updates the [Cypress](https://www.cypress.io/) tests to reflect changes in the Sourcepoint UI loaded in an `iframe`. Specifically it seems `aria-labels` on some `div`s have been updated to user `title`. 

## Why?

This change in the Sourcepoint UI was causing our tests to fail, we need to update to keep our tests in line with reality.
