### PR TITLE
Chore: Create test to check 'dist' build folder

### DIFF
--- a/.github/workflows/cmp-build-release.yml
+++ b/.github/workflows/cmp-build-release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build package
         run: yarn build
 
+      - name: Check dist folder for files
+        run: ./scripts/check-build-folders
+
       - name: Save build
         if: github.ref == 'refs/heads/main' || github.event.label.name == '[beta] @guardian/consent-management-platform'
         uses: actions/upload-artifact@v3

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -18,13 +18,13 @@ echo "Checking Dist folder"
 if test -d "${BUILT_APP_DIR_PATH}"; then # If the dist folder exists
   for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do # Loop through EXPECTED_BUILT_DIRECTORIES array
     if [ ! -d "${BUILT_APP_DIR_PATH}/${dir}" ]; then # If the sub directory doesn't exist
-    	echo "Directory '${dir}' does not exist in ${BUILT_APP_DIR_PATH}"
+    	echo "Error: Directory '${dir}' does not exist in ${BUILT_APP_DIR_PATH}"
     	exit 1
     fi
   done
   echo "The expected folders are in the dist directory"
   exit 0
 else
-  echo "Can't find dist folder"
+  echo "Error: Can't find dist folder"
   exit 1
 fi

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -7,12 +7,12 @@ ROOT_DIR="${CURRENT_DIR}/.."
 
 EXPECTED_BUILT_DIRECTORIES=("assets" "aus" "ccpa" "lib" "tcfv2" "types")
 
-get_abs_filename() {
+get_absolute_path() {
   # $1 : relative filename
   echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 }
 
-BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist") # Get absolute path to dist folder
+BUILT_APP_DIR_PATH=$(get_absolute_path "${ROOT_DIR}/dist") # Get absolute path to dist folder
 
 echo "Checking Dist folder for the different directories"
 if test -d "${BUILT_APP_DIR_PATH}"; then # If the dist folder exists

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR="${DIR}/.."
+
+EXPECTED_BUILT_DIRECTORIES=("assets" "aus" "ccpa" "lib" "tcfv2" "types")
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist")
+echo "The expected folders are in the build directory"
+
+if test -d "${BUILT_APP_DIR_PATH}"; then
+  for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do
+    if [ ! -d "${BUILT_APP_DIR_PATH}/${dir}" ]; then
+    	echo "Directory '${dir}' does not exist in ${BUILT_APP_DIR_PATH}"
+    	exit 1
+    fi
+  done
+  echo "The expected folders are in the build directory"
+  exit 0
+else
+  echo "Can't find dist folder"
+  exit 1
+fi
+
+

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -12,12 +12,12 @@ get_abs_filename() {
   echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 }
 
-BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist")
+BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist") # Get absolute path to dist folder
 echo "Checking Dist folder"
 
-if test -d "${BUILT_APP_DIR_PATH}"; then
-  for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do
-    if [ ! -d "${BUILT_APP_DIR_PATH}/${dir}" ]; then
+if test -d "${BUILT_APP_DIR_PATH}"; then # If the dist folder exists
+  for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do # Loop through EXPECTED_BUILT_DIRECTORIES array
+    if [ ! -d "${BUILT_APP_DIR_PATH}/${dir}" ]; then # If the sub directory doesn't exist
     	echo "Directory '${dir}' does not exist in ${BUILT_APP_DIR_PATH}"
     	exit 1
     fi

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -13,7 +13,7 @@ get_abs_filename() {
 }
 
 BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist")
-echo "The expected folders are in the build directory"
+echo "Checking Dist folder"
 
 if test -d "${BUILT_APP_DIR_PATH}"; then
   for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do
@@ -28,5 +28,3 @@ else
   echo "Can't find dist folder"
   exit 1
 fi
-
-

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -2,8 +2,8 @@
 
 set -e
 
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-ROOT_DIR="${DIR}/.."
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR="${CURRENT_DIR}/.."
 
 EXPECTED_BUILT_DIRECTORIES=("assets" "aus" "ccpa" "lib" "tcfv2" "types")
 
@@ -13,16 +13,16 @@ get_abs_filename() {
 }
 
 BUILT_APP_DIR_PATH=$(get_abs_filename "${ROOT_DIR}/dist") # Get absolute path to dist folder
-echo "Checking Dist folder"
 
+echo "Checking Dist folder for the different directories"
 if test -d "${BUILT_APP_DIR_PATH}"; then # If the dist folder exists
-  for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do # Loop through EXPECTED_BUILT_DIRECTORIES array
+  for dir in "${EXPECTED_BUILT_DIRECTORIES[@]}"; do # Loop through EXPECTED_BUILT_DIRECTORIES string array
     if [ ! -d "${BUILT_APP_DIR_PATH}/${dir}" ]; then # If the sub directory doesn't exist
     	echo "Error: Directory '${dir}' does not exist in ${BUILT_APP_DIR_PATH}"
     	exit 1
     fi
   done
-  echo "The expected folders are in the dist directory"
+  echo "The expected directories are in the dist directory"
   exit 0
 else
   echo "Error: Can't find dist folder"

--- a/scripts/check-build-folders
+++ b/scripts/check-build-folders
@@ -22,7 +22,7 @@ if test -d "${BUILT_APP_DIR_PATH}"; then
     	exit 1
     fi
   done
-  echo "The expected folders are in the build directory"
+  echo "The expected folders are in the dist directory"
   exit 0
 else
   echo "Can't find dist folder"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
This is a script that checks the "assets", "aus", "ccpa", "lib", "tcfv2", "types" are in the dist folder after a build.

## Why?
To ensure the dist folder is exported correctly.

https://trello.com/c/aqnoEy63/1188-create-tests-to-check-the-dist-folder-in-cmp-after-build-to-prevent-issue-where-the-folders-are-not-exported-correctly