### PR TITLE
chore: Create sub groups for each directory dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,13 @@ updates:
       - 'dependencies'
       - 'javascript'
     groups:
-      cdk:
+      cdk-aws:
+        patterns:
+          - 'aws*'
+      cdk-guardian:
+        patterns:
+          - '@guardian*'
+      cdk-all:
         patterns:
           - '*'
   - package-ecosystem: 'npm'
@@ -38,7 +44,13 @@ updates:
       - 'dependencies'
       - 'javascript'
     groups:
-      monitoring:
+      monitoring-aws:
+        patterns:
+          - '@guardian*'
+      monitoring-guardian:
+        patterns:
+          - '@guardian*'
+      monitoring-all:
         patterns:
           - '*'
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,13 @@
 
 version: 2
 updates:
+  # Grouping base directory npm packages
+  # Created groups for rollup, guardian, babel and all.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
     labels:
-      - 'cmp_app_group'
       - 'dependencies'
       - 'javascript'
     groups:
@@ -27,12 +28,13 @@ updates:
       cmp-app-all:
         patterns:
           - '*'
+  # Grouping the cdk npm packages
+  # Created groups for aws, guardian and all.
   - package-ecosystem: 'npm'
     directory: '/cdk'
     schedule:
       interval: 'weekly'
     labels:
-      - 'cdk_group'
       - 'dependencies'
       - 'javascript'
     groups:
@@ -45,12 +47,13 @@ updates:
       cdk-all:
         patterns:
           - '*'
+  # Grouping the monitoring npm packages
+  # Created groups for aws, guardian and all.
   - package-ecosystem: 'npm'
     directory: '/monitoring'
     schedule:
       interval: 'weekly'
     labels:
-      - 'monitoring_group'
       - 'dependencies'
       - 'javascript'
     groups:
@@ -63,6 +66,8 @@ updates:
       monitoring-all:
         patterns:
           - '*'
+  # Grouping the base directory github-actions packages
+  # Created group for all.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,17 @@ updates:
       - 'dependencies'
       - 'javascript'
     groups:
-      cmp-app:
+      cdk-guardian:
+        patterns:
+          - '@guardian*'
+      cdk-rollup:
+        patterns:
+          - '@rollup*'
+          - 'rollup*'
+      cdk-babel:
+        patterns:
+          - '@babel*'
+      cmp-app-all:
         patterns:
           - '*'
   - package-ecosystem: 'npm'
@@ -46,7 +56,7 @@ updates:
     groups:
       monitoring-aws:
         patterns:
-          - '@guardian*'
+          - '@aws*'
       monitoring-guardian:
         patterns:
           - '@guardian*'


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
This creates smaller groups to make them more manageable. 
## Why?
I previously merged a PR that grouped updates based on the directory. which created three failing PR's with 12,14,40 updates. These are quite difficult to resolve as there many packages being updated at once.
https://github.com/guardian/consent-management-platform/pull/864/files
## Link to Trello
https://trello.com/c/ntimUWJd/1203-group-dependabot-dependencies


