### PR TITLE
refactor: update the css stub for tcfv2 dotcom plus documentation

### DIFF
--- a/docs/02-sourcepoint-ui-instructions.md
+++ b/docs/02-sourcepoint-ui-instructions.md
@@ -1,1 +1,11 @@
 # Sourcepoint UI instructions
+
+Sourcepoint's UI for messages does not have any version control.  Furthermore it is difficult to use and easy to lose work by refreshing or closing the interface without saving - or having someone overwrite all your changes by working on the same file concurrently.
+
+A better way to ensure your change are not lost is to take a copy of the full CSS file by opening the CSS panel in Sourcepoint and with the cursor inside that, using cmd+a, cmd+c to take a copy of the CSS then paste it into a file in your feature branch.  You can then make your changes in VSCode then paste them into Sourcepoint's CSS panel for testing. This allows you to take advantage of committing your changes incrementally and rolling back if needed.
+
+Ideally, in the longer term we hope to create a better way of testing locally before pushing the tested changes to Sourcepoint so that this repo becomes the source of truth for the CSS files rather than a (hopeful) reflection of it.
+
+For testing your message, make a note of the message id in SourcePoint's UI.  Alter the message_id field in MessageTester.html iFrame URL then spin up MessageTester.html within sourcepoint-ui via Live Server or similar and point your selected browser at localhost.
+
+As you change and save the message in the SourcePoint Portal, those changes will reflect in the browser after a refresh.

--- a/sourcepoint-ui/README.md
+++ b/sourcepoint-ui/README.md
@@ -10,6 +10,6 @@ A better way to ensure your change are not lost is to take a copy of the full CS
 
 Ideally, in the longer term we hope to create a better way of testing locally before pushing the tested changes to Sourcepoint so that this repo becomes the source of truth rather than a (hopeful) reflection of it.
 
-For testing your message, make a note of the message id in SourcePoint's UI.  Alter the message_id field in MessageTester.html iFrame URL then spin up MessageTester.html via Live Server or similar and point your selected browser at localhost.
+For testing your message, make a note of the message id in SourcePoint's UI.  Alter the message_id field in MessageTester.html iFrame URL then spin up MessageTester.html in sourcepoint-ui via Live Server or similar and point your selected browser at localhost.
 
-As you change and save the message in the SourcePoint UI, those changes will reflect in the browser after a refresh.
+As you change and save the message in the SourcePoint Portal, those changes will reflect in the browser after a refresh.

--- a/sourcepoint-ui/live/TCFv2/theguardianDotCom TCFv2 first_layer.css
+++ b/sourcepoint-ui/live/TCFv2/theguardianDotCom TCFv2 first_layer.css
@@ -5,10 +5,17 @@
 • Move blur from gs-container to cta-container √
 • Gu-content vs gs-container padding bottom ?
 •
-•
-
 
 --------------- End of TODO ----------------*/
+
+/*--------------- Start NOTE ----------------
+• Make your changes in relevant file in
+https://github.com/guardian/consent-management-platform/tree/main/sourcepoint-ui
+and then paste the whole of the file contents into sourcepoint's css window for the file
+you're working on to avoid losing work on refresh
+or when others overwrite your work accidentally.
+--------------- End of NOTE ----------------*/
+
 
 * {
 	box-sizing: border-box;
@@ -20,7 +27,7 @@
 
 .gu-overlay {
 	font-size: 16px;
-	line-height: 20px;
+	/*line-height: 20px;*/
 }
 
 @font-face {
@@ -56,6 +63,11 @@
 ::selection {
 	background: #ffe500;
 	color: #121212;
+}
+
+/* needed for safari buttons? No knock on effect with Chrome at least*/
+button:focus {
+	box-shadow: 0 0 0 4px #0077B6 !important;
 }
 
 .accordion .chevron {
@@ -151,7 +163,7 @@
 	flex-direction: row;
 }
 
-.gu-privacy-headline > p {
+.gu-privacy-headline > h1 {
 	font-family: "Guardian Titlepiece", serif !important;
 	font-size: 24px !important;
 }
@@ -172,31 +184,66 @@
 	padding-bottom: 90px !important;
 }
 
+.main-text .cta-description em {
+	font-style: normal;
+	font-weight: bold;
+}
+
+.main-text .cta-description:focus {
+	border: none;
+	outline: unset;
+	outline: 4px solid #0077B6;
+}
+
+.main-text a:-webkit-any-link:focus-visible {
+	outline: 4px solid #0077B6;
+	outline-offset: 1px;
+}
+
 .message-stacks .accordion {
 	background: #052962;
+}
+
+.message-stacks button:focus {
+	border: unset;
+	box-shadow: none;
+}
+
+.message-stacks:focus {
+	border: unset;
+	outline: unset;
+	outline-offset: -4px !important;
+	outline: 4px solid #0077B6 !important;
+}
+
+.message-stacks .panel {
+	background: #052962;
+	border-bottom: 0px;
 }
 
 .message-stacks .stack {
 	width: 100%;
 	background-color: #052962;
+	margin-bottom: 5px; /* added */
+	padding: 4px !important;
+}
+
+.message-stacks .stack:focus,
+.message-stacks .stack:focus-within {
+	border: unset;
+	outline: unset;
+	outline: 4px solid #0077B6 !important;
+	outline-offset: -4px;
 }
 
 .message-stacks .stack:hover {
 	background-color: transparent;
 }
 
-.message-stacks button:focus {
-	box-shadow: none !important;
-}
+/*------------------------ HERE ------------------------------*/
 
-.main-text .cta-description em {
-	font-style: normal;
-	font-weight: bold;
-}
-
-.message-stacks .panel {
-	background: #052962;
-	border-bottom: 0px;
+.stack-container {
+	overflow: visible !important;
 }
 
 .panel {
@@ -211,6 +258,20 @@
 	line-height: 20px !important;
 	padding-left: 24px !important;
 	padding-right: 8px !important;
+}
+
+.tab-index-focus:focus-visible {
+	outline: 4px solid #0077B6;
+	outline-offset: 1px;
+}
+
+/* TEST - Added as potential fix for older Firefox lack of focus-visible */
+@supports not selector(:focus-visible) {
+	.tab-index-focus:focus {
+	  /* Fallback for browsers without :focus-visible support */
+	  outline: 4px solid #0077B6;
+	  outline-offset: 1px;
+	}
 }
 
 @media (max-width: 375px) {
@@ -282,15 +343,14 @@
 	}
 
 	.gu-privacy-headline {
-		margin-bottom: 17px !important;
+		margin-bottom: 12px !important;
 	}
 
-	.gu-privacy-headline > p {
+	.gu-privacy-headline > h1 {
 		font-size: 42px !important;
 	}
 
-	.body-copy,
-	.gu-tcfv2-privacy-notice {
+	.body-copy {
 		font-size: 15px !important;
 		line-height: 20px !important;
 		width: 35rem;
@@ -316,7 +376,7 @@
 	.main-text {
 		flex-direction: row;
 		flex-wrap: nowrap;
-		padding-bottom: 0 !important;
+		padding-bottom: 5px !important;
 	}
 }
 


### PR DESCRIPTION
## What does this change?

Minor change to update the CSS stub for TCFv2 in DotCom to the latest version which includes the tab index focus changes.
Also update to the docs in relation to making changes to the CSS in Sourcepoint's portal and being able to test locally.

## Why?

To keep an up-to-date versioned copy of the current CSS file associated with our live Sourcepoint banner.