### PR TITLE
test: Express failure in types

### DIFF
--- a/monitoring/src/index.ts
+++ b/monitoring/src/index.ts
@@ -1,14 +1,32 @@
 import { envConfig } from './config';
+import type { CheckStatus } from './types';
 
-export const handler = async (): Promise<void> => {
+export const handler = async (): Promise<CheckStatus> => {
 	console.log(
 		`(cmp monitoring) Starting cmp-monitoring for stage: ${envConfig.stage}, jurisdiction: ${envConfig.jurisdiction}`,
 	);
 
 	try {
 		await envConfig.checkFunction(envConfig);
-		console.log('(cmp monitoring) Finished cmp-monitoring');
+		console.log('(cmp monitoring) Finished successfully :)');
+
+		return {
+			key: 'success',
+		};
 	} catch (error) {
-		console.log(error);
+		let errorMessage = 'Unknown Error!';
+
+		if (typeof error === 'string') {
+			errorMessage = error;
+		} else if (error instanceof Error) {
+			errorMessage = error.message;
+		}
+
+		console.log(`(cmp monitoring) Finished with failure: ${errorMessage}`);
+
+		return {
+			key: 'failure',
+			errorMessage: errorMessage,
+		};
 	}
 };

--- a/monitoring/src/types.ts
+++ b/monitoring/src/types.ts
@@ -20,3 +20,14 @@ export type Config = {
 	iframeDomain: string;
 	checkFunction: (config: Config) => Promise<void>;
 };
+
+export type SuccessfulCheck = {
+	key: 'success';
+};
+
+export type FailedCheck = {
+	key: 'failure';
+	errorMessage: string;
+};
+
+export type CheckStatus = SuccessfulCheck | FailedCheck;


### PR DESCRIPTION
## What does this change?

Move towards better reporting on failure.

## Why?

At the moment the lambda monitoring only returns logs, this adds a return status (so far unused).