### PR TITLE
fix: bump guardian.lib to 7.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "wait-for-expect": "^3"
   },
   "dependencies": {
-    "@guardian/libs": "6.1.0"
+    "@guardian/libs": "^7.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,10 +1365,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/libs@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-6.1.0.tgz#4fc63a988db93fb3554216256a24b22875122e0b"
-  integrity sha512-UpkM+EjkZLoDvTqFEpLaWjxbWsxtUd2w8qYrCa02eTMO3nwmuz/kygN3D4+nKhnl77qWSlLp5wyVJHJ7gP5mxw==
+"@guardian/libs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
## What does this change?

Updates to the latest version of guardian.libs.

## Why?

Keep up to date.