### PR TITLE
refactor!: make `@guardian/libs` a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compile": "rollup --config",
     "dev": "yarn clean && yarn compile --watch",
     "fix": "yarn lint --fix",
-		"github-pages-deploy": "gh-pages -d test-page/dist -u \"github-actions-bot <support+actions@github.com>\"",
+    "github-pages-deploy": "gh-pages -d test-page/dist -u \"github-actions-bot <support+actions@github.com>\"",
     "lint": "eslint . --ext=js,ts,tsx",
     "prepublishOnly": "yarn build",
     "readme-toc:commit": "git add README.md && git commit -m 'Update README toc' || true",
@@ -47,6 +47,7 @@
     "@babel/runtime": "^7",
     "@guardian/eslint-config": "^0.7.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
+    "@guardian/libs": "10.0.0",
     "@guardian/node-riffraff-artifact": "^0.3.2",
     "@guardian/prettier": "^0.7.0",
     "@rollup/plugin-babel": "^5.3.1",
@@ -92,11 +93,11 @@
     "serve": "^11",
     "start-server-and-test": "~1.14.0",
     "svelte": "~3.52.0",
-    "tslib": "^2.3.1",
+    "tslib": "^2.4.0",
     "typescript": "^4",
     "wait-for-expect": "^3"
   },
-  "dependencies": {
-    "@guardian/libs": "^7.1.4"
+  "peerDependencies": {
+    "@guardian/libs": "^10.0.0"
   }
 }

--- a/src/rollup.config.js
+++ b/src/rollup.config.js
@@ -10,6 +10,7 @@ import pkg from '../package.json';
 
 export default {
 	input: './src/index.ts',
+	external: (id) => !/^[./]/.test(id),
 	output: [
 		{
 			file: pkg.main,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,10 +1414,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/libs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+"@guardian/libs@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/@guardian/libs/-/libs-10.0.0.tgz#3624e5ead3a9f4ffb6244327d3ee5c3d55d688fa"
+  integrity sha512-N6+5e0DrusWryaZCH6/cppJlLEksuZWFyYnQjHbe/HXM2cLe2i3GAU5kRhIh98pOlPTPer5GennBAYQ6gzQofg==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"
@@ -10947,10 +10947,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- makes `@guardian/libs` a peer dependency
- adds a pinned `@guardian/libs` to dev dependencies (per [the recommendation](https://github.com/guardian/recommendations/blob/main/npm-packages.md#pin-the-lowest-possible-version-of-peerdependencies-in-your-packages-devdependencies))
- bumps the version of `@guardian/libs` it uses

## Why?

currently the CMP bundles libs with CMP code. this means it ships two copies to browsers. changing it to a peer dep means consumer's handle the presence of libs.

co-authored @joecowton1 
