### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@guardian/commercial-dev
+@guardian/transparency-consent


### PR DESCRIPTION
Switch owners to @guardian/transparency-consent

