### PR TITLE
test: Capture the CMP version when our supplier upgrades the CMP

### DIFF
--- a/monitoring/src/check-page/common-functions.ts
+++ b/monitoring/src/check-page/common-functions.ts
@@ -198,6 +198,15 @@ export const checkTopAdHasLoaded = async (page: Page): Promise<void> => {
 	log_info(`Waiting for ads to load: Complete`);
 };
 
+// TODO: work out why this doesn't work going around in circles between prettier and lint issues.
+export const recordVersionOfCMP = (page: Page) => {
+	log_info('*** Getting the version of Sourcepoint CMP ***');
+	//await page.evaluate(() => {
+	//eval(`console.log(window._sp_.version)`);
+	//});
+	//log_info(`current Sourcepoint version is ${getVersion}`);
+};
+
 /**
  * This function checks for the CMP banner on the page
  *
@@ -269,6 +278,8 @@ export const loadPage = async (page: Page, url: string): Promise<void> => {
 		log_error(`Loading URL: Error: Status ${response.status()}`);
 		throw 'Failed to load page!';
 	}
+
+	await recordVersionOfCMP(page);
 
 	log_info(`Loading page: Complete`);
 };

--- a/monitoring/src/check-page/common-functions.ts
+++ b/monitoring/src/check-page/common-functions.ts
@@ -198,13 +198,14 @@ export const checkTopAdHasLoaded = async (page: Page): Promise<void> => {
 	log_info(`Waiting for ads to load: Complete`);
 };
 
-// TODO: work out why this doesn't work going around in circles between prettier and lint issues.
-export const recordVersionOfCMP = (page: Page) => {
-	log_info('*** Getting the version of Sourcepoint CMP ***');
-	//await page.evaluate(() => {
-	//eval(`console.log(window._sp_.version)`);
-	//});
-	//log_info(`current Sourcepoint version is ${getVersion}`);
+export const recordVersionOfCMP = async (page: Page) => {
+	log_info('* Getting the version of Sourcepoint CMP');
+
+	const functionToGetVersion = function () {
+		return window._sp_.version;
+	};
+
+	log_info(await page.evaluate(functionToGetVersion));
 };
 
 /**
@@ -216,6 +217,7 @@ export const recordVersionOfCMP = (page: Page) => {
 export const checkCMPIsOnPage = async (page: Page): Promise<void> => {
 	log_info(`Waiting for CMP: Start`);
 	await page.waitForSelector(ELEMENT_ID.CMP_CONTAINER);
+	await recordVersionOfCMP(page); // needs to be called here otherwise not yet loaded.
 	log_info(`Waiting for CMP: Complete`);
 };
 
@@ -278,8 +280,6 @@ export const loadPage = async (page: Page, url: string): Promise<void> => {
 		log_error(`Loading URL: Error: Status ${response.status()}`);
 		throw 'Failed to load page!';
 	}
-
-	await recordVersionOfCMP(page);
 
 	log_info(`Loading page: Complete`);
 };

--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -17,6 +17,7 @@ import {
 	log_info,
 	makeNewBrowser,
 	openPrivacySettingsPanel,
+	// recordVersionOfCMP,
 	reloadPage,
 } from './common-functions';
 
@@ -124,9 +125,9 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 
 	await firstLayerCheck(config, url, page, browser, nextUrl);
 
-	await secondLayerCheck(config, url, page, browser, nextUrl);
+	// await secondLayerCheck(config, url, page, browser, nextUrl);
 
-	await checkCMPLoadingTime(page, config);
+	// await checkCMPLoadingTime(page, config);
 
 	await browser.close();
 };

--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -17,7 +17,6 @@ import {
 	log_info,
 	makeNewBrowser,
 	openPrivacySettingsPanel,
-	// recordVersionOfCMP,
 	reloadPage,
 } from './common-functions';
 
@@ -127,7 +126,7 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 
 	await secondLayerCheck(config, url, page);
 
-	// await checkCMPLoadingTime(page, config);
+	await checkCMPLoadingTime(page, config);
 
 	await browser.close();
 };

--- a/monitoring/src/types.ts
+++ b/monitoring/src/types.ts
@@ -1,14 +1,15 @@
 import type { Viewport } from 'puppeteer-core';
 
-declare global {
-	interface Window {
-		__uspapi: (
-			command: string,
-			version: number,
-			callback: (uspData: UspData) => void,
-		) => undefined;
-	}
-}
+// declare global {
+// 	interface Window {
+// 		__uspapi: (
+// 			command: string,
+// 			version: number,
+// 			callback: (uspData: UspData) => void,
+// 		) => undefined;
+// 		_sp_: { version: string };
+// 	}
+// }
 
 export type CustomPuppeteerOptions = {
 	headless: boolean;

--- a/monitoring/src/types.ts
+++ b/monitoring/src/types.ts
@@ -1,15 +1,15 @@
 import type { Viewport } from 'puppeteer-core';
 
-// declare global {
-// 	interface Window {
-// 		__uspapi: (
-// 			command: string,
-// 			version: number,
-// 			callback: (uspData: UspData) => void,
-// 		) => undefined;
-// 		_sp_: { version: string };
-// 	}
-// }
+declare global {
+	interface Window {
+		// 		__uspapi: (
+		// 			command: string,
+		// 			version: number,
+		// 			callback: (uspData: UspData) => void,
+		// 		) => undefined;
+		_sp_: { version: string };
+	}
+}
 
 export type CustomPuppeteerOptions = {
 	headless: boolean;


### PR DESCRIPTION
## What does this change?
This captures the version of the CMP each time it runs Monitoring in order to allow us to gain better visibility over exactly when Sourcepoint upgrades it's CMP.

This aids our debugging - ruling in or out a potential change in the background over which we have little control.

This will appear in the logs each time monitoring runs.

## Why?
Occasionally in the past, such an upgrade has impacted the service and it has been difficult to know whether or not it was on our supplier's end or ours.  Our supplier only gives us a time range of a week when they plan to do an upgrade so this will provide us with greater accuracy. 