### PR TITLE
refactor: Moving from using title text to using apparently-unique class names to identify SourcePoint buttons

### DIFF
--- a/monitoring/src/check-page/aus.ts
+++ b/monitoring/src/check-page/aus.ts
@@ -11,7 +11,7 @@ import {
 	makeNewBrowser,
 } from './common-functions';
 
-const interactWithCMP = async (config: Config, page: Page) => {
+const clickAcceptAllCookies = async (config: Config, page: Page) => {
 	// Ensure that Sourcepoint has enough time to load the CMP
 	await page.waitForTimeout(5000);
 
@@ -75,7 +75,7 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 
 	await checkCMPIsOnPage(page);
 
-	await interactWithCMP(config, page);
+	await clickAcceptAllCookies(config, page);
 
 	await checkCMPIsNotVisible(page);
 

--- a/monitoring/src/check-page/aus.ts
+++ b/monitoring/src/check-page/aus.ts
@@ -23,7 +23,9 @@ const interactWithCMP = async (config: Config, page: Page) => {
 		return;
 	}
 
-	await frame.click('button[title="Continue"]');
+	await frame.click(
+		'div.message-component.message-row > button.sp_choice_type_11',
+	);
 };
 
 const reloadPage = async (page: Page) => {

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -11,7 +11,7 @@ import {
 	makeNewBrowser,
 } from './common-functions';
 
-const interactWithCMP = async (config: Config, page: Page) => {
+const clickDoNotSellMyInfo = async (config: Config, page: Page) => {
 	// Ensure that Sourcepoint has enough time to load the CMP
 	await page.waitForTimeout(5000);
 
@@ -104,7 +104,7 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 
 	await checkCMPIsOnPage(page);
 
-	await interactWithCMP(config, page);
+	await clickDoNotSellMyInfo(config, page);
 
 	await checkCMPIsNotVisible(page);
 

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -23,9 +23,7 @@ const interactWithCMP = async (config: Config, page: Page) => {
 		return;
 	}
 
-	await frame.click(
-		'div.message-component.message-row > button.sp_choice_type_13',
-	);
+	await frame.click('div.message-component > button.sp_choice_type_13');
 };
 
 const reloadPage = async (page: Page) => {
@@ -78,7 +76,6 @@ const checkGpcRespected = async (page: Page, url: string) => {
 	};
 
 	const invokeUspApiResults = await page.evaluate(invokeUspApi);
-
 	if (!invokeUspApiResults.gpcEnabled) {
 		throw new Error('GPC Signal not respected!');
 	}

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -23,7 +23,9 @@ const interactWithCMP = async (config: Config, page: Page) => {
 		return;
 	}
 
-	await frame.click('button[title="Do not sell my personal information"]');
+	await frame.click(
+		'div.message-component.message-row > button.sp_choice_type_13',
+	);
 };
 
 const reloadPage = async (page: Page) => {

--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -27,7 +27,7 @@ const checkTopAdDidNotLoad = async (page: Page): Promise<void> => {
 	log_info(`Checking ads do not load: Complete`);
 };
 
-const interactWithCMP = async (config: Config, page: Page) => {
+const clickAcceptAllCookies = async (config: Config, page: Page) => {
 	// Ensure that Sourcepoint has enough time to load the CMP
 	await page.waitForTimeout(5000);
 
@@ -90,7 +90,7 @@ const checkSubsequentPage = async (
 	await clearLocalStorage(page);
 	await reloadPage(page);
 	await checkTopAdDidNotLoad(page);
-	await interactWithCMP(config, page);
+	await clickAcceptAllCookies(config, page);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
 };
@@ -116,7 +116,7 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 
 	await checkTopAdDidNotLoad(page);
 
-	await interactWithCMP(config, page);
+	await clickAcceptAllCookies(config, page);
 
 	await checkCMPIsNotVisible(page);
 

--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -39,7 +39,9 @@ const interactWithCMP = async (config: Config, page: Page) => {
 		return;
 	}
 
-	await frame.click('button[title="Yes, I’m happy"]');
+	await frame.click(
+		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
+	);
 };
 
 const checkCMPDidNotLoad = async (page: Page) => {

--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -40,7 +40,7 @@ const interactWithCMP = async (config: Config, page: Page) => {
 	}
 
 	await frame.click(
-		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
+		'div.message-component.message-row > button.sp_choice_type_11',
 	);
 };
 


### PR DESCRIPTION
## What does this change? 

Alters the monitoring test to use class names to identify the buttons within Sourcepoint's CMP in the absence of HTML element ids.  

## Why?

This fixes the issue that ab tests often change the text of the button which we were previously relying on.  It makes the monitoring tests slightly less fragile until we can persuade Sourcepoint to add ids into their code. (we hope).

Sue Burt and Akinsola Lawanson