### PR TITLE
fix: remove fb vendor from vendor list

### DIFF
--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -4,7 +4,6 @@ export const VendorIDs = {
 	acast: ['5f203dcb1f0dea790562e20f'],
 	braze: ['5ed8c49c4b8ce4571c7ad801'],
 	comscore: ['5efefe25b8e05c06542b2a77'],
-	fb: ['5e7e1298b8e05c54a85c52d2'],
 	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
 	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
 	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],


### PR DESCRIPTION
## What does this change?

Removed the Facebook vendor from the vendor list

## Why?

It is being removed from our IAB list and therefore must be removed from this.