### PR TITLE
test: fix broken monitoring after SP upgrade

### DIFF
--- a/monitoring/src/check-page/tcfv2.ts
+++ b/monitoring/src/check-page/tcfv2.ts
@@ -201,6 +201,7 @@ export const secondLayerCheck = async function (
 ): Promise<void> {
 	const client = await page.target().createCDPSession();
 	await clearCookies(client);
+	await clearLocalStorage(page);
 
 	log_info('Checking second layer: Start');
 
@@ -225,6 +226,7 @@ export const secondLayerCheck = async function (
 	log_info('Starting Reject All check');
 	// Testing the Reject All button hides the CMP and does not load Ads
 	await clearCookies(client);
+	await clearLocalStorage(page);
 
 	await reloadPage(page);
 


### PR DESCRIPTION
## What does this change?

This change clears local storage as well as cookies before testing the second layer in cmp monitoring. 

## Why?

Following an upgrade to our underlying CMP to 4.9.0, consent is lingering in local storage from the previous test of the first layer and clearing cookies only no longer clears the consent ready to test the second layer. 