### PR TITLE
test: Increases memory allocation of lambda to 2048

### DIFF
--- a/cdk/lib/__snapshots__/monitoring.test.ts.snap
+++ b/cdk/lib/__snapshots__/monitoring.test.ts.snap
@@ -63,7 +63,7 @@ Object {
           ],
         },
         "Handler": "index.handler",
-        "MemorySize": 1024,
+        "MemorySize": 2048,
         "Role": Object {
           "Fn::GetAtt": Array [
             "cmpmonitoringServiceRole3F7FDCEC",

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -22,7 +22,7 @@ export class Monitoring extends GuStack {
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_14_X,
 			timeout: Duration.seconds(300),
-			memorySize: 1024,
+			memorySize: 2048,
 		});
 	}
 }


### PR DESCRIPTION
## What does this change?

Increase the memory allocation of lambda as it is hitting the limit sometimes.

## Why?

Reduce false reporting of errors when lambda stalls as it runs out of memory.