### PR TITLE
fix: change vendor id for Permutive, add Magnite

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ type: `string`
 -   `"permutive"`
 -   `"prebid"`
 -   `"qm"` (Quantum Metric)
+-   `"redplanet"` (Australia only)
 -   `"remarketing"`
 -   `"sentry"`
 -   `"teads"`

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ type: `string`
 -   `"inizio"`
 -   `"ipsos"`
 -   `"lotame"`
+-   `"magnite"` (do not use until contract signed)
 -   `"nielsen"`
 -   `"ophan"`
 -   `"permutive"`

--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -33,7 +33,7 @@ export const TCFV2VendorIDs: VendorIDType = {
 	lotame: ['5ed6aeb1b8e05c241a63c71f'],
 	nielsen: ['5ef5c3a5b8e05c69980eaa5b'],
 	ophan: ['5f203dbeeaaaa8768fd3226a'],
-	permutive: ['5eff0d77969bfa03746427eb'],
+	permutive: ['5f369a02b8e05c2f2d546a40'],
 	prebid: ['5f92a62aa22863685f4daa4c'],
 	qm: ['5f295fa4b8e05c76a44c3149'],
 	remarketing: ['5ed0eb688a76503f1016578f'],

--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -31,6 +31,7 @@ export const TCFV2VendorIDs: VendorIDType = {
 	inizio: ['5e37fc3e56a5e6615502f9c9'],
 	ipsos: ['5fa51b29a228638b4a1980e4'],
 	lotame: ['5ed6aeb1b8e05c241a63c71f'],
+	magnite: ['5e7ced57b8e05c485246cce5'],
 	nielsen: ['5ef5c3a5b8e05c69980eaa5b'],
 	ophan: ['5f203dbeeaaaa8768fd3226a'],
 	permutive: ['5f369a02b8e05c2f2d546a40'],


### PR DESCRIPTION
## What does this change?

This changes the vendor id for Permutive from a custom vendor id to their IAB vendor id.  It also adds Magnite so that Commercial Dev can test.  This has been agreed with Data Privacy as long as Magnite is not actively used in production. 

## Why?

The old custom Permutive vendor id needs to be removed.
There were 3 permutive vendor ids at one point and only 1 is current.  We need to change from the previous older one so it can be removed from the Sourcepoint vendor list.  As the new vendor has been in the vendor list for some time it will have gone through a repermission already.

Adding Magnite for testing only at this point.