### PR TITLE
Use exclude-patterns for monitoring group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,10 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    ignore:
-      - dependency-name: 'inquirer'
-      - dependency-name: '@types/inquirer'
+        exclude-patterns:
+          - 'inquirer'
+          - '@types/inquirer'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
Using exclude-patterns instead of ignore. 
The `ignore` param works on the package-ecosystem whilst `exclude-patterns` works on groups.
## Why?
The `ignore` param failed to remove the inquirer from the monitoring group.
## Link to Trello
https://trello.com/c/lSCfUOYr