### PR TITLE
test: add a timeout to aus to ensure choice persisted before a reload

### DIFF
--- a/monitoring/src/check-page/aus.ts
+++ b/monitoring/src/check-page/aus.ts
@@ -28,6 +28,8 @@ const clickAcceptAllCookies = async (config: Config, page: Page) => {
 	await frame.click(ELEMENT_ID.TCFV2_FIRST_LAYER_ACCEPT_ALL);
 	log_info(`Clicked on "Continue" on CMP`);
 	log_info(`Waiting for the choice to be persisted.`);
+	/* As there is a long delay in persisting the user's consent to the browser in Australia,
+	 * we are adding a sleep at this point to delay the page reload until that is likely complete. */
 	await new Promise(r => setTimeout(r, 5000));
 
 };

--- a/monitoring/src/check-page/aus.ts
+++ b/monitoring/src/check-page/aus.ts
@@ -14,6 +14,11 @@ import {
 	reloadPage,
 } from './common-functions';
 
+/**
+ * Clicks the accept all button and then waits for the choice to be persisted.
+ * @param config
+ * @param page
+ */
 const clickAcceptAllCookies = async (config: Config, page: Page) => {
 
 	log_info(`Clicking on "Continue" on CMP`);
@@ -21,8 +26,10 @@ const clickAcceptAllCookies = async (config: Config, page: Page) => {
 	const frame = await getFrame(page, config.iframeDomain);
 	await frame.waitForSelector(ELEMENT_ID.TCFV2_FIRST_LAYER_ACCEPT_ALL);
 	await frame.click(ELEMENT_ID.TCFV2_FIRST_LAYER_ACCEPT_ALL);
-
 	log_info(`Clicked on "Continue" on CMP`);
+	log_info(`Waiting for the choice to be persisted.`);
+	await new Promise(r => setTimeout(r, 5000));
+
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Adds a timeout after the accept all button has been clicked to ensure the choice is persisted.
This affects the Australia monitoring only.

## Why?

In Australia monitoring only, there have been errors with the checkSubsequentPage suggesting that the checkTopAdHasLoaded is being called after the page has been closed.
I suspect it relates to slow consent choice persistence in Australia in combination with a quick page reload.

We believe that Australia has an issue with slowness on persisting the user's consent to the browser.
In the function checkPages of aus.ts we call AcceptAllCookies.
We then check the CMP has gone but this doesn't mean the choice has been persisted.
We immediately reload the page.
We check if the ads have loaded - in AUS they always do 
...but we don't check yet if the CMP has reappeared at this point... I bet it has!

Next we go into the checkSubsequentPage where we have two items running in parallel inside a Promise.all.
The first function in the array checks to see if the CMP has reappeared and if so throws an error.
The second one is where we are seeing the page closed error in.
I think that the error is being thrown because the CMP IS reappearing owing to the user's choice was not being persisted - the enclosing function is then catching the error and closing the page and browser in the finally clause. 
...but the checkTopAdHasLoaded is still running in parallel despite the page having already been closed.
I think we need to add a 5 second(ish) wait before reloading the page to make sure the choice is persisted.