### PR TITLE
Fix flaky ccpa monitoring tests

### DIFF
--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -80,7 +80,8 @@ export class Monitoring extends GuStack {
 
 
 		const monitoringDuration: Duration =
-			stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.days(1); // Every day for CODE; Every 2 minutes for PROD.
+		stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.minutes(prodDurationInMinutes); // Testing US flakiness.
+		//stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.days(1); // Every day for CODE; Every 2 minutes for PROD.
 
 		new Rule(this, 'cmp monitoring schedule', {
 			schedule: Schedule.rate(monitoringDuration),

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -80,8 +80,7 @@ export class Monitoring extends GuStack {
 
 
 		const monitoringDuration: Duration =
-		stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.minutes(prodDurationInMinutes); // Testing US flakiness.
-		//stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.days(1); // Every day for CODE; Every 2 minutes for PROD.
+			stage === 'PROD' ? Duration.minutes(prodDurationInMinutes) : Duration.days(1); // Every day for CODE; Every 2 minutes for PROD.
 
 		new Rule(this, 'cmp monitoring schedule', {
 			schedule: Schedule.rate(monitoringDuration),

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -80,7 +80,6 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 	await checkCMPIsOnPage(page);
 	await clickDoNotSellMyInfo(config, page);
 	await checkCMPIsNotVisible(page);
-	//await reloadPage(page); // this is now happening as part of the process so do we need this?
 	await checkTopAdHasLoaded(page);
 
 	if (nextUrl) {

--- a/monitoring/src/check-page/ccpa.ts
+++ b/monitoring/src/check-page/ccpa.ts
@@ -80,7 +80,7 @@ const checkPages = async (config: Config, url: string, nextUrl: string) => {
 	await checkCMPIsOnPage(page);
 	await clickDoNotSellMyInfo(config, page);
 	await checkCMPIsNotVisible(page);
-	await reloadPage(page);
+	//await reloadPage(page); // this is now happening as part of the process so do we need this?
 	await checkTopAdHasLoaded(page);
 
 	if (nextUrl) {


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?

Removes a possibly redundant reload call from the CCPA monitoring checkPages function.  It is believed that a reload is happening as part of onConsentChange and therefore this reload may be causing issues when run against production.

## Why?

Since the PR to add a final parameter to onConsentChange and the equivalent PR on the commercial side were added, the CCPA (US) monitoring has been flaky.

My working assumption is that on clickingDoNotSellMyInfo the commercial code is doing a refresh as part of it's final callback parameter triggered by the onConsentChange event and our actively pushing another refresh onto the call stack is causing the error we're seeing.  We do not appear to have any missing awaits that might otherwise account for this error.  

Unfortunately, I am unable to check which event it is actually being triggered by this button owing to the lack of available VPN.

I have tested in CODE (against PROD) but am unable to replicate (with either main or this code).  This code appears to work without the reload to pull the adverts into the page (these should not be targeting adverts).

Without a VPN, there is only one way to confirm this assumption and that is to push it into PROD.

## Link to Trello

[Card](https://trello.com/c/rlUYmulg)