### PR TITLE
chore: Update stack name to disambiguate stack 

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -20,7 +20,7 @@ function stackProps(
 	awsRegion: AwsRegion,
 	stage: DeployableEnvironments,
 ): GuStackProps {
-	const stackName = 'frontend';
+	const stackName = 'cmp-monitoring';
 
 	return {
 		stack: stackName,

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,4 +1,4 @@
-stacks: [frontend]
+stacks: [cmp-monitoring]
 allowedStages:
     - CODE
     - PROD


### PR DESCRIPTION
## What does this change?

This change updates the stack name in the CDK package to make it clear who owns these lambdas in reporting.

## Why?

It's wrong now.

**Note:** This needs a change to riff-raff configuration to understand that the `cmp-monitoring` stack needs deploying into the Frontend account.
