### PR TITLE
refactor: generate stacks from list of envs and regions

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -5,9 +5,21 @@ import { Monitoring } from '../lib/monitoring';
 
 const app = new App();
 
-type AwsRegion = 'eu-west-1' | 'us-west-1' | 'ap-southeast-2' | 'ca-central-1';
+const regionNames = [
+	'eu-west-1',
+	'us-west-1',
+	'ap-southeast-2',
+	'ca-central-1',
+] as const;
+type AwsRegion = typeof regionNames[number];
 
-function stackProps(awsRegion: AwsRegion, stage: string): GuStackProps {
+const deployableEnvs = ['CODE', 'PROD'] as const;
+type DeployableEnvironments = typeof deployableEnvs[number];
+
+function stackProps(
+	awsRegion: AwsRegion,
+	stage: DeployableEnvironments,
+): GuStackProps {
 	const stackName = 'frontend';
 
 	return {
@@ -19,43 +31,15 @@ function stackProps(awsRegion: AwsRegion, stage: string): GuStackProps {
 	};
 }
 
-new Monitoring(
-	app,
-	'CmpMonitoringStackEUCode',
-	stackProps('eu-west-1', 'CODE'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackEUProd',
-	stackProps('eu-west-1', 'PROD'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackUSCode',
-	stackProps('us-west-1', 'CODE'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackUSProd',
-	stackProps('us-west-1', 'PROD'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackAUCode',
-	stackProps('ap-southeast-2', 'CODE'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackAUProd',
-	stackProps('ap-southeast-2', 'PROD'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackCACode',
-	stackProps('ca-central-1', 'CODE'),
-);
-new Monitoring(
-	app,
-	'CmpMonitoringStackCAProd',
-	stackProps('ca-central-1', 'PROD'),
-);
+for (const region of regionNames) {
+	for (const stage of deployableEnvs) {
+		const zoneCode = region.substring(0, 2).toUpperCase();
+		const stageName = stage.charAt(0) + stage.slice(1).toLowerCase();
+
+		new Monitoring(
+			app,
+			'CmpMonitoringStack' + zoneCode + stageName,
+			stackProps(region, stage),
+		);
+	}
+}

--- a/cdk/lib/monitoring.test.ts
+++ b/cdk/lib/monitoring.test.ts
@@ -1,6 +1,4 @@
-import '@aws-cdk/assert/jest';
-import { SynthUtils } from '@aws-cdk/assert';
-import { App } from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Monitoring } from './monitoring';
 

--- a/cdk/lib/monitoring.test.ts
+++ b/cdk/lib/monitoring.test.ts
@@ -1,6 +1,6 @@
 import '@aws-cdk/assert/jest';
 import { SynthUtils } from '@aws-cdk/assert';
-import { App, Stage } from '@aws-cdk/core';
+import { App } from '@aws-cdk/core';
 import { Monitoring } from './monitoring';
 
 describe('The Monitoring stack', () => {

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -55,8 +55,8 @@ deployments:
             prependStackToCloudFormationStackName: false
             cloudFormationStackName: cmp-monitoring
             templateStagePaths:
-                CODE: CmpMonitoringStackAUCode.template.json
-                PROD: CmpMonitoringStackAUProd.template.json
+                CODE: CmpMonitoringStackAPCode.template.json
+                PROD: CmpMonitoringStackAPProd.template.json
             cloudFormationStackByTags: false
             manageStackPolicy: false
     cmp-monitoring-lambda-ap-southeast-2:


### PR DESCRIPTION
## What does this change?

Generate new stacks based on lists of region & env.

## Why?

Removes a bit of code duplication, makes adding removing regions a bit more straightforward.

note: this will rename the Asia Pacific region stack (replacing AU with AP)