### PR TITLE
docs: Use update ghpages action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
           BUILD_DIR: 'test-page/dist/'
-        uses: maxheld83/ghpages@v0.3.0
+        uses: guardian/ghpages@v0.4.0


### PR DESCRIPTION
## What does this change?

The current version of the `ghpages` action is hard coded [to publish from `master`](https://github.com/maxheld83/ghpages/blob/master/entrypoint.sh#L16) whereas we use `main`.

This updates to use a forked version of the action [that references `main`](https://github.com/guardian/ghpages/blob/master/entrypoint.sh#L16). This approach was taken as the original repo seems abandoned with an outstanding [issue to fix the issue open for over a year](https://github.com/maxheld83/ghpages/issues/35).

## Why?

So that our build works and publishes to gh-pages.