### PR TITLE
chore!: fix semantic release conventional commits preset for ! syntax

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,10 +1,19 @@
 {
   "branches": ["main", { "name": "beta", "prerelease": true }],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/npm",
     "@semantic-release/github"
-  ],
-  "preset": "conventionalcommits"
+  ]
 }


### PR DESCRIPTION
## What does this change?

As described in https://github.com/guardian/commercial/pull/848 the conventionalcommits preset configuration for semantic-release stopped working for `!` with types (build, chore, ci, docs, style, refactor, perf, test) and now only works for fix or feat.

This change should fix the preset for all commit types so that commits with with a `!` should create a major release.

I've deliberately created a chore! commit to test this.

