### PR TITLE
test: Add Monitoring Lambdas for Canada

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -36,6 +36,16 @@
 			"action": "cmp-monitoring-lambda-ap-southeast-2",
 			"path": "monitoring/dist",
 			"compress": "zip"
+		},
+		{
+			"action": "cmp-monitoring-cdk-ca-central-1",
+			"path": "cdk/cdk.out/CmpMonitoringStackCA.template.json",
+			"compress": false
+		},
+		{
+			"action": "cmp-monitoring-lambda-ca-central-1",
+			"path": "monitoring/dist",
+			"compress": "zip"
 		}
 	]
 }

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -5,7 +5,7 @@ import { Monitoring } from '../lib/monitoring';
 
 const app = new App();
 
-type AwsRegion = 'eu-west-1' | 'us-west-1' | 'ap-southeast-2';
+type AwsRegion = 'eu-west-1' | 'us-west-1' | 'ap-southeast-2' | 'ca-central-1';
 
 function stackProps(awsRegion: AwsRegion): GuStackProps {
 	const stackName = 'frontend';
@@ -21,3 +21,4 @@ function stackProps(awsRegion: AwsRegion): GuStackProps {
 new Monitoring(app, 'CmpMonitoringStackEU', stackProps('eu-west-1'));
 new Monitoring(app, 'CmpMonitoringStackUS', stackProps('us-west-1'));
 new Monitoring(app, 'CmpMonitoringStackAU', stackProps('ap-southeast-2'));
+new Monitoring(app, 'CmpMonitoringStackCA', stackProps('ca-central-1'));

--- a/monitoring/remoteRun.ts
+++ b/monitoring/remoteRun.ts
@@ -25,7 +25,12 @@ function processResult(result: InvokeCommandOutput) {
 }
 
 async function main() {
-	const regionsToCheck = ['us-west-1', 'eu-west-1', 'ap-southeast-2'];
+	const regionsToCheck = [
+		'us-west-1',
+		'eu-west-1',
+		'ap-southeast-2',
+		'ca-central-1',
+	];
 
 	const invokeSettledResults = await Promise.allSettled(
 		regionsToCheck.map((region) =>

--- a/monitoring/src/config.ts
+++ b/monitoring/src/config.ts
@@ -22,6 +22,9 @@ const decideJurisdiction = (
 	if (awsRegion === 'us-west-1') {
 		return 'ccpa';
 	}
+	if (awsRegion === 'ca-central-1') {
+		return 'tcfv2';
+	}
 	if (awsRegion === 'ap-southeast-2') {
 		return 'aus';
 	}

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -132,3 +132,22 @@ deployments:
             bucket: com-gu-frontend-artifacts-ap-southeast-2
             fileName: cmp-monitoring-lambda-ap-southeast-2.zip
             lookupByTags: true
+    cmp-monitoring-cdk-ca-central-1:
+        regions: [ca-central-1]
+        type: cloud-formation
+        parameters:
+            prependStackToCloudFormationStackName: false
+            cloudFormationStackName: cmp-monitoring
+            templatePath: CmpMonitoringStackCA.template.json
+            cloudFormationStackByTags: false
+            manageStackPolicy: false
+    cmp-monitoring-lambda-ca-central-1:
+        dependencies: [cmp-monitoring-cdk-ca-central-1]
+        regions: [ca-central-1]
+        type: aws-lambda
+        actions: [uploadLambda, updateLambda]
+        parameters:
+            prefixStack: false
+            bucket: com-gu-frontend-artifacts-ca-central-1
+            fileName: cmp-monitoring-lambda-ca-central-1.zip
+            lookupByTags: true


### PR DESCRIPTION
## What does this change?

This change adds monitoring lambdas to the `ca-central-1` region.

## Why?

The advertising setup in Canada is different from elsewhere and has had unusual / different behaviour with the CMP in the past. This change will allow us to test in this region.

**Note**: When this is deployed we will need to follow the instructions in https://github.com/guardian/consent-management-platform/blob/main/riff-raff.yaml#L6 as this will add a new stack.