### PR TITLE
fix: Update getConsentFor to include Quantum Metric

### DIFF
--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -18,6 +18,7 @@ export const VendorIDs = {
 	ophan: ['5f203dbeeaaaa8768fd3226a'],
 	permutive: ['5eff0d77969bfa03746427eb'],
 	prebid: ['5f92a62aa22863685f4daa4c'],
+	qm: ['5f295fa4b8e05c76a44c3149'],
 	redplanet: ['5f199c302425a33f3f090f51'],
 	remarketing: ['5ed0eb688a76503f1016578f'],
 	sentry: ['5f0f39014effda6e8bbd2006'],


### PR DESCRIPTION
## What does this change?

Adds Quantum Metric as a vendor identifiable to the `getConsentFor` function as `qm`.

Example use: 

```ts
const qmConsent: boolean = getConsentFor('qm');
```

## Why?

Needed for https://trello.com/c/72Khgq68/709-add-quantum-metric-to-list-of-vendors-the-cmp-knows-about (requested by @GHaberis).