### PR TITLE
fix!: Upgrade Typescript ~4.9.5 & Cypress

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   viewportHeight: 768,
   video: false,
   chromeWebSecurity: false,
-  retries: 2,
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
   defaultCommandTimeout: 5000,
   e2e: {
     // We've imported your old cypress plugins here.

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,21 +1,21 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  viewportWidth: 1440,
-  viewportHeight: 768,
-  video: false,
-  chromeWebSecurity: false,
-  retries: {
-    runMode: 2,
-    openMode: 0,
-  },
-  defaultCommandTimeout: 5000,
-  e2e: {
-    // We've imported your old cypress plugins here.
-    // You may want to clean this up later by importing these.
-    setupNodeEvents(on, config) {
-      return require('./cypress/plugins/index.js').default(on, config)
-    },
-    baseUrl: 'http://localhost:10001/',
-  },
-})
+	viewportWidth: 1440,
+	viewportHeight: 768,
+	video: false,
+	chromeWebSecurity: false,
+	retries: {
+		runMode: 2,
+		openMode: 0,
+	},
+	defaultCommandTimeout: 5000,
+	e2e: {
+		// We've imported your old cypress plugins here.
+		// You may want to clean this up later by importing these.
+		setupNodeEvents(on, config) {
+			return require('./cypress/plugins/index.js').default(on, config);
+		},
+		baseUrl: 'http://localhost:10001/',
+	},
+});

--- a/cypress/e2e/sourcepoint-aus.cy.js
+++ b/cypress/e2e/sourcepoint-aus.cy.js
@@ -4,7 +4,6 @@ import {
 	ENDPOINT,
 	PRIVACY_MANAGER_AUSTRALIA,
 } from '../../src/lib/sourcepointConfig';
-import { loadPage } from '../utils';
 
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = `#sp_message_iframe_${PRIVACY_MANAGER_AUSTRALIA}`;
@@ -21,10 +20,14 @@ const personalisedAdvertisingIs = (boolean) => {
 };
 
 describe('Window', () => {
-	loadPage(url);
+	beforeEach(() => {
+		cy.visit(url);
+	});
+
 	it('has the guCmpHotFix object', () => {
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
+
 	it('has correct config params', () => {
 		cy.window()
 			.its('_sp_.config')
@@ -36,7 +39,9 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	loadPage(url);
+	beforeEach(() => {
+		cy.visit(url);
+	});
 
 	it('should have the Sourcepoint iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
@@ -52,17 +57,9 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	loadPage(url);
-
-	// Cookies need to be kept for consent to be passed from one test to the next
 	beforeEach(() => {
+		cy.visit(url);
 		cy.setCookie('ccpaApplies', 'true');
-		Cypress.Cookies.preserveOnce(
-			'ccpaUUID',
-			'ccpaReject',
-			'ccpaConsentAll',
-			'consentStatus',
-		);
 	});
 
 	it('should have personalised advertising set to true by default', () => {

--- a/cypress/e2e/sourcepoint-aus.cy.js
+++ b/cypress/e2e/sourcepoint-aus.cy.js
@@ -20,15 +20,13 @@ const personalisedAdvertisingIs = (boolean) => {
 };
 
 describe('Window', () => {
-	beforeEach(() => {
-		cy.visit(url);
-	});
-
 	it('has the guCmpHotFix object', () => {
+		cy.visit(url);
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
 
 	it('has correct config params', () => {
+		cy.visit(url);
 		cy.window()
 			.its('_sp_.config')
 			.then((spConfig) => {
@@ -39,15 +37,13 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	beforeEach(() => {
-		cy.visit(url);
-	});
-
 	it('should have the Sourcepoint iframe', () => {
+		cy.visit(url);
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
 
 	it('should have the correct script URL', () => {
+		cy.visit(url);
 		cy.get('script#sourcepoint-lib').should(
 			'have.attr',
 			'src',
@@ -57,22 +53,26 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	beforeEach(() => {
+	it('should have personalised advertising set to true by default', () => {
 		cy.visit(url);
 		cy.setCookie('ccpaApplies', 'true');
-	});
-
-	it('should have personalised advertising set to true by default', () => {
 		personalisedAdvertisingIs(true);
 	});
 
 	it('Should click continue to dismiss the banner', () => {
+		cy.visit(url);
+		cy.setCookie('ccpaApplies', 'true');
 		cy.getIframeBody(iframeMessage)
 			.find(`button[title="Continue"]`)
 			.click();
 	});
 
 	it(`should be able to retract consent`, () => {
+		cy.visit(url);
+		cy.setCookie('ccpaApplies', 'true');
+
+		personalisedAdvertisingIs(true);
+
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager).find('.pm-toggle .off').click();

--- a/cypress/e2e/sourcepoint-ccpa.cy.js
+++ b/cypress/e2e/sourcepoint-ccpa.cy.js
@@ -3,7 +3,6 @@ import {
 	ENDPOINT,
 	PRIVACY_MANAGER_CCPA,
 } from '../../src/lib/sourcepointConfig';
-import { loadPage } from '../utils';
 
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = `#sp_message_iframe_${PRIVACY_MANAGER_CCPA}`;
@@ -20,13 +19,12 @@ const doNotSellIs = (boolean) => {
 };
 
 describe('Window', () => {
-	beforeEach(() => {
-		cy.visit(url);
-	});
 	it('has the guCmpHotFix object', () => {
+		cy.visit(url);
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
 	it('has correct config params', () => {
+		cy.visit(url);
 		cy.window()
 			.its('_sp_.config')
 			.then((spConfig) => {
@@ -37,13 +35,12 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	beforeEach(() => {
-		cy.visit(url);
-	});
 	it('should have the SP iframe', () => {
+		cy.visit(url);
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
 	it('should have the correct script URL', () => {
+		cy.visit(url);
 		cy.get('script#sourcepoint-lib').should(
 			'have.attr',
 			'src',
@@ -53,24 +50,30 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	beforeEach(() => {
-		cy.visit(url);
-	});
 	const buttonTitle = 'Do not sell my personal information';
 
 	it('should have DNS set to false by default', () => {
+		cy.visit(url);
 		doNotSellIs(false);
 	});
 
 	it(`should retract consent when clicking "${buttonTitle}"`, () => {
+		cy.visit(url);
 		cy.getIframeBody(iframeMessage)
 			.find(`button[title="${buttonTitle}"]`)
 			.click();
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(2000);
 
 		doNotSellIs(true);
 	});
 
 	it(`should be able to retract consent`, () => {
+		cy.visit(url);
+
+		doNotSellIs(false);
+
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager).find('.pm-toggle .off').click();
@@ -79,6 +82,9 @@ describe('Interaction', () => {
 			.find('.sp_choice_type_SAVE_AND_EXIT')
 			.should('be.visible')
 			.click();
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(2000);
 
 		doNotSellIs(true);
 	});

--- a/cypress/e2e/sourcepoint-ccpa.cy.js
+++ b/cypress/e2e/sourcepoint-ccpa.cy.js
@@ -20,7 +20,9 @@ const doNotSellIs = (boolean) => {
 };
 
 describe('Window', () => {
-	loadPage(url);
+	beforeEach(() => {
+		cy.visit(url);
+	});
 	it('has the guCmpHotFix object', () => {
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
@@ -35,7 +37,9 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	loadPage(url);
+	beforeEach(() => {
+		cy.visit(url);
+	});
 	it('should have the SP iframe', () => {
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
@@ -49,7 +53,9 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	loadPage(url);
+	beforeEach(() => {
+		cy.visit(url);
+	});
 	const buttonTitle = 'Do not sell my personal information';
 
 	it('should have DNS set to false by default', () => {

--- a/cypress/e2e/sourcepoint-tcfv2.cy.js
+++ b/cypress/e2e/sourcepoint-tcfv2.cy.js
@@ -1,5 +1,4 @@
 import { ENDPOINT } from '../../src/lib/sourcepointConfig';
-import { loadPage } from '../utils';
 
 const iframeMessage = `[id^="sp_message_iframe_"]`;
 const iframePrivacyManager = '#sp_message_iframe_106842';
@@ -8,11 +7,12 @@ const iframePrivacyManager = '#sp_message_iframe_106842';
 const url = `/#tcfv2`;
 
 describe('Window', () => {
-	loadPage(url);
 	it('has the guCmpHotFix object', () => {
+		cy.visit(url);
 		cy.window().should('have.property', 'guCmpHotFix');
 	});
 	it('has correct config params', () => {
+		cy.visit(url);
 		cy.window()
 			.its('_sp_.config')
 			.then((spConfig) => {
@@ -23,12 +23,13 @@ describe('Window', () => {
 });
 
 describe('Document', () => {
-	loadPage(url);
 	it('should have the SP iframe', () => {
+		cy.visit(url);
 		cy.get('iframe').should('be.visible').get(iframeMessage);
 	});
 
 	it('should have the correct script URL', () => {
+		cy.visit(url);
 		cy.get('script#sourcepoint-lib').should(
 			'have.attr',
 			'src',
@@ -38,22 +39,19 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	loadPage(url);
 	const buttonTitle = 'Yes, I’m happy';
 
-	beforeEach(() => {
+	it(`should give all consents when clicking "${buttonTitle}"`, () => {
+		cy.visit(url);
 		cy.setCookie('ccpaApplies', 'false');
 		cy.setCookie('gdprApplies', 'true');
-		Cypress.Cookies.preserveOnce('consentUUID', 'euconsent-v2');
-	});
 
-	it(`should give all consents when clicking "${buttonTitle}"`, () => {
 		cy.getIframeBody(iframeMessage)
 			.find(`button[title="${buttonTitle}"]`)
 			.click();
 
 		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-		cy.wait(1000);
+		cy.wait(2000);
 
 		[(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)].forEach((purpose) => {
 			cy.get(`[data-purpose="${purpose}"]`).should(
@@ -65,6 +63,17 @@ describe('Interaction', () => {
 	});
 
 	it(`should be able to only deactivate purpose 1`, () => {
+		cy.visit(url);
+		cy.setCookie('ccpaApplies', 'false');
+		cy.setCookie('gdprApplies', 'true');
+
+		cy.getIframeBody(iframeMessage)
+			.find(`button[title="${buttonTitle}"]`)
+			.click();
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
+		cy.wait(2000);
+
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager)
@@ -77,7 +86,7 @@ describe('Interaction', () => {
 			.click();
 
 		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-		cy.wait(1000);
+		cy.wait(2000);
 
 		cy.get(`[data-purpose="1"]`)
 			.should('have.data', 'consent')
@@ -91,6 +100,14 @@ describe('Interaction', () => {
 	});
 
 	it(`should be able to refuse all but purpose 1`, () => {
+		cy.visit(url);
+		cy.setCookie('ccpaApplies', 'false');
+		cy.setCookie('gdprApplies', 'true');
+
+		cy.getIframeBody(iframeMessage)
+			.find(`button[title="${buttonTitle}"]`)
+			.click();
+
 		cy.get('[data-cy=pm]').click();
 
 		cy.getIframeBody(iframePrivacyManager)
@@ -107,16 +124,16 @@ describe('Interaction', () => {
 			.click();
 
 		// eslint-disable-next-line cypress/no-unnecessary-waiting -- should we do this?
-		cy.wait(1000);
+		cy.wait(2000);
 
 		cy.get(`[data-purpose="1"]`)
 			.should('have.data', 'consent')
-			.should('equal', false);
+			.should('equal', true);
 
 		[2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((purpose) => {
 			cy.get(`[data-purpose="${purpose}"]`)
 				.should('have.data', 'consent')
-				.should('equal', true);
+				.should('equal', false);
 		});
 	});
 });

--- a/cypress/e2e/sourcepoint-tcfv2.cy.js
+++ b/cypress/e2e/sourcepoint-tcfv2.cy.js
@@ -62,7 +62,7 @@ describe('Interaction', () => {
 		});
 	});
 
-	it(`should be able to only deactivate purpose 1`, () => {
+	it(`should deactivate purpose 1 only`, () => {
 		cy.visit(url);
 		cy.setCookie('ccpaApplies', 'false');
 		cy.setCookie('gdprApplies', 'true');
@@ -99,7 +99,7 @@ describe('Interaction', () => {
 		});
 	});
 
-	it(`should be able to refuse all but purpose 1`, () => {
+	it(`should deactivate all purposes except purpose 1`, () => {
 		cy.visit(url);
 		cy.setCookie('ccpaApplies', 'false');
 		cy.setCookie('gdprApplies', 'true');

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -2,9 +2,7 @@ export const loadPage = (url) => {
 	it(`should load the page: ${url}`, () => {
 		cy.clearLocalStorage();
 
-		// undocumented fix for cookies from non-localhost domains
-		// https://github.com/cypress-io/cypress/issues/408#issuecomment-643281127
-		cy.clearCookies({ domain: null });
+		cy.clearAllCookies();
 
 		cy.visit(url);
 	});

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,9 +1,0 @@
-export const loadPage = (url) => {
-	it(`should load the page: ${url}`, () => {
-		cy.clearLocalStorage();
-
-		cy.clearAllCookies();
-
-		cy.visit(url);
-	});
-};

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@rollup/plugin-typescript": "^8",
     "@semantic-release/github": "^8",
     "@types/jest": "^27",
+    "@types/node": "^18.15.5",
     "@typescript-eslint/eslint-plugin": "~4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "axios": "^0.25.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
-    "cypress": "^11.2.0",
+    "cypress": "^12.8.1",
     "cypress-wait-until": "^1.7.2",
     "eslint": "^7",
     "eslint-config-airbnb-typescript": "^12",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "start-server-and-test": "~1.14.0",
     "svelte": "~3.52.0",
     "tslib": "^2.4.1",
-    "typescript": "^4",
+    "typescript": "~4.9.5",
     "wait-for-expect": "^3"
   },
   "peerDependencies": {

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -8,7 +8,10 @@ export const getConsentFor: GetConsentFor = (
 ): boolean => {
 	const sourcepointIds = VendorIDs[vendor];
 
-	if (typeof sourcepointIds === 'undefined' || sourcepointIds === []) {
+	if (
+		typeof sourcepointIds === 'undefined' ||
+		(Array.isArray(sourcepointIds) && sourcepointIds.length === 0)
+	) {
 		throw new Error(
 			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
 				'If it should be added, raise an issue at https://github.com/guardian/consent-management-platform/issues',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11094,10 +11094,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.13.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4327,10 +4327,10 @@ cypress-wait-until@^1.7.2:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
   integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
-cypress@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
-  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
+cypress@^12.8.1:
+  version "12.8.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.8.1.tgz#0c6e67f34554d553138697aaf349b637d80004eb"
+  integrity sha512-lIFbKdaSYAOarNLHNFa2aPZu6YSF+8UY4VRXMxJrFUnk6RvfG0AWsZ7/qle/aIz30TNUD4aOihz2ZgS4vuQVSA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -4349,7 +4349,7 @@ cypress@^11.2.0:
     commander "^5.1.0"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
@@ -4413,7 +4413,7 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,6 +2532,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.9.tgz#b97c057e6138adb7b720df2bd0264b03c9f504fd"
   integrity sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==
 
+"@types/node@^18.15.5":
+  version "18.15.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.5.tgz#3af577099a99c61479149b716183e70b5239324a"
+  integrity sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
## What does this change?

Upgrade:

- typescript@~4.9.5 to align with other repos
- cypress@^12.8.1

Cypress 12 now enforces [test isolation](https://www.cypress.io/blog/2022/12/06/announcing-cypress-12/#test-isolation-is-now-default). So I've also updated the e2e tests to not rely on previous test state and each test run initialises itself.

## Why?

Upgrade all the things

I attempted to release #724 previously with a `chore!` but it did not trigger a major release and it is blocking https://github.com/guardian/frontend/pull/25892.

I'm overriding the semantic prefix here with `fix!` to force a major release.
