### PR TITLE
test: permissions for gh-pages deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,6 @@
 name: Deploy to GitHub Pages
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,5 @@
 name: Deploy to GitHub Pages
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

Adding extra permissions for gh-page deploy.

## Why?

Deploys have been failing since we moved to enterprise.