### PR TITLE
ci: Remove Riff-Raff configuration workaround

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,6 @@ deployments:
                 CODE: CmpMonitoringStackEUCode.template.json
                 PROD: CmpMonitoringStackEUProd.template.json
             cloudFormationStackByTags: false
-            manageStackPolicy: false
     cmp-monitoring-lambda-eu-west-1:
         dependencies: [cmp-monitoring-cdk-eu-west-1]
         regions: [eu-west-1]
@@ -36,7 +35,6 @@ deployments:
                 CODE: CmpMonitoringStackUSCode.template.json
                 PROD: CmpMonitoringStackUSProd.template.json
             cloudFormationStackByTags: false
-            manageStackPolicy: false
     cmp-monitoring-lambda-us-west-1:
         dependencies: [cmp-monitoring-cdk-us-west-1]
         regions: [us-west-1]
@@ -58,7 +56,6 @@ deployments:
                 CODE: CmpMonitoringStackAPCode.template.json
                 PROD: CmpMonitoringStackAPProd.template.json
             cloudFormationStackByTags: false
-            manageStackPolicy: false
     cmp-monitoring-lambda-ap-southeast-2:
         dependencies: [cmp-monitoring-cdk-ap-southeast-2]
         regions: [ap-southeast-2]
@@ -80,7 +77,6 @@ deployments:
                 CODE: CmpMonitoringStackCACode.template.json
                 PROD: CmpMonitoringStackCAProd.template.json
             cloudFormationStackByTags: false
-            manageStackPolicy: false
     cmp-monitoring-lambda-ca-central-1:
         dependencies: [cmp-monitoring-cdk-ca-central-1]
         regions: [ca-central-1]


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

During a CloudFormation deployment, Riff-Raff sets the stack policy to protect against unintentional deletion of sensitive resources (see https://github.com/guardian/riff-raff/pull/623). The policy it uses is the same regardless of region. However, when the policy is applied to the us-west-1 region, we get an error.

We previously set `manageStackPolicy` to `false` to opt-out of this behaviour, as deployments to us-west-1 would otherwise be impossible.

https://github.com/guardian/riff-raff/pull/874 patches Riff-Raff to make the policy region aware, removing the need for this workaround.

## Why?
- More standard deployment configuration
- More protection during deployment
- Unblocks https://github.com/guardian/consent-management-platform/pull/659

## Notes
To be merged after https://github.com/guardian/riff-raff/pull/874.