### PR TITLE
chore: fix incorrect libs peerdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
 		"wait-for-expect": "^3"
 	},
 	"peerDependencies": {
-		"@guardian/libs": "^14.0.0"
+		"@guardian/libs": "^15.0.0"
 	}
 }


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Updates incorrect peer dep for @guardian/labs-beta 		

## Why?
This was missed in an earlier update.