### PR TITLE
test: Update Snyk PR to cover **/package.json

### DIFF
--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -3,7 +3,7 @@ name: Snyk PR
 on:
   pull_request:
     paths:
-      - 'package.json'
+      - '**/package.json'
 
 jobs:
   security:


### PR DESCRIPTION
## What does this change?

The paths param in the GitHub action should specify package.json at any depth (as there are multiple in this repo).

## Why?

This will ensure we see changes in all projects in this repo.