### PR TITLE
chore: Replace git.io links with resolved links

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ type: `string`
 -   `"youtube-player"`
 
 </details>
-If the vendor you need is missing, please [raise an issue](https://git.io/JUzVL) (or a PR!).
+If the vendor you need is missing, please [raise an issue](https://github.com/guardian/consent-management-platform/issues) (or a PR!).
 
 #### `consentState`
 

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -11,7 +11,7 @@ export const getConsentFor: GetConsentFor = (
 	if (typeof sourcepointIds === 'undefined' || sourcepointIds === []) {
 		throw new Error(
 			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
-				'If it should be added, raise an issue at https://git.io/JUzVL',
+				'If it should be added, raise an issue at https://github.com/guardian/consent-management-platform/issues',
 		);
 	}
 

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -77,7 +77,7 @@ const enhanceConsentState = (consentState: ConsentStateBasic): ConsentState => {
 
 const getConsentState: () => Promise<ConsentState> = async () => {
 	if (window.__uspapi) {
-		// in USA or AUS - https://git.io/JUOdq
+		// in USA or AUS - https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md
 		if (getCurrentFramework() === 'aus')
 			return enhanceConsentState({ aus: await getAUSConsentState() });
 
@@ -85,7 +85,7 @@ const getConsentState: () => Promise<ConsentState> = async () => {
 	}
 
 	if (window.__tcfapi) {
-		// in RoW - https://git.io/JfrZr
+		// in RoW - https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 		return enhanceConsentState({ tcfv2: await getTCFv2ConsentState() });
 	}
 

--- a/src/tcfv2/stub.js
+++ b/src/tcfv2/stub.js
@@ -6,7 +6,7 @@
 export const stub = () => {
 	// prettier-ignore
 	var e=function(){for(var e,t="__tcfapiLocator",a=[],n=window;n;){try{if(n.frames[t]){e=n;break}}catch(e){}if(n===window.top)break;n=n.parent}e||(function e(){var a=n.document,r=!!n.frames[t];if(!r)if(a.body){var i=a.createElement("iframe");i.style.cssText="display:none",i.name=t,a.body.appendChild(i)}else setTimeout(e,5);return!r}(),n.__tcfapi=function(){for(var e,t=arguments.length,n=new Array(t),r=0;r<t;r++)n[r]=arguments[r];if(!n.length)return a;if("setGdprApplies"===n[0])n.length>3&&2===parseInt(n[1],10)&&"boolean"==typeof n[3]&&(e=n[3],"function"==typeof n[2]&&n[2]("set",!0));else if("ping"===n[0]){var i={gdprApplies:e,cmpLoaded:!1,cmpStatus:"stub"};"function"==typeof n[2]&&n[2](i)}else a.push(n)},n.addEventListener("message",function(e){var t="string"==typeof e.data,a={};try{a=t?JSON.parse(e.data):e.data}catch(e){}var n=a.__tcfapiCall;n&&window.__tcfapi(n.command,n.version,function(a,r){var i={__tcfapiReturn:{returnValue:a,success:r,callId:n.callId}};t&&(i=JSON.stringify(i)),e.source.postMessage(i,"*")},n.parameter)},!1))};
-	// call `e` directly. See https://git.io/JJxcM
+	// call `e` directly. See https://github.com/guardian/consent-management-platform/pull/185
 	// 'undefined' != typeof module ? (module.exports = e) : e();
 	e();
 };

--- a/src/types/tcfv2/TCData.ts
+++ b/src/types/tcfv2/TCData.ts
@@ -1,6 +1,6 @@
 import type { TCEventStatusCode, TCFv2ConsentList, TCPingStatusCode } from '.';
 
-// From the IAB spec – https://git.io/JJtY6
+// From the IAB spec – https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 export interface TCData {
 	tcString: string;
 	tcfPolicyVersion: number;

--- a/src/types/tcfv2/index.ts
+++ b/src/types/tcfv2/index.ts
@@ -11,13 +11,13 @@ export interface TCFv2ConsentState {
 
 export type ConsentVector = Record<string, boolean>;
 
-// From the IAB spec – https://git.io/JUmoi
+// From the IAB spec – https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 export type TCEventStatusCode =
 	| 'tcloaded'
 	| 'cmpuishown'
 	| 'useractioncomplete';
 
-// From the IAB spec – https://git.io/JUmw8
+// From the IAB spec – https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 export type TCPingStatusCode =
 	| 'stub'
 	| 'loading'


### PR DESCRIPTION
Co-authored-by: Max Duval <max.duval@theguardian.com>

## What does this change?

Replace git.io links with resolved links as git.io will be deprecated on 2022-04-29:

https://github.blog/changelog/2022-04-25-git-io-deprecation

Used @mxdvl 's guide