### PR TITLE
test: added token permissions for gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,10 @@ on:
       - main
 jobs:
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## What does this change?

The job to deploy to gh_pages suddenly stopped working last week. 
On discussion with the DevX team it appears we need to add more permissions to the workflow to ensure that it has access to the token.

[GitHub Docs for assigning permissions to a specific job](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) and [GitHub's starter workflow pages](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) suggested this set of permissions.

## Why?

Moving to an enterprise account has made access to GITHUB_TOKEN more restrictive so we need to add permissions on a per job basis - ideally the minimum set of permissions required for the job to complete.
