### PR TITLE
fix: bump version of guardian/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "wait-for-expect": "^3"
   },
   "dependencies": {
-    "@guardian/libs": "1.6.1 - 3.3.0"
+    "@guardian/libs": "6.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,10 +1365,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/libs@1.6.1 - 3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
-  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
+"@guardian/libs@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-6.1.0.tgz#4fc63a988db93fb3554216256a24b22875122e0b"
+  integrity sha512-UpkM+EjkZLoDvTqFEpLaWjxbWsxtUd2w8qYrCa02eTMO3nwmuz/kygN3D4+nKhnl77qWSlLp5wyVJHJ7gP5mxw==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION

## What does this change?
Updates to the latest version of guardian/lib

## Why?
To keep up to date.