### PR TITLE
feat: Implement vendor cookie and localStorage consent based deny list

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ type: `string`
 -   `"acast"`
 -   `"braze"`
 -   `"comscore"`
+-   `"criteo"`
 -   `"google-analytics"`
 -   `"google-mobile-ads"`
 -   `"google-tag-manager"`

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "markdown-toc": "^1",
     "np": "^7",
     "npm-run-all": "^4",
-    "prettier": "^2.5.1",
+    "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.6.0",
     "rollup": "^2.70.1",
     "rollup-plugin-css-only": "^3",
@@ -101,8 +101,8 @@
   "peerDependencies": {
     "@guardian/libs": "^14.0.0"
   },
-	"resolutions":{
-		"//": "Once Jest upgrades its transitive dependency on json5 >=2.0.0, <2.2.2, remove this resolution",
-		"json5": "^2.2.2"
-	}
+  "resolutions": {
+    "//": "Once Jest upgrades its transitive dependency on json5 >=2.0.0, <2.2.2, remove this resolution",
+    "json5": "^2.2.2"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,9 +63,9 @@ const init: InitCMP = ({ pubData, country }) => {
 		log('cmp', 'initComplete');
 	});
 
-	initVendorDataManager();
-
 	resolveInitialised();
+
+	initVendorDataManager();
 };
 
 const willShowPrivacyMessage: WillShowPrivacyMessage = () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 	onConsentChange as serverOnConsentChange,
 } from './server';
 import type { CMP, InitCMP, WillShowPrivacyMessage } from './types';
+import { initVendorDataManager } from './vendorDataManager';
 
 // Store some bits in the global scope for reuse, in case there's more
 // than one instance of the CMP on the page in different scopes.
@@ -61,6 +62,8 @@ const init: InitCMP = ({ pubData, country }) => {
 		initComplete = true;
 		log('cmp', 'initComplete');
 	});
+
+	initVendorDataManager();
 
 	resolveInitialised();
 };

--- a/src/vendorDataManager.test.ts
+++ b/src/vendorDataManager.test.ts
@@ -1,7 +1,7 @@
 import { initVendorDataManager } from './vendorDataManager';
 import { onConsentChange } from './onConsentChange';
 import { removeCookie, storage } from '@guardian/libs';
-import { vendorLocalStorageData, vendorCookieData } from './vendorStorageIds';
+import { vendorStorageIds } from './vendorStorageIds';
 import { Callback, ConsentState } from './types';
 import { TCFv2ConsentState } from './types/tcfv2';
 
@@ -17,7 +17,7 @@ const tcfv2ConsentState: TCFv2ConsentState = {
 	eventStatus: 'tcloaded',
 	vendorConsents: {
 		'5fa51b29a228638b4a1980e4': true, // ipsos
-		'5e98e7f1b8e05c111d01b462': false, // criteo
+		'5eff0d77969bfa03746427eb': false, // permutive
 	},
 	addtlConsent: 'xyz',
 	gdprApplies: true,
@@ -26,19 +26,23 @@ const tcfv2ConsentState: TCFv2ConsentState = {
 
 jest.mock('./vendors', () => ({
 	VendorIDs: {
-		criteo: ['5e98e7f1b8e05c111d01b462'],
+		permutive: ['5eff0d77969bfa03746427eb'],
 		ipsos: ['5fa51b29a228638b4a1980e4'],
 	},
 }));
 
 jest.mock('./vendorStorageIds', () => ({
-	vendorCookieData: {
-		criteo: ['criteoCookie1', 'criteoCookie2'],
-		ipsos: ['ipsosCookie1', 'ipsosCookie2'],
-	},
-	vendorLocalStorageData: {
-		criteo: ['criteoLocalStorage1', 'criteoLocalStorage2'],
-		ipsos: ['ipsosLocalStorage1', 'ipsosLocalStorage2'],
+	vendorStorageIds: {
+		permutive: {
+			cookies: ['permutiveCookie1', 'permutiveCookie2'],
+			localStorage: ['permutiveLocalStorage1', 'permutiveLocalStorage2'],
+			sessionStorage: ['permutiveSessionStorage1'],
+		},
+		ipsos: {
+			cookies: ['ipsosCookie1', 'ipsosCookie2'],
+			localStorage: ['ipsosLocalStorage1', 'ipsosLocalStorage2'],
+			sessionStorage: ['ipsosSessionStorage1'],
+		},
 	},
 }));
 
@@ -71,22 +75,24 @@ describe('initVendorDataManager', () => {
 
 		initVendorDataManager();
 
-		vendorCookieData.criteo.forEach((name) => {
+		vendorStorageIds.permutive.cookies.forEach((name) => {
 			expect(removeCookie).toHaveBeenCalledWith({ name });
 		});
 
-		vendorCookieData.ipsos.forEach((name) => {
+		vendorStorageIds.ipsos.cookies.forEach((name) => {
 			expect(removeCookie).not.toHaveBeenCalledWith({ name });
 		});
 
-		vendorLocalStorageData.criteo.forEach((name) => {
+		vendorStorageIds.permutive.localStorage.forEach((name) => {
 			expect(storage.local.remove).toHaveBeenCalledWith(name);
+		});
+
+		vendorStorageIds.permutive.sessionStorage.forEach((name) => {
 			expect(storage.session.remove).toHaveBeenCalledWith(name);
 		});
 
-		vendorLocalStorageData.ipsos.forEach((name) => {
+		vendorStorageIds.ipsos.localStorage.forEach((name) => {
 			expect(storage.local.remove).not.toHaveBeenCalledWith(name);
-			expect(storage.session.remove).not.toHaveBeenCalledWith(name);
 		});
 	});
 });

--- a/src/vendorDataManager.test.ts
+++ b/src/vendorDataManager.test.ts
@@ -1,0 +1,87 @@
+import { initVendorDataManager } from './vendorDataManager';
+import { onConsentChange } from './onConsentChange';
+import { removeCookie, storage } from '@guardian/libs';
+import { vendorLocalStorageData, vendorCookieData } from './vendorStorageIds';
+import { Callback, ConsentState } from './types';
+import { TCFv2ConsentState } from './types/tcfv2';
+
+jest.mock('./onConsentChange');
+
+const tcfv2ConsentState: TCFv2ConsentState = {
+	consents: { 1: true },
+	eventStatus: 'tcloaded',
+	vendorConsents: {
+		'5fa51b29a228638b4a1980e4': true, // ipsos
+		'5e98e7f1b8e05c111d01b462': false, // criteo
+	},
+	addtlConsent: 'xyz',
+	gdprApplies: true,
+	tcString: 'YAAA',
+};
+
+jest.mock('./vendors', () => ({
+	VendorIDs: {
+		criteo: ['5e98e7f1b8e05c111d01b462'],
+		ipsos: ['5fa51b29a228638b4a1980e4'],
+	},
+}));
+
+jest.mock('./vendorStorageIds', () => ({
+	vendorCookieData: {
+		criteo: ['criteoCookie1', 'criteoCookie2'],
+		ipsos: ['ipsosCookie1', 'ipsosCookie2'],
+	},
+	vendorLocalStorageData: {
+		criteo: ['criteoLocalStorage1', 'criteoLocalStorage2'],
+		ipsos: ['ipsosLocalStorage1', 'ipsosLocalStorage2'],
+	},
+}));
+
+const mockOnConsentChange = (consentState: ConsentState) =>
+	(onConsentChange as jest.Mock).mockImplementation((cb: Callback) =>
+		cb(consentState),
+	);
+
+jest.mock('@guardian/libs', () => ({
+	removeCookie: jest.fn(),
+	storage: {
+		local: {
+			remove: jest.fn(),
+		},
+		session: {
+			remove: jest.fn(),
+		},
+	},
+}));
+
+describe('initVendorDataManager', () => {
+	it('should remove cookies and localStorage data only for vendors that the user has not consented to', async () => {
+		const consentState: ConsentState = {
+			tcfv2: tcfv2ConsentState,
+			canTarget: true,
+			framework: 'tcfv2',
+		};
+
+		mockOnConsentChange(consentState);
+
+		initVendorDataManager();
+
+		vendorCookieData.criteo.forEach((name) => {
+			expect(removeCookie).toHaveBeenCalledWith({ name });
+		});
+
+		vendorCookieData.ipsos.forEach((name) => {
+			expect(removeCookie).not.toHaveBeenCalledWith({ name });
+		});
+
+		vendorLocalStorageData.criteo.forEach((name) => {
+			expect(storage.local.remove).toHaveBeenCalledWith(name);
+			expect(storage.session.remove).toHaveBeenCalledWith(name);
+		});
+
+		vendorLocalStorageData.ipsos.forEach((name) => {
+			expect(storage.local.remove).not.toHaveBeenCalledWith(name);
+			expect(storage.session.remove).not.toHaveBeenCalledWith(name);
+		});
+	});
+});

--- a/src/vendorDataManager.test.ts
+++ b/src/vendorDataManager.test.ts
@@ -7,6 +7,11 @@ import { TCFv2ConsentState } from './types/tcfv2';
 
 jest.mock('./onConsentChange');
 
+Object.defineProperty(window, 'requestIdleCallback', {
+	writable: false,
+	value: jest.fn().mockImplementation((cb) => cb()),
+});
+
 const tcfv2ConsentState: TCFv2ConsentState = {
 	consents: { 1: true },
 	eventStatus: 'tcloaded',

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -1,7 +1,7 @@
 import { removeCookie, storage } from "@guardian/libs";
 import { getConsentFor } from "./getConsentFor";
 import { onConsentChange } from "./onConsentChange";
-import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
+import { VendorWithCookieData, VendorWithLocalStorageData, storageKeys, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
 
 /**
  * This function is called when the CMP is initialised. It listens for consent changes and removes cookies and localStorage data for vendors that the user has not consented to.
@@ -9,24 +9,16 @@ import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, ven
 export const initVendorDataManager = (): void => {
 	onConsentChange((consent) => {
 		requestIdleCallback(() => {
-			(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
+			storageKeys.forEach(([vendor, key, storageType]) => {
 				const consentForVendor = getConsentFor(vendor, consent);
+
 				if (!consentForVendor) {
-					vendorCookieData[vendor].forEach((name) => {
-						removeCookie({name});
-					});
-
-				}
-			});
-
-			(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
-				const consentForVendor = getConsentFor(vendor, consent);
-				if (!consentForVendor) {
-					vendorLocalStorageData[vendor].forEach((name) => {
-						storage.local.remove(name);
-						storage.session.remove(name);
-					});
-
+					if (storageType === "cookie") {
+						removeCookie({name: key});
+					} else {
+						storage.local.remove(key);
+						storage.session.remove(key);
+					}
 				}
 			});
 		});

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -1,0 +1,32 @@
+import { removeCookie, storage } from "@guardian/libs";
+import { getConsentFor } from "./getConsentFor";
+import { onConsentChange } from "./onConsentChange";
+import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
+
+/**
+ * This function is called when the CMP is initialised. It listens for consent changes and removes cookies and localStorage data for vendors that the user has not consented to.
+ */
+export const initVendorDataManager = (): void => {
+	onConsentChange((consent) => {
+		(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
+			const consentForVendor = getConsentFor(vendor, consent);
+			if (!consentForVendor) {
+				vendorCookieData[vendor].forEach((name) => {
+					removeCookie({name});
+				});
+
+			}
+		});
+
+		(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
+			const consentForVendor = getConsentFor(vendor, consent);
+			if (!consentForVendor) {
+				vendorLocalStorageData[vendor].forEach((name) => {
+					storage.local.remove(name);
+					storage.session.remove(name);
+				});
+
+			}
+		});
+	});
+};

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -1,7 +1,7 @@
-import { removeCookie, storage } from "@guardian/libs";
-import { getConsentFor } from "./getConsentFor";
-import { onConsentChange } from "./onConsentChange";
-import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
+import { removeCookie, storage } from '@guardian/libs';
+import { getConsentFor } from './getConsentFor';
+import { onConsentChange } from './onConsentChange';
+import { VendorWithData, vendorStorageIds } from './vendorStorageIds';
 
 /**
  * This function is called when the CMP is initialised. It listens for consent changes and removes cookies and localStorage data for vendors that the user has not consented to.
@@ -9,26 +9,29 @@ import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, ven
 export const initVendorDataManager = (): void => {
 	onConsentChange((consent) => {
 		requestIdleCallback(() => {
-			(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
-				const consentForVendor = getConsentFor(vendor, consent);
-				if (!consentForVendor) {
-					vendorCookieData[vendor].forEach((name) => {
-						removeCookie({name});
-					});
-
-				}
-			});
-
-			(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
-				const consentForVendor = getConsentFor(vendor, consent);
-				if (!consentForVendor) {
-					vendorLocalStorageData[vendor].forEach((name) => {
-						storage.local.remove(name);
-						storage.session.remove(name);
-					});
-
-				}
-			});
+			(<VendorWithData[]>Object.keys(vendorStorageIds)).forEach(
+				(vendor) => {
+					const consentForVendor = getConsentFor(vendor, consent);
+					const vendorData = vendorStorageIds[vendor];
+					if (!consentForVendor) {
+						if ('cookies' in vendorData) {
+							vendorData.cookies.forEach((name) => {
+								removeCookie({ name });
+							});
+						}
+						if ('localStorage' in vendorData) {
+							vendorData.localStorage.forEach((name) => {
+								storage.local.remove(name);
+							});
+						}
+						if ('sessionStorage' in vendorData) {
+							vendorData.sessionStorage.forEach((name) => {
+								storage.session.remove(name);
+							});
+						}
+					}
+				},
+			);
 		});
 	});
 };

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -32,6 +32,8 @@ export const initVendorDataManager = (): void => {
 					}
 				},
 			);
+		}, {
+			timeout: 2000,
 		});
 	});
 };

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -8,25 +8,27 @@ import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, ven
  */
 export const initVendorDataManager = (): void => {
 	onConsentChange((consent) => {
-		(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
-			const consentForVendor = getConsentFor(vendor, consent);
-			if (!consentForVendor) {
-				vendorCookieData[vendor].forEach((name) => {
-					removeCookie({name});
-				});
+		requestIdleCallback(() => {
+			(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
+				const consentForVendor = getConsentFor(vendor, consent);
+				if (!consentForVendor) {
+					vendorCookieData[vendor].forEach((name) => {
+						removeCookie({name});
+					});
 
-			}
-		});
+				}
+			});
 
-		(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
-			const consentForVendor = getConsentFor(vendor, consent);
-			if (!consentForVendor) {
-				vendorLocalStorageData[vendor].forEach((name) => {
-					storage.local.remove(name);
-					storage.session.remove(name);
-				});
+			(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
+				const consentForVendor = getConsentFor(vendor, consent);
+				if (!consentForVendor) {
+					vendorLocalStorageData[vendor].forEach((name) => {
+						storage.local.remove(name);
+						storage.session.remove(name);
+					});
 
-			}
+				}
+			});
 		});
 	});
 };

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -1,7 +1,7 @@
 import { removeCookie, storage } from "@guardian/libs";
 import { getConsentFor } from "./getConsentFor";
 import { onConsentChange } from "./onConsentChange";
-import { VendorWithCookieData, VendorWithLocalStorageData, storageKeys, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
+import { VendorWithCookieData, VendorWithLocalStorageData, vendorCookieData, vendorLocalStorageData } from "./vendorStorageIds";
 
 /**
  * This function is called when the CMP is initialised. It listens for consent changes and removes cookies and localStorage data for vendors that the user has not consented to.
@@ -9,16 +9,24 @@ import { VendorWithCookieData, VendorWithLocalStorageData, storageKeys, vendorCo
 export const initVendorDataManager = (): void => {
 	onConsentChange((consent) => {
 		requestIdleCallback(() => {
-			storageKeys.forEach(([vendor, key, storageType]) => {
+			(<VendorWithCookieData[]>Object.keys(vendorCookieData)).forEach((vendor) => {
 				const consentForVendor = getConsentFor(vendor, consent);
-
 				if (!consentForVendor) {
-					if (storageType === "cookie") {
-						removeCookie({name: key});
-					} else {
-						storage.local.remove(key);
-						storage.session.remove(key);
-					}
+					vendorCookieData[vendor].forEach((name) => {
+						removeCookie({name});
+					});
+
+				}
+			});
+
+			(<VendorWithLocalStorageData[]>Object.keys(vendorLocalStorageData)).forEach((vendor) => {
+				const consentForVendor = getConsentFor(vendor, consent);
+				if (!consentForVendor) {
+					vendorLocalStorageData[vendor].forEach((name) => {
+						storage.local.remove(name);
+						storage.session.remove(name);
+					});
+
 				}
 			});
 		});

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -12,6 +12,7 @@ export const vendorLocalStorageData = {
 		'cto_bundle',
 		'criteo_fast_bid',
 		'criteo_pt_cdb_mngr_metrics',
+		'__ansync3rdp_criteo',
 	],
 	ipsos: [
 		'DotmetricsSiteData',
@@ -42,7 +43,9 @@ export type VendorWithLocalStorageData = keyof typeof vendorLocalStorageData;
 
 export const vendorCookieData = {
 	criteo: ['cto_bundle'],
-	ipsos: ['DM_SitId1073', 'DM_SitId1073SecId5802'],
+	comscore: ['comScore'],
+	ipsos: ['DM_SitId1073', 'DM_SitId1073SecId5802', 'DotMetrics.AmpCookie'],
+	permutive: ['permutive-id'],
 	googletag: ['__gpi', '__gads'],
 	'google-analytics': ['_gid', '_ga'],
 } satisfies Partial<Record<VendorName, string[]>>;

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -1,0 +1,50 @@
+import type { VendorName } from './vendors';
+
+/**
+ * This is a list of vendors that store data in localStorage or cookies along with the keys they use (that we know of).
+ */
+
+export const vendorLocalStorageData = {
+	a9: ['apstagUserAgentClientHints', 'apstagCxMEnabled'],
+	inizio: ['__bm_s', '__bm_m'],
+	criteo: [
+		'criteo_fast_bid_expires',
+		'cto_bundle',
+		'criteo_fast_bid',
+		'criteo_pt_cdb_mngr_metrics',
+	],
+	ipsos: [
+		'DotmetricsSiteData',
+		'DotMetricsTimeOnPage',
+		'DotMetricsUserId',
+		'DotMetricsDeviceGuidId',
+	],
+	permutive: [
+		'permutive-data-queries',
+		'_pubcid',
+		'permutive-pvc',
+		'permutive-data-enrichers',
+		'permutive-session',
+		'permutive-data-misc',
+		'permutive-unprocessed-pba',
+		'permutive-app',
+		'permutive-data-models',
+		'permutive-id',
+		'permutive-consent',
+		'permutive-events-cache',
+		'permutive-data-queries',
+		'permutive-events-for-page',
+	],
+	prebid: ['_psegs', '_pubcid_exp'],
+} satisfies Partial<Record<VendorName, string[]>>;
+
+export type VendorWithLocalStorageData = keyof typeof vendorLocalStorageData;
+
+export const vendorCookieData = {
+	criteo: ['cto_bundle'],
+	ipsos: ['DM_SitId1073', 'DM_SitId1073SecId5802'],
+	googletag: ['__gpi', '__gads'],
+	'google-analytics': ['_gid', '_ga'],
+} satisfies Partial<Record<VendorName, string[]>>;
+
+export type VendorWithCookieData = keyof typeof vendorCookieData;

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -53,6 +53,7 @@ export const vendorCookieData = {
 
 export type VendorWithCookieData = keyof typeof vendorCookieData;
 
+// Create a list of all the storage keys we know about so we can iterate over them and remove them when the user revokes consent.
 export const storageKeys: [VendorName, string, 'cookie' | 'localStorage'][] = [];
 
 Object.entries(vendorCookieData).forEach(([vendor, keys]) => keys.forEach((key) => storageKeys.push([vendor as VendorName, key, 'cookie'])));

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -50,4 +50,12 @@ export const vendorCookieData = {
 	'google-analytics': ['_gid', '_ga'],
 } satisfies Partial<Record<VendorName, string[]>>;
 
+
 export type VendorWithCookieData = keyof typeof vendorCookieData;
+
+export const storageKeys: [VendorName, string, 'cookie' | 'localStorage'][] = [];
+
+Object.entries(vendorCookieData).forEach(([vendor, keys]) => keys.forEach((key) => storageKeys.push([vendor as VendorName, key, 'cookie'])));
+
+Object.entries(vendorLocalStorageData).forEach(([vendor, keys]) => keys.forEach((key) => storageKeys.push([vendor as VendorName, key, 'localStorage'])));
+

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -50,13 +50,4 @@ export const vendorCookieData = {
 	'google-analytics': ['_gid', '_ga'],
 } satisfies Partial<Record<VendorName, string[]>>;
 
-
 export type VendorWithCookieData = keyof typeof vendorCookieData;
-
-// Create a list of all the storage keys we know about so we can iterate over them and remove them when the user revokes consent.
-export const storageKeys: [VendorName, string, 'cookie' | 'localStorage'][] = [];
-
-Object.entries(vendorCookieData).forEach(([vendor, keys]) => keys.forEach((key) => storageKeys.push([vendor as VendorName, key, 'cookie'])));
-
-Object.entries(vendorLocalStorageData).forEach(([vendor, keys]) => keys.forEach((key) => storageKeys.push([vendor as VendorName, key, 'localStorage'])));
-

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -4,50 +4,70 @@ import type { VendorName } from './vendors';
  * This is a list of vendors that store data in localStorage or cookies along with the keys they use (that we know of).
  */
 
-export const vendorLocalStorageData = {
-	a9: ['apstagUserAgentClientHints', 'apstagCxMEnabled'],
-	inizio: ['__bm_s', '__bm_m'],
-	criteo: [
-		'criteo_fast_bid_expires',
-		'cto_bundle',
-		'criteo_fast_bid',
-		'criteo_pt_cdb_mngr_metrics',
-		'__ansync3rdp_criteo',
-	],
-	ipsos: [
-		'DotmetricsSiteData',
-		'DotMetricsTimeOnPage',
-		'DotMetricsUserId',
-		'DotMetricsDeviceGuidId',
-	],
-	permutive: [
-		'permutive-data-queries',
-		'_pubcid',
-		'permutive-pvc',
-		'permutive-data-enrichers',
-		'permutive-session',
-		'permutive-data-misc',
-		'permutive-unprocessed-pba',
-		'permutive-app',
-		'permutive-data-models',
-		'permutive-id',
-		'permutive-consent',
-		'permutive-events-cache',
-		'permutive-data-queries',
-		'permutive-events-for-page',
-	],
-	prebid: ['_psegs', '_pubcid_exp'],
-} satisfies Partial<Record<VendorName, string[]>>;
+export const vendorStorageIds = {
+	a9: {
+		localStorage: ['apstagUserAgentClientHints', 'apstagCxMEnabled'],
+	},
+	inizio: {
+		localStorage: ['__bm_s', '__bm_m'],
+	},
+	criteo: {
+		cookies: ['cto_bundle'],
+		localStorage: [
+			'criteo_fast_bid_expires',
+			'cto_bundle',
+			'criteo_fast_bid',
+			'criteo_pt_cdb_mngr_metrics',
+			'__ansync3rdp_criteo',
+		],
+	},
+	comscore: {
+		cookies: ['comScore'],
+	},
 
-export type VendorWithLocalStorageData = keyof typeof vendorLocalStorageData;
+	ipsos: {
+		cookies: [
+			'DM_SitId1073',
+			'DM_SitId1073SecId5802',
+			'DotMetrics.AmpCookie',
+		],
+		localStorage: [
+			'DotmetricsSiteData',
+			'DotMetricsTimeOnPage',
+			'DotMetricsUserId',
+			'DotMetricsDeviceGuidId',
+		],
+	},
+	permutive: {
+		cookies: ['permutive-id'],
+		localStorage: [
+			'permutive-data-queries',
+			'_pubcid',
+			'permutive-pvc',
+			'permutive-data-enrichers',
+			'permutive-session',
+			'permutive-data-misc',
+			'permutive-unprocessed-pba',
+			'permutive-app',
+			'permutive-data-models',
+			'permutive-id',
+			'permutive-consent',
+			'permutive-events-cache',
+			'permutive-data-queries',
+			'permutive-events-for-page',
+			'__permutiveConfigQueryParams',
+		],
+		sessionStorage: ['__permutiveConfigQueryParams'],
+	},
+	prebid: {
+		localStorage: ['_psegs', '_pubcid_exp'],
+	},
+	googletag: { cookies: ['__gpi', '__gads'] },
+	'google-analytics': {
+		cookies: ['_gid', '_ga'],
+	},
+} satisfies Partial<
+	Record<VendorName, { cookies?: string[]; localStorage?: string[], sessionStorage?: string[] }>
+>;
 
-export const vendorCookieData = {
-	criteo: ['cto_bundle'],
-	comscore: ['comScore'],
-	ipsos: ['DM_SitId1073', 'DM_SitId1073SecId5802', 'DotMetrics.AmpCookie'],
-	permutive: ['permutive-id'],
-	googletag: ['__gpi', '__gads'],
-	'google-analytics': ['_gid', '_ga'],
-} satisfies Partial<Record<VendorName, string[]>>;
-
-export type VendorWithCookieData = keyof typeof vendorCookieData;
+export type VendorWithData = keyof typeof vendorStorageIds;

--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -17,6 +17,7 @@ export const VendorIDs = {
 	acast: ['5f203dcb1f0dea790562e20f'],
 	braze: ['5ed8c49c4b8ce4571c7ad801'],
 	comscore: ['5efefe25b8e05c06542b2a77'],
+	criteo: ['5e98e7f1b8e05c111d01b462'],
 	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
 	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
 	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9574,10 +9574,10 @@ prettier-plugin-svelte@^2.6.0:
   resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz#0e845b560b55cd1d951d6c50431b4949f8591746"
   integrity sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==
 
-prettier@^2.5.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
-  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## What does this change?
Make sure that cookies and localStorage set by vendors are removed if their consent is removed.

## Why?
From the RFC:

> A recent user comment prompted us to re-examine the behaviour of cookies for users who initially accept, but then later decline consent on our website via the CMP.
> PECR regulation means that the user must take a clear and positive action to give their consent to non-essential cookies. We only set non-essential cookies, or launch the scripts that set non-essential cookies, after we’ve checked that consent has been given. This means users who never give consent never have non-essential cookies set.
> However if the user initially consents but then goes on to decline consent subsequently, we have no standard mechanism in place to remove already-set cookies. At the moment we see cookies or items in local storage left from tools like Permutive and vendors like Criteo. This is an opportunity for improvement.
> By their nature, cookies are sent by the browser, back to the domain they belong to with every request to that server, regardless of the current consent state. Removing cookies that aren’t useful will slightly reduce the data sent over the wire to request a page on the site.

This is step 1 which is implementing a "deny" list of items to remove.