### PR TITLE
chore: Update Sourcepoint getTCData to addEventListener

### DIFF
--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -134,7 +134,7 @@ describe('under AUS', () => {
 describe('under TCFv2', () => {
 	beforeEach(() => {
 		window.__tcfapi = jest.fn((command, b, callback) => {
-			if (command === 'getTCData') callback(tcData, true);
+			if (command === 'addEventListener') callback(tcData, true);
 			if (command === 'getCustomVendorConsents') {
 				callback(customVendorConsents, true);
 			}

--- a/src/tcfv2/api.test.js
+++ b/src/tcfv2/api.test.js
@@ -13,7 +13,7 @@ it('calls the correct IAB api with the correct methods', async () => {
 
 	expect(window.__tcfapi).toHaveBeenNthCalledWith(
 		1,
-		'getTCData',
+		'addEventListener',
 		expect.any(Number),
 		expect.any(Function),
 	);

--- a/src/tcfv2/api.ts
+++ b/src/tcfv2/api.ts
@@ -22,8 +22,11 @@ const api = (command: Command) =>
 		}
 	});
 
+// export const getTCData = (): Promise<TCData> =>
+// 	api('getTCData') as Promise<TCData>;
+
 export const getTCData = (): Promise<TCData> =>
-	api('getTCData') as Promise<TCData>;
+	api('addEventListener') as Promise<TCData>;
 
 export const getCustomVendorConsents = (): Promise<CustomVendorConsents> =>
 	api('getCustomVendorConsents') as Promise<CustomVendorConsents>;

--- a/src/tcfv2/api.ts
+++ b/src/tcfv2/api.ts
@@ -22,15 +22,14 @@ const api = (command: Command) =>
 		}
 	});
 
-// export const getTCData = (): Promise<TCData> =>
-// 	api('getTCData') as Promise<TCData>;
 
-export /**
+ /**
  * This function previously used getTCData. However, this has been deprecated.
  * The documentation below suggests using the addEventListener which returns the same object
+ * https://docs.sourcepoint.com/hc/en-us/articles/17344938802707-IAB-GDPR-TCF-v2-2-Transition-readiness-
  * @return {*}  {Promise<TCData>}
  */
-const getTCData = (): Promise<TCData> =>
+export const getTCData = (): Promise<TCData> =>
 	api('addEventListener') as Promise<TCData>;
 
 

--- a/src/tcfv2/api.ts
+++ b/src/tcfv2/api.ts
@@ -25,8 +25,14 @@ const api = (command: Command) =>
 // export const getTCData = (): Promise<TCData> =>
 // 	api('getTCData') as Promise<TCData>;
 
-export const getTCData = (): Promise<TCData> =>
+export /**
+ * This function previously used getTCData. However, this has been deprecated.
+ * The documentation below suggests using the addEventListener which returns the same object
+ * @return {*}  {Promise<TCData>}
+ */
+const getTCData = (): Promise<TCData> =>
 	api('addEventListener') as Promise<TCData>;
+
 
 export const getCustomVendorConsents = (): Promise<CustomVendorConsents> =>
 	api('getCustomVendorConsents') as Promise<CustomVendorConsents>;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
The TCF v2.2 update further strengthens the TCF as a standard in the industry: revised purpose names and descriptions, introduced retention periods for all purposes, removed legitimate interest for purposes 3 to 6, the introduction of data categories used in conjunction with the purposes, support for legitimate interest claim urls, adding support for localized policy urls, deprecation of the __tcfapi command "getTCData" and introducing a more robust vendor compliance program.

https://trello.com/c/axpgteSv

## Why?
"getTCData" has been deprecated.
