### PR TITLE
add new comscore cookie to `vendorStorageIds`

### DIFF
--- a/.changeset/chilled-trains-talk.md
+++ b/.changeset/chilled-trains-talk.md
@@ -1,0 +1,5 @@
+---
+"@guardian/consent-management-platform": patch
+---
+
+Add new comscore cookie to vendorStorageIds

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -22,7 +22,7 @@ export const vendorStorageIds = {
 		],
 	},
 	comscore: {
-		cookies: ['comScore'],
+		cookies: ['comScore','_scor_uid'],
 	},
 
 	ipsos: {


### PR DESCRIPTION
## Why
ComDev is making a change that will allow comscore to drop this first party cookie. https://github.com/guardian/commercial/pull/1313

By adding it here we can make sure it's removed if consent changes.
