### PR TITLE
chore(deps): bumped gucdk to v39

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,8 @@
 	"useractioncomplete",
 	"uspapi",
 	"youtube"
-]
+],
+"files.watcherExclude": {
+	"**/target": true
+}
 }

--- a/artifact.json
+++ b/artifact.json
@@ -8,8 +8,8 @@
 			"compress": "zip"
 		},
 		{
-			"action": "cmp-monitoring-cdk-eu-west-1",
-			"path": "cdk/cdk.out/CmpMonitoringStackEU.template.json",
+			"action": "cloud-formation",
+			"path": "cdk/cdk.out/",
 			"compress": false
 		},
 		{
@@ -18,29 +18,14 @@
 			"compress": "zip"
 		},
 		{
-			"action": "cmp-monitoring-cdk-us-west-1",
-			"path": "cdk/cdk.out/CmpMonitoringStackUS.template.json",
-			"compress": false
-		},
-		{
 			"action": "cmp-monitoring-lambda-us-west-1",
 			"path": "monitoring/dist",
 			"compress": "zip"
 		},
 		{
-			"action": "cmp-monitoring-cdk-ap-southeast-2",
-			"path": "cdk/cdk.out/CmpMonitoringStackAU.template.json",
-			"compress": false
-		},
-		{
 			"action": "cmp-monitoring-lambda-ap-southeast-2",
 			"path": "monitoring/dist",
 			"compress": "zip"
-		},
-		{
-			"action": "cmp-monitoring-cdk-ca-central-1",
-			"path": "cdk/cdk.out/CmpMonitoringStackCA.template.json",
-			"compress": false
 		},
 		{
 			"action": "cmp-monitoring-lambda-ca-central-1",

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -7,18 +7,55 @@ const app = new App();
 
 type AwsRegion = 'eu-west-1' | 'us-west-1' | 'ap-southeast-2' | 'ca-central-1';
 
-function stackProps(awsRegion: AwsRegion): GuStackProps {
+function stackProps(awsRegion: AwsRegion, stage: string): GuStackProps {
 	const stackName = 'frontend';
 
 	return {
 		stack: stackName,
+		stage: stage,
 		env: {
 			region: awsRegion,
 		},
 	};
 }
 
-new Monitoring(app, 'CmpMonitoringStackEU', stackProps('eu-west-1'));
-new Monitoring(app, 'CmpMonitoringStackUS', stackProps('us-west-1'));
-new Monitoring(app, 'CmpMonitoringStackAU', stackProps('ap-southeast-2'));
-new Monitoring(app, 'CmpMonitoringStackCA', stackProps('ca-central-1'));
+new Monitoring(
+	app,
+	'CmpMonitoringStackEUCode',
+	stackProps('eu-west-1', 'CODE'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackEUProd',
+	stackProps('eu-west-1', 'PROD'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackUSCode',
+	stackProps('us-west-1', 'CODE'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackUSProd',
+	stackProps('us-west-1', 'PROD'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackAUCode',
+	stackProps('ap-southeast-2', 'CODE'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackAUProd',
+	stackProps('ap-southeast-2', 'PROD'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackCACode',
+	stackProps('ca-central-1', 'CODE'),
+);
+new Monitoring(
+	app,
+	'CmpMonitoringStackCAProd',
+	stackProps('ca-central-1', 'PROD'),
+);

--- a/cdk/lib/__snapshots__/monitoring.test.ts.snap
+++ b/cdk/lib/__snapshots__/monitoring.test.ts.snap
@@ -8,15 +8,6 @@ Object {
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "Stage": Object {
-      "AllowedValues": Array [
-        "CODE",
-        "PROD",
-      ],
-      "Default": "CODE",
-      "Description": "Stage name",
-      "Type": "String",
-    },
   },
   "Resources": Object {
     "cmpmonitoring2CD05B94": Object {
@@ -29,39 +20,16 @@ Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "cmp-monitoring/",
-                Object {
-                  "Ref": "Stage",
-                },
-                "/cmp-monitoring-lambda-eu-west-1/cmp-monitoring-lambda-eu-west-1.zip",
-              ],
-            ],
-          },
+          "S3Key": "cmp-monitoring/PROD/cmp-monitoring-lambda-eu-west-1/cmp-monitoring-lambda-eu-west-1.zip",
         },
         "Environment": Object {
           "Variables": Object {
             "APP": "cmp-monitoring-lambda-eu-west-1",
             "STACK": "cmp-monitoring",
-            "STAGE": Object {
-              "Ref": "Stage",
-            },
+            "STAGE": "PROD",
           },
         },
-        "FunctionName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "cmp-monitoring-",
-              Object {
-                "Ref": "Stage",
-              },
-            ],
-          ],
-        },
+        "FunctionName": "cmp-monitoring-PROD",
         "Handler": "index.handler",
         "MemorySize": 2048,
         "Role": Object {
@@ -90,9 +58,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "PROD",
           },
         ],
         "Timeout": 300,
@@ -146,9 +112,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "PROD",
           },
         ],
       },
@@ -214,11 +178,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "/cmp-monitoring/cmp-monitoring-lambda-eu-west-1",
+                    ":parameter/PROD/cmp-monitoring/cmp-monitoring-lambda-eu-west-1",
                   ],
                 ],
               },
@@ -241,11 +201,7 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "/cmp-monitoring/cmp-monitoring-lambda-eu-west-1/*",
+                    ":parameter/PROD/cmp-monitoring/cmp-monitoring-lambda-eu-west-1/*",
                   ],
                 ],
               },
@@ -283,7 +239,7 @@ Object {
     },
     "cmpmonitoringscheduleFB1DBC53": Object {
       "Properties": Object {
-        "ScheduleExpression": "rate(1 day)",
+        "ScheduleExpression": "rate(2 minutes)",
         "State": "ENABLED",
         "Targets": Array [
           Object {

--- a/cdk/lib/monitoring.test.ts
+++ b/cdk/lib/monitoring.test.ts
@@ -1,6 +1,6 @@
 import '@aws-cdk/assert/jest';
 import { SynthUtils } from '@aws-cdk/assert';
-import { App } from '@aws-cdk/core';
+import { App, Stage } from '@aws-cdk/core';
 import { Monitoring } from './monitoring';
 
 describe('The Monitoring stack', () => {
@@ -8,6 +8,7 @@ describe('The Monitoring stack', () => {
 		const app = new App();
 		const stack = new Monitoring(app, 'CmpMonitoringStack', {
 			stack: 'cmp-monitoring',
+			stage: 'PROD',
 		});
 		expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
 	});

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/cloudformation-include": "1.147.0",
     "@aws-cdk/core": "1.147.0",
-    "@guardian/cdk": "38.2.1",
+    "@guardian/cdk": "39.0.0",
     "source-map-support": "^0.5.20"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2623,10 +2623,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@38.2.1":
-  version "38.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-38.2.1.tgz#86044a64fc918b73391eca2b846b8d208da86af0"
-  integrity sha512-YqXXxhRQ5yUHx9IPE54GxcGPuoGvad3ciEiBaeOtQm1BiBjmaPxrM6BdJpZRh4KcNGJwUmA9/3OQgi1/oyJbFw==
+"@guardian/cdk@39.0.0":
+  version "39.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-39.0.0.tgz#e298950dcf004e04b1c755b75c17e3ee0a9c8198"
+  integrity sha512-5UOMXusS33xsgn2hJoL0Nltpjkyar3Z2o8Gf9wn8ycdjHvAniEzhBfcN9x+A7YpFDBY9NcbHms2d0yzUl8rQ1w==
   dependencies:
     "@aws-cdk/assert" "1.147.0"
     "@aws-cdk/aws-apigateway" "1.147.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -78,10 +78,10 @@ deployments:
     cmp-monitoring-cdk-eu-west-1:
         regions: [eu-west-1]
         type: cloud-formation
+        contentDirectory: 'cloud-formation'
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            contentDirectory: 'cloud-formation'
             templateStagePaths:
                 CODE: CmpMonitoringStackEUCode.template.json
                 PROD: CmpMonitoringStackEUProd.template.json
@@ -100,10 +100,10 @@ deployments:
     cmp-monitoring-cdk-us-west-1:
         regions: [us-west-1]
         type: cloud-formation
+        contentDirectory: 'cloud-formation'
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            contentDirectory: 'cloud-formation'
             templateStagePaths:
                 CODE: CmpMonitoringStackUSCode.template.json
                 PROD: CmpMonitoringStackUSProd.template.json
@@ -122,10 +122,10 @@ deployments:
     cmp-monitoring-cdk-ap-southeast-2:
         regions: [ap-southeast-2]
         type: cloud-formation
+        contentDirectory: 'cloud-formation'
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            contentDirectory: 'cloud-formation'
             templateStagePaths:
                 CODE: CmpMonitoringStackAUCode.template.json
                 PROD: CmpMonitoringStackAUProd.template.json
@@ -144,10 +144,10 @@ deployments:
     cmp-monitoring-cdk-ca-central-1:
         regions: [ca-central-1]
         type: cloud-formation
+        contentDirectory: 'cloud-formation'
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            contentDirectory: 'cloud-formation'
             templateStagePaths:
                 CODE: CmpMonitoringStackCACode.template.json
                 PROD: CmpMonitoringStackCAProd.template.json

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -81,7 +81,10 @@ deployments:
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            templatePath: CmpMonitoringStackEU.template.json
+            contentDirectory: 'cloud-formation'
+            templateStagePaths:
+                CODE: CmpMonitoringStackEUCode.template.json
+                PROD: CmpMonitoringStackEUProd.template.json
             cloudFormationStackByTags: false
             manageStackPolicy: false
     cmp-monitoring-lambda-eu-west-1:
@@ -100,7 +103,10 @@ deployments:
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            templatePath: CmpMonitoringStackUS.template.json
+            contentDirectory: 'cloud-formation'
+            templateStagePaths:
+                CODE: CmpMonitoringStackUSCode.template.json
+                PROD: CmpMonitoringStackUSProd.template.json
             cloudFormationStackByTags: false
             manageStackPolicy: false
     cmp-monitoring-lambda-us-west-1:
@@ -119,7 +125,10 @@ deployments:
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            templatePath: CmpMonitoringStackAU.template.json
+            contentDirectory: 'cloud-formation'
+            templateStagePaths:
+                CODE: CmpMonitoringStackAUCode.template.json
+                PROD: CmpMonitoringStackAUProd.template.json
             cloudFormationStackByTags: false
             manageStackPolicy: false
     cmp-monitoring-lambda-ap-southeast-2:
@@ -138,7 +147,10 @@ deployments:
         parameters:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
-            templatePath: CmpMonitoringStackCA.template.json
+            contentDirectory: 'cloud-formation'
+            templateStagePaths:
+                CODE: CmpMonitoringStackCACode.template.json
+                PROD: CmpMonitoringStackCAProd.template.json
             cloudFormationStackByTags: false
             manageStackPolicy: false
     cmp-monitoring-lambda-ca-central-1:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Updates Gucdk version to 39.0.0 - successfully tested in code.

## Why?

As per the issue raised [here](https://github.com/guardian/consent-management-platform/issues/645) -  using the latest version is always desired, and this'll enable us to test a feature from the cdk.