### PR TITLE
test: add missing instuctions in the ccpa and aus checkPages functions

### DIFF
--- a/monitoring/src/check-page/aus.ts
+++ b/monitoring/src/check-page/aus.ts
@@ -84,6 +84,8 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 	if (nextUrl) {
 		await checkSubsequentPage(browser, nextUrl);
 	}
+
+	await browser.close();
 };
 
 export const mainCheck = async function (config: Config): Promise<void> {

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -83,6 +83,8 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 	if (nextUrl) {
 		await checkSubsequentPage(browser, nextUrl);
 	}
+
+	await browser.close();
 };
 
 export const mainCheck = async function (config: Config): Promise<void> {


### PR DESCRIPTION
This is an addition to https://github.com/guardian/consent-management-platform/pull/620 to add `browser.close()` instruction in the ccpa and aus cases. 