### PR TITLE
ci: Use `actions/setup-node` to remove a dependency

### DIFF
--- a/.github/workflows/CI-monitoring.yml
+++ b/.github/workflows/CI-monitoring.yml
@@ -24,13 +24,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            monitoring/yarn.lock
+            cdk/yarn.lock
 
       - name: Install Root dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Lambda Install CDK dependencies
         working-directory: './monitoring'
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Lambda lint
         working-directory: './monitoring'
@@ -42,7 +47,7 @@ jobs:
 
       - name: CDK Install CDK dependencies
         working-directory: './cdk'
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: CDK Test
         working-directory: './cdk'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,9 +16,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Run unit tests
         uses: mattallty/jest-github-action@v1.0.3
@@ -43,9 +44,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Run e2e tests on dist with Cypress
         run: yarn test:e2e
@@ -60,9 +62,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Lint files
         run: yarn lint
@@ -77,9 +80,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Check types
         run: yarn tsc
@@ -94,9 +98,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Build package
         run: yarn build
@@ -123,9 +128,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Fetch build
         uses: actions/download-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -37,8 +39,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -52,8 +56,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -67,8 +73,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -82,8 +90,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -109,8 +119,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,8 +10,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
-        uses: guardian/actions-setup-node@main
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

This repository currently uses both `guardian/actions-setup-node` and `actions/setup-node`.

`guardian/actions-setup-node` is a fork of `actions/setup-node` and has fallen behind. In this change, we move to using only `actions/setup-node` for simplicity.

Also replace `bahmutov/npm-install` with a DIY solution, as it's not too complex and removes a dependency: we use `actions/setup-node` to manage the cache, and manually install yarn deps.