### PR TITLE
Update settings.json following vscode upgrade

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,12 @@
   "[typescript]": {
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": false
-    }
+		"source.organizeImports": "never"
+	}
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
+	"source.fixAll.eslint": "explicit"
+},
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": [
 	"SP’s",


### PR DESCRIPTION
## What does this change?

Change to VS Code settings file only.

## Why?
Microsoft changed the value of the fields - these are apparently equivalent. 
[VS Code update notes](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto)
