### PR TITLE
fix: test adding contents:write to ci permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,6 +121,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
+      contents: write # in order to write labels to main branch?
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:


### PR DESCRIPTION
## What does this change?

Adding contents:write to CI.yml 

## Why?

An attempt to find the minimum set of permissions required to successfully complete a release after permissions became restricted.