### PR TITLE
Revoke gpp ccpa stub

### DIFF
--- a/.changeset/spotty-kangaroos-change.md
+++ b/.changeset/spotty-kangaroos-change.md
@@ -1,0 +1,5 @@
+---
+"@guardian/consent-management-platform": minor
+---
+
+Removing \_\_gpp stub load in CCPA

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -9,7 +9,7 @@ describe('Sourcepoint unified', () => {
 	beforeEach(() => {
 		window.__tcfapi = undefined;
 		window.__uspapi = undefined;
-		window.__gpp = undefined;
+		// window.__gpp = undefined;
 	});
 	afterEach(() => {
 		window._sp_ = undefined;
@@ -43,7 +43,7 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.ccpa).toBeUndefined();
 				expect(window.__tcfapi).toBeDefined();
 				expect(window.__uspapi).toBeUndefined();
-				expect(window.__gpp).toBeUndefined();
+				// expect(window.__gpp).toBeUndefined();
 			} else if (framework == 'ccpa') {
 				expect(
 					window._sp_.config.ccpa.targetingParams.framework,
@@ -57,7 +57,7 @@ describe('Sourcepoint unified', () => {
 				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window._sp_.config.ccpa.includeGppApi).toBeFalsy();
-				expect(window.__gpp).toBeUndefined();
+				// expect(window.__gpp).toBeUndefined();
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			}

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -9,7 +9,6 @@ describe('Sourcepoint unified', () => {
 	beforeEach(() => {
 		window.__tcfapi = undefined;
 		window.__uspapi = undefined;
-		// window.__gpp = undefined;
 	});
 	afterEach(() => {
 		window._sp_ = undefined;
@@ -43,7 +42,6 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.ccpa).toBeUndefined();
 				expect(window.__tcfapi).toBeDefined();
 				expect(window.__uspapi).toBeUndefined();
-				// expect(window.__gpp).toBeUndefined();
 			} else if (framework == 'ccpa') {
 				expect(
 					window._sp_.config.ccpa.targetingParams.framework,
@@ -57,7 +55,6 @@ describe('Sourcepoint unified', () => {
 				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window._sp_.config.ccpa.includeGppApi).toBeFalsy();
-				// expect(window.__gpp).toBeUndefined();
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			}

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -49,9 +49,7 @@ describe('Sourcepoint unified', () => {
 					window._sp_.config.ccpa.targetingParams.framework,
 				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
-				// expect(window._sp_.config.ccpa.includeGppApi).toBeTruthy();
 				expect(window.__uspapi).toBeDefined();
-				// expect(window.__gpp).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			} else if (framework == 'aus') {
 				expect(

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -49,9 +49,9 @@ describe('Sourcepoint unified', () => {
 					window._sp_.config.ccpa.targetingParams.framework,
 				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
-				expect(window._sp_.config.ccpa.includeGppApi).toBeTruthy();
+				// expect(window._sp_.config.ccpa.includeGppApi).toBeTruthy();
 				expect(window.__uspapi).toBeDefined();
-				expect(window.__gpp).toBeDefined();
+				// expect(window.__gpp).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			} else if (framework == 'aus') {
 				expect(

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -54,7 +54,6 @@ describe('Sourcepoint unified', () => {
 					window._sp_.config.ccpa.targetingParams.framework,
 				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
-				expect(window._sp_.config.ccpa.includeGppApi).toBeFalsy();
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			}

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -170,7 +170,6 @@ export const init = (framework: Framework, pubData = {}): void => {
 			break;
 		case 'ccpa':
 			window._sp_.config.ccpa = {
-				// includeGppApi: true,
 				targetingParams: {
 					framework,
 				},

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -170,7 +170,7 @@ export const init = (framework: Framework, pubData = {}): void => {
 			break;
 		case 'ccpa':
 			window._sp_.config.ccpa = {
-				includeGppApi: true,
+				// includeGppApi: true,
 				targetingParams: {
 					framework,
 				},

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -156,7 +156,7 @@ export const init = (framework: Framework, pubData = {}): void => {
 
 	// NOTE - Contrary to the SourcePoint documentation, it's important that we add EITHER gdpr OR ccpa
 	// to the _sp_ object. wrapperMessagingWithoutDetection.js uses the presence of these keys to attach
-	// __tcfapi or __uspapi or _gpp to the window object respectively. If both of these functions appear on the window,
+	// __tcfapi or __uspapi to the window object respectively. If both of these functions appear on the window,
 	// advertisers seem to assume that __tcfapi is the one to use, breaking CCPA consent.
 	// https://documentation.sourcepoint.com/implementation/web-implementation/multi-campaign-web-implementation#implementation-code-snippet-overview
 

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,4 +1,3 @@
-// import { stub_gpp_ccpa } from './stub_gpp_ccpa';
 import { stub_tcfv2 } from './stub_tcfv2';
 import { stub_uspapi_ccpa } from './stub_uspapi_ccpa';
 import type { Framework } from './types';
@@ -14,7 +13,6 @@ export const stub = (framework: Framework): void => {
 			break;
 		case 'ccpa':
 			stub_uspapi_ccpa();
-			// stub_gpp_ccpa();
 			break;
 		case 'aus':
 			stub_uspapi_ccpa();

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,4 +1,4 @@
-import { stub_gpp_ccpa } from './stub_gpp_ccpa';
+// import { stub_gpp_ccpa } from './stub_gpp_ccpa';
 import { stub_tcfv2 } from './stub_tcfv2';
 import { stub_uspapi_ccpa } from './stub_uspapi_ccpa';
 import type { Framework } from './types';
@@ -14,7 +14,7 @@ export const stub = (framework: Framework): void => {
 			break;
 		case 'ccpa':
 			stub_uspapi_ccpa();
-			stub_gpp_ccpa();
+			// stub_gpp_ccpa();
 			break;
 		case 'aus':
 			stub_uspapi_ccpa();

--- a/src/types/ccpa.ts
+++ b/src/types/ccpa.ts
@@ -6,8 +6,3 @@ export interface CCPAData {
 	version: number;
 	uspString: string;
 }
-
-export interface GPPData {
-	gppVersion: number;
-	gppString: string;
-}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -3,7 +3,7 @@ import type { Property } from '../lib/property';
 import type { EndPoint } from '../lib/sourcepointConfig';
 import type { onConsent } from '../onConsent';
 import type { onConsentChange } from '../onConsentChange';
-import type { CCPAData, GPPData } from './ccpa';
+import type { CCPAData } from './ccpa';
 import type { TCData } from './tcfv2/TCData';
 import type { CMP, Framework, PubData } from '.';
 
@@ -35,7 +35,6 @@ declare global {
 					framework: Framework;
 				};
 				ccpa?: {
-					includeGppApi?: boolean;
 					targetingParams?: {
 						framework: Framework;
 					};

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -98,9 +98,5 @@ declare global {
 			callback: (tcData: TCData, success: boolean) => void,
 			vendorIDs?: number[],
 		) => void;
-		// __gpp?: (
-		// 	command: string,
-		// 	callback: (gppData: GPPData, success: boolean) => void,
-		// ) => void;
 	}
 }

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -98,9 +98,9 @@ declare global {
 			callback: (tcData: TCData, success: boolean) => void,
 			vendorIDs?: number[],
 		) => void;
-		__gpp?: (
-			command: string,
-			callback: (gppData: GPPData, success: boolean) => void,
-		) => void;
+		// __gpp?: (
+		// 	command: string,
+		// 	callback: (gppData: GPPData, success: boolean) => void,
+		// ) => void;
 	}
 }


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
Removes __gpp stub from loading in CCPA.
## Why?
This caused an issue with ads. This is a temporary removal and will be reinstated once it's been debugged.

Tested using about us to check the stubs loaded.
## Link to Trello
