### PR TITLE
Update tsconfig.build.json

### DIFF
--- a/.changeset/silly-horses-jam.md
+++ b/.changeset/silly-horses-jam.md
@@ -1,0 +1,5 @@
+---
+'@guardian/consent-management-platform': patch
+---
+
+Fixing previous build by exposing types in package

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,6 @@
 		"rootDir": "src"
 	},
 	"files": ["src/index.ts"],
+	"exclude": ["src/rollup.config.js"],
 	"include": ["src"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,7 @@
 		"emitDeclarationOnly": true,
 		"noEmit": false,
 		"outDir": "dist",
-		"rootDir": "./"
+		"rootDir": "src"
 	},
 	"files": ["src/index.ts"],
 	"include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"isolatedModules": true,
 		"noEmit": true,
 		"removeComments": true,
+		"incremental": false,
 	},
 	"include": ["*.js", "src", ".eslintrc.js"]
 }


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
The latest release broke the build commands. This exports the contents of the src folder to be exposed by the cmp package.
## Why?
