### PR TITLE
chore: Update @guardian/libs to 16.0.1 and update peerDependency

### DIFF
--- a/.changeset/happy-cheetahs-wave.md
+++ b/.changeset/happy-cheetahs-wave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/consent-management-platform': patch
+---
+
+Update version of @guardian/libs to 16.0.1

--- a/.changeset/happy-cheetahs-wave.md
+++ b/.changeset/happy-cheetahs-wave.md
@@ -3,3 +3,4 @@
 ---
 
 Update version of @guardian/libs to 16.0.1
+Remove the @guardian/libs peerDependency

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@babel/runtime": "^7.23.2",
 		"@changesets/cli": "^2.26.2",
 		"@guardian/eslint-config-typescript": "^7.0.0",
-		"@guardian/libs": "15.0.0",
+		"@guardian/libs": "^16.0.1",
 		"@guardian/prettier": "^4.0.0",
 		"@guardian/tsconfig": "^0.2.0",
 		"@rollup/plugin-babel": "^6.0.3",
@@ -91,6 +91,6 @@
 		"wait-for-expect": "^3"
 	},
 	"peerDependencies": {
-		"@guardian/libs": "^15.0.0"
+		"@guardian/libs": "^16.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -89,8 +89,5 @@
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3",
 		"wait-for-expect": "^3"
-	},
-	"peerDependencies": {
-		"@guardian/libs": "^16.0.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,10 +1511,10 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.27.5"
 
-"@guardian/libs@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.0.0.tgz#c3fbb1d7fdafaefe156232b7088f43e2ff4cd18b"
-  integrity sha512-UnNxcJHYDfpElrxc7sbfwSJ82erH3mjdKsALAgevggsbhOSAkE9yoCn+XMBPN7iQ14bEHZPYyOMt0y1hNCItyg==
+"@guardian/libs@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.1.tgz#81214a701ef7159e8bdbba901af30bdaec901c28"
+  integrity sha512-/pgkDwWu9xp4TAEx07LFu80XsJWIti0VHRxjRRV6vNCMIb44OktONXs5Lu9deoSXWNZh+VcyAEj8vFF2DRPdMA==
 
 "@guardian/prettier@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
Updating the version of @guardian/libs to 16.0.1 and updating peer Dependency

## Why?
DCR has updated their version to 16.0.1.

This has been tested locally using about-us
## Link to Trello
https://trello.com/c/j5eOyKbm