### PR TITLE
Mark CMP source code as moved

### DIFF
--- a/src/aus/__fixtures__/api.getCustomVendorRejects.json
+++ b/src/aus/__fixtures__/api.getCustomVendorRejects.json
@@ -1,4 +1,5 @@
 {
+	"WARNING": "THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON. THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform",
 	"rejectedCategories": [],
 	"rejectedVendors": [],
 	"ccpaApplies": true

--- a/src/aus/__fixtures__/api.getUSPData.json
+++ b/src/aus/__fixtures__/api.getUSPData.json
@@ -1,4 +1,5 @@
 {
+	"WARNING": "THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON. THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform",
 	"version": 1,
 	"uspString": "1YNN"
 }

--- a/src/aus/api.test.js
+++ b/src/aus/api.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getUSPData } from './api.ts';
 
 jest.mock('../sourcepoint', () => ({

--- a/src/aus/api.ts
+++ b/src/aus/api.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CCPAData } from '../types/ccpa';
 
 type Command = 'getUSPData';

--- a/src/aus/getConsentState.test.js
+++ b/src/aus/getConsentState.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import ausData from './__fixtures__/api.getUSPData.json';
 import { getUSPData } from './api.ts';
 import { getConsentState } from './getConsentState.ts';

--- a/src/aus/getConsentState.ts
+++ b/src/aus/getConsentState.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { AUSConsentState } from '../types/aus';
 import { getUSPData } from './api';
 

--- a/src/ccpa/__fixtures__/api.getUSPData.json
+++ b/src/ccpa/__fixtures__/api.getUSPData.json
@@ -1,4 +1,5 @@
 {
+	"WARNING": "THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON. THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform",
 	"version": 1,
 	"uspString": "1YYN"
 }

--- a/src/ccpa/api.test.js
+++ b/src/ccpa/api.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getUSPData } from './api.ts';
 
 it('calls the correct IAB api with the correct methods', async () => {

--- a/src/ccpa/api.ts
+++ b/src/ccpa/api.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CCPAData } from '../types/ccpa';
 
 type Command = 'getUSPData';

--- a/src/ccpa/getConsentState.test.js
+++ b/src/ccpa/getConsentState.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import uspData from './__fixtures__/api.getUSPData.json';
 import { getUSPData } from './api.ts';
 import { getConsentState } from './getConsentState.ts';

--- a/src/ccpa/getConsentState.ts
+++ b/src/ccpa/getConsentState.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CCPAConsentState } from '../types/ccpa';
 import { getUSPData } from './api';
 

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getCurrentFramework } from './getCurrentFramework';
 import { mark } from './lib/mark';
 import {

--- a/src/disable.test.js
+++ b/src/disable.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { disable, enable, isDisabled } from './disable.ts';
 
 describe('Disabling consent management', () => {

--- a/src/disable.ts
+++ b/src/disable.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 const COOKIE_NAME = 'gu-cmp-disabled';
 
 export const disable = (): void => {

--- a/src/getConsentFor.test.js
+++ b/src/getConsentFor.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 // cSpell:ignore doesnotexist
 
 import { getConsentFor } from './getConsentFor.ts';
@@ -28,9 +36,9 @@ jest.mock('./vendors', () => ({
 }));
 
 it('throws an error if the vendor found ', () => {
-	jest
-		.spyOn(vendors, 'VendorIDs')
-		.mockReturnValue({ vendorOne: [vendorOne, vendorAlt] });
+	jest.spyOn(vendors, 'VendorIDs').mockReturnValue({
+		vendorOne: [vendorOne, vendorAlt],
+	});
 	expect(() => {
 		getConsentFor('doesnotexist', tcfv2ConsentFoundTrue);
 	}).toThrow("Vendor 'doesnotexist' not found");
@@ -48,9 +56,9 @@ test.each([
 ])(
 	`In %s mode, returns %s, for vendor %s`,
 	(cmpMode, expected, vendor, mock) => {
-		jest
-			.spyOn(vendors, 'VendorIDs')
-			.mockReturnValue({ vendorOne: [vendorOne, vendorAlt] });
+		jest.spyOn(vendors, 'VendorIDs').mockReturnValue({
+			vendorOne: [vendorOne, vendorAlt],
+		});
 		expect(() => {
 			getConsentFor(vendor, mock);
 		});

--- a/src/getConsentFor.ts
+++ b/src/getConsentFor.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { ConsentState, GetConsentFor } from './types';
 import type { VendorName } from './vendors';
 import { VendorIDs } from './vendors';

--- a/src/getCurrentFramework.ts
+++ b/src/getCurrentFramework.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { log } from '@guardian/libs';
 import type { Framework } from './types';
 

--- a/src/getFramework.ts
+++ b/src/getFramework.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CountryCode } from '@guardian/libs';
 import type { Framework } from './types';
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CountryCode } from '@guardian/libs';
 import { CMP as actualCMP } from './cmp';
 import { disable, enable } from './disable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CountryCode } from '@guardian/libs';
 import { log } from '@guardian/libs';
 import { version } from '../package.json';

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { isServerSide } from '../server';
 
 let isGuardian: boolean | undefined;

--- a/src/lib/mark.ts
+++ b/src/lib/mark.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /* istanbul ignore file */
 import { log } from '@guardian/libs';
 

--- a/src/lib/property.ts
+++ b/src/lib/property.ts
@@ -1,1 +1,9 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 export type Property = string | null;

--- a/src/lib/signals.ts
+++ b/src/lib/signals.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { isServerSide } from '../server';
 
 /**

--- a/src/lib/sourcepointConfig.ts
+++ b/src/lib/sourcepointConfig.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { isGuardianDomain } from './domain';
 
 export const ACCOUNT_ID = 1257;

--- a/src/onConsent.test.ts
+++ b/src/onConsent.test.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { onConsent } from './onConsent';
 import { onConsentChange } from './onConsentChange';
 import type { Callback, ConsentState } from './types';

--- a/src/onConsent.ts
+++ b/src/onConsent.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { onConsentChange } from './onConsentChange';
 import type { ConsentState } from './types';
 

--- a/src/onConsentChange.enhanced.test.ts
+++ b/src/onConsentChange.enhanced.test.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getConsentState as getAUSConsentState } from './aus/getConsentState';
 import { getConsentState as getCCPAConsentState } from './ccpa/getConsentState';
 import { setCurrentFramework, unsetFramework } from './getCurrentFramework';

--- a/src/onConsentChange.test.js
+++ b/src/onConsentChange.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import ausData from './aus/__fixtures__/api.getUSPData.json';
 import uspData from './ccpa/__fixtures__/api.getUSPData.json';
 import { setCurrentFramework } from './getCurrentFramework.ts';
@@ -96,16 +104,9 @@ describe('under CCPA', () => {
 		expect(callback4).toHaveBeenCalledTimes(1);
 
 		// callbacks initially executed in order they were registered in
-		expect(callbackLastExecuted[3]).toBeLessThan(
-			callbackLastExecuted[4],
-		);
-		expect(callbackLastExecuted[4]).toBeLessThan(
-			callbackLastExecuted[1],
-		);
-		expect(callbackLastExecuted[1]).toBeLessThan(
-			callbackLastExecuted[2],
-		);
-
+		expect(callbackLastExecuted[3]).toBeLessThan(callbackLastExecuted[4]);
+		expect(callbackLastExecuted[4]).toBeLessThan(callbackLastExecuted[1]);
+		expect(callbackLastExecuted[1]).toBeLessThan(callbackLastExecuted[2]);
 
 		uspData.uspString = '1YNN';
 		invokeCallbacks();
@@ -117,15 +118,9 @@ describe('under CCPA', () => {
 		expect(callback4).toHaveBeenCalledTimes(2);
 
 		// after consent state change, callbacks were executed in order 1, 2, 3, 4
-		expect(callbackLastExecuted[1]).toBeLessThan(
-			callbackLastExecuted[2],
-		);
-		expect(callbackLastExecuted[2]).toBeLessThan(
-			callbackLastExecuted[3],
-		);
-		expect(callbackLastExecuted[3]).toBeLessThan(
-			callbackLastExecuted[4],
-		);
+		expect(callbackLastExecuted[1]).toBeLessThan(callbackLastExecuted[2]);
+		expect(callbackLastExecuted[2]).toBeLessThan(callbackLastExecuted[3]);
+		expect(callbackLastExecuted[3]).toBeLessThan(callbackLastExecuted[4]);
 	});
 });
 
@@ -207,15 +202,9 @@ describe('under AUS', () => {
 		expect(callback4).toHaveBeenCalledTimes(1);
 
 		// callbacks initially executed in order they were registered in
-		expect(callbackLastExecuted[3]).toBeLessThan(
-			callbackLastExecuted[4],
-		);
-		expect(callbackLastExecuted[4]).toBeLessThan(
-			callbackLastExecuted[1],
-		);
-		expect(callbackLastExecuted[1]).toBeLessThan(
-			callbackLastExecuted[2],
-		);
+		expect(callbackLastExecuted[3]).toBeLessThan(callbackLastExecuted[4]);
+		expect(callbackLastExecuted[4]).toBeLessThan(callbackLastExecuted[1]);
+		expect(callbackLastExecuted[1]).toBeLessThan(callbackLastExecuted[2]);
 
 		ausData.uspString = '1YNN';
 		invokeCallbacks();
@@ -227,15 +216,9 @@ describe('under AUS', () => {
 		expect(callback4).toHaveBeenCalledTimes(2);
 
 		// after consent state change, callbacks were executed in order 1, 2, 3, 4
-		expect(callbackLastExecuted[1]).toBeLessThan(
-			callbackLastExecuted[2],
-		);
-		expect(callbackLastExecuted[2]).toBeLessThan(
-			callbackLastExecuted[3],
-		);
-		expect(callbackLastExecuted[3]).toBeLessThan(
-			callbackLastExecuted[4],
-		);
+		expect(callbackLastExecuted[1]).toBeLessThan(callbackLastExecuted[2]);
+		expect(callbackLastExecuted[2]).toBeLessThan(callbackLastExecuted[3]);
+		expect(callbackLastExecuted[3]).toBeLessThan(callbackLastExecuted[4]);
 	});
 });
 
@@ -353,14 +336,8 @@ describe('under TCFv2', () => {
 		expect(callback4).toHaveBeenCalledTimes(1);
 
 		// callbacks were executed in order 1, 2, 3, 4
-		expect(callbackLastExecuted[1]).toBeLessThan(
-			callbackLastExecuted[2],
-		);
-		expect(callbackLastExecuted[2]).toBeLessThan(
-			callbackLastExecuted[3],
-		);
-		expect(callbackLastExecuted[3]).toBeLessThan(
-			callbackLastExecuted[4],
-		);
+		expect(callbackLastExecuted[1]).toBeLessThan(callbackLastExecuted[2]);
+		expect(callbackLastExecuted[2]).toBeLessThan(callbackLastExecuted[3]);
+		expect(callbackLastExecuted[3]).toBeLessThan(callbackLastExecuted[4]);
 	});
 });

--- a/src/onConsentChange.ts
+++ b/src/onConsentChange.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getConsentState as getAUSConsentState } from './aus/getConsentState';
 import { getConsentState as getCCPAConsentState } from './ccpa/getConsentState';
 import { getCurrentFramework } from './getCurrentFramework';

--- a/src/rollup.config.js
+++ b/src/rollup.config.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /* eslint-disable import/no-default-export -- it's what rollup wants */
 
 import commonjs from '@rollup/plugin-commonjs';
@@ -6,7 +14,7 @@ import replace from '@rollup/plugin-replace';
 import strip from '@rollup/plugin-strip';
 import typescript from '@rollup/plugin-typescript';
 import css from 'rollup-plugin-css-only';
-import json from "@rollup/plugin-json";
+import json from '@rollup/plugin-json';
 import pkg from '../package.json';
 
 export default {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { onConsent as OnConsent } from './onConsent';
 import type {
 	CMP,

--- a/src/sourcepoint.test.js
+++ b/src/sourcepoint.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import http from 'http';
 import url from 'url';
 import { ACCOUNT_ID, ENDPOINT } from './lib/sourcepointConfig.ts';
@@ -28,29 +36,31 @@ describe('Sourcepoint unified', () => {
 			expect(window._sp_.config.baseEndpoint).toEqual(ENDPOINT);
 			expect(window._sp_.config.accountId).toEqual(ACCOUNT_ID);
 			expect(window._sp_.config.events).toBeDefined();
-			expect(typeof window._sp_.config.events.onConsentReady).toBe('function');
+			expect(typeof window._sp_.config.events.onConsentReady).toBe(
+				'function',
+			);
 			expect(typeof window._sp_.config.events.onMessageReceiveData).toBe(
 				'function',
 			);
 
 			if (framework == 'tcfv2') {
-				expect(window._sp_.config.gdpr.targetingParams.framework).toEqual(
-					framework,
-				);
+				expect(
+					window._sp_.config.gdpr.targetingParams.framework,
+				).toEqual(framework);
 				expect(window._sp_.config.ccpa).toBeUndefined();
 				expect(window.__tcfapi).toBeDefined();
 				expect(window.__uspapi).toBeUndefined();
 			} else if (framework == 'ccpa') {
-				expect(window._sp_.config.ccpa.targetingParams.framework).toEqual(
-					framework,
-				);
+				expect(
+					window._sp_.config.ccpa.targetingParams.framework,
+				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 			} else if (framework == 'aus') {
-				expect(window._sp_.config.ccpa.targetingParams.framework).toEqual(
-					framework,
-				);
+				expect(
+					window._sp_.config.ccpa.targetingParams.framework,
+				).toEqual(framework);
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
@@ -61,7 +71,9 @@ describe('Sourcepoint unified', () => {
 	it.each(frameworks)('points at a real file', (framework, done) => {
 		init(framework);
 		expect(document.getElementById('sourcepoint-lib')).toBeTruthy();
-		const src = document.getElementById('sourcepoint-lib')?.getAttribute('src');
+		const src = document
+			.getElementById('sourcepoint-lib')
+			?.getAttribute('src');
 
 		const { host, path } = url.parse(src ?? '');
 
@@ -80,16 +92,16 @@ describe('Sourcepoint unified', () => {
 		});
 		expect(window._sp_.config.pubData.browserId).toEqual('abc123');
 		expect(window._sp_.config.pubData.pageViewId).toEqual('abcdef');
-		expect(window._sp_.config.pubData.cmpInitTimeUtc).toBeGreaterThanOrEqual(
-			now,
-		);
+		expect(
+			window._sp_.config.pubData.cmpInitTimeUtc,
+		).toBeGreaterThanOrEqual(now);
 	});
 
 	it.each(frameworks)('should handle no pubData', (framework) => {
 		const now = new Date().getTime();
 		init(framework);
-		expect(window._sp_.config.pubData.cmpInitTimeUtc).toBeGreaterThanOrEqual(
-			now,
-		);
+		expect(
+			window._sp_.config.pubData.cmpInitTimeUtc,
+		).toBeGreaterThanOrEqual(now);
 	});
 });

--- a/src/sourcepoint.ts
+++ b/src/sourcepoint.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { log } from '@guardian/libs';
 import { setCurrentFramework } from './getCurrentFramework';
 import { isGuardianDomain } from './lib/domain';

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { stub_tcfv2 } from './stub_tcfv2';
 import { stub_uspapi_ccpa } from './stub_uspapi_ccpa';
 import type { Framework } from './types';

--- a/src/stub_gpp_ccpa.js
+++ b/src/stub_gpp_ccpa.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /* eslint-disable -- this is third party code */
 /* istanbul ignore file */
 // Reference : https://docs.sourcepoint.com/hc/en-us/articles/18007731422099-Enable-GPP-Multi-State-Privacy-String-MSPS-with-U-S-Privacy-CCPA-solution

--- a/src/stub_tcfv2.js
+++ b/src/stub_tcfv2.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /* eslint-disable -- this is third party code */
 /* istanbul ignore file */
 
@@ -19,7 +27,8 @@ export const stub_tcfv2 = () => {
 		(n.m = t),
 			(n.c = e),
 			(n.d = function (t, e, r) {
-				n.o(t, e) || Object.defineProperty(t, e, { enumerable: !0, get: r });
+				n.o(t, e) ||
+					Object.defineProperty(t, e, { enumerable: !0, get: r });
 			}),
 			(n.r = function (t) {
 				'undefined' != typeof Symbol &&
@@ -31,7 +40,8 @@ export const stub_tcfv2 = () => {
 			}),
 			(n.t = function (t, e) {
 				if ((1 & e && (t = n(t)), 8 & e)) return t;
-				if (4 & e && 'object' == typeof t && t && t.__esModule) return t;
+				if (4 & e && 'object' == typeof t && t && t.__esModule)
+					return t;
 				var r = Object.create(null);
 				if (
 					(n.r(r),
@@ -83,7 +93,9 @@ export const stub_tcfv2 = () => {
 		},
 		function (t, e) {
 			t.exports = function (t) {
-				return 'object' == typeof t ? null !== t : 'function' == typeof t;
+				return 'object' == typeof t
+					? null !== t
+					: 'function' == typeof t;
 			};
 		},
 		function (t, e) {
@@ -117,7 +129,9 @@ export const stub_tcfv2 = () => {
 							})() &&
 							((n.__tcfapi = function () {
 								for (
-									var n = arguments.length, r = new Array(n), o = 0;
+									var n = arguments.length,
+										r = new Array(n),
+										o = 0;
 									o < n;
 									o++
 								)
@@ -127,7 +141,9 @@ export const stub_tcfv2 = () => {
 									r.length > 3 &&
 										2 === parseInt(r[1], 10) &&
 										'boolean' == typeof r[3] &&
-										((t = r[3]), 'function' == typeof r[2] && r[2]('set', !0));
+										((t = r[3]),
+										'function' == typeof r[2] &&
+											r[2]('set', !0));
 								else if ('ping' === r[0]) {
 									var i = {
 										gdprApplies: t,
@@ -165,7 +181,10 @@ export const stub_tcfv2 = () => {
 													},
 												};
 												e && (i = JSON.stringify(i)),
-													t.source.postMessage(i, '*');
+													t.source.postMessage(
+														i,
+														'*',
+													);
 											},
 											o.parameter,
 										);
@@ -275,11 +294,19 @@ export const stub_tcfv2 = () => {
 			t.exports = function (t, e) {
 				if (!r(t)) return t;
 				var n, o;
-				if (e && 'function' == typeof (n = t.toString) && !r((o = n.call(t))))
+				if (
+					e &&
+					'function' == typeof (n = t.toString) &&
+					!r((o = n.call(t)))
+				)
 					return o;
 				if ('function' == typeof (n = t.valueOf) && !r((o = n.call(t))))
 					return o;
-				if (!e && 'function' == typeof (n = t.toString) && !r((o = n.call(t))))
+				if (
+					!e &&
+					'function' == typeof (n = t.toString) &&
+					!r((o = n.call(t)))
+				)
 					return o;
 				throw TypeError("Can't convert object to primitive value");
 			};

--- a/src/stub_uspapi_ccpa.js
+++ b/src/stub_uspapi_ccpa.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /* eslint-disable -- this is third party code */
 /* istanbul ignore file */
 

--- a/src/tcfv2/__fixtures__/README.md
+++ b/src/tcfv2/__fixtures__/README.md
@@ -1,3 +1,10 @@
+<!--
+"WARNING": "THIS FILE IS NO LONGER USED.
+IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON.
+
+THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform"
+-->
+
 # Fixtures
 
 These were obtained by running

--- a/src/tcfv2/__fixtures__/api.getCustomVendorConsents.json
+++ b/src/tcfv2/__fixtures__/api.getCustomVendorConsents.json
@@ -1,4 +1,5 @@
 {
+	"WARNING": "THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON. THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform",
 	"consentedPurposes": [
 		{
 			"_id": "5ec67f5baf2b474b46b67d8c",

--- a/src/tcfv2/__fixtures__/api.getTCData.json
+++ b/src/tcfv2/__fixtures__/api.getTCData.json
@@ -1,4 +1,5 @@
 {
+	"WARNING": "THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE DELETED SOON. THE EQUIVALENT FILE IS NOW LOCATED AT: https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform",
 	"cmpId": 6,
 	"cmpVersion": 1,
 	"gdprApplies": true,

--- a/src/tcfv2/api.test.js
+++ b/src/tcfv2/api.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getCustomVendorConsents, getTCData } from './api.ts';
 
 it('calls the correct IAB api with the correct methods', async () => {

--- a/src/tcfv2/api.ts
+++ b/src/tcfv2/api.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CustomVendorConsents } from '../types/tcfv2/CustomVendorConsents';
 import type { TCData } from '../types/tcfv2/TCData';
 

--- a/src/tcfv2/getConsentState.test.js
+++ b/src/tcfv2/getConsentState.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import customVendorConsents from './__fixtures__/api.getCustomVendorConsents.json';
 import tcData from './__fixtures__/api.getTCData.json';
 import { getCustomVendorConsents, getTCData } from './api.ts';

--- a/src/tcfv2/getConsentState.ts
+++ b/src/tcfv2/getConsentState.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { getCurrentFramework } from '../getCurrentFramework';
 import type { TCFv2ConsentList, TCFv2ConsentState } from '../types/tcfv2';
 import { getCustomVendorConsents, getTCData } from './api';

--- a/src/types/aus.ts
+++ b/src/types/aus.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 export interface AUSConsentState {
 	personalisedAdvertising: boolean;
 }

--- a/src/types/ccpa.ts
+++ b/src/types/ccpa.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 export interface CCPAConsentState {
 	doNotSell: boolean;
 }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 interface Navigator {
 	globalPrivacyControl?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { CountryCode } from '@guardian/libs';
 import type { VendorName } from '../vendors';
 import type { AUSConsentState } from './aus';

--- a/src/types/tcfv2/CustomVendorConsents.ts
+++ b/src/types/tcfv2/CustomVendorConsents.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 // https://documentation.sourcepoint.com/web-implementation/sourcepoint-gdpr-and-tcf-v2-support/__tcfapi-getcustomvendorconsents-api#data-the-__tcfapi-getcustomconsentdata-api-returns
 
 export interface CustomVendorConsents {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { getConsentFor } from '../getConsentFor';
 import type { Property } from '../lib/property';
 import type { EndPoint } from '../lib/sourcepointConfig';

--- a/src/vendorDataManager.test.ts
+++ b/src/vendorDataManager.test.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { removeCookie, storage } from '@guardian/libs';
 import { onConsentChange } from './onConsentChange';
 import type { Callback, ConsentState } from './types';

--- a/src/vendorDataManager.ts
+++ b/src/vendorDataManager.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import { removeCookie, storage } from '@guardian/libs';
 import { getConsentFor } from './getConsentFor';
 import { onConsentChange } from './onConsentChange';

--- a/src/vendorStorageIds.ts
+++ b/src/vendorStorageIds.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import type { VendorName } from './vendors';
 
 /**

--- a/src/vendors.test.js
+++ b/src/vendors.test.js
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 import axios from 'axios';
 import { TCFV2VendorIDs } from './vendors.ts';
 
@@ -6,7 +14,9 @@ const guardianId = '5ec67f5bb8e05c4a1160fda1';
 const guardianVendorListUrl = `https://${cmpBaseUrl}/consent/tcfv2/vendor-list?vendorListId=${guardianId}`;
 
 it('the tcfv2 vendor ids used must be a subset of those known by the IAB as our vendors', async () => {
-	const iabGuardianVendorListResponse = await axios.get(guardianVendorListUrl);
+	const iabGuardianVendorListResponse = await axios.get(
+		guardianVendorListUrl,
+	);
 
 	const vendorIds = Object.values(TCFV2VendorIDs).flat();
 
@@ -14,7 +24,9 @@ it('the tcfv2 vendor ids used must be a subset of those known by the IAB as our 
 		(vendor) => vendor['_id'],
 	);
 
-	const missingVendorIds = vendorIds.filter((id) => !iabVendorIds.includes(id));
+	const missingVendorIds = vendorIds.filter(
+		(id) => !iabVendorIds.includes(id),
+	);
 
 	expect(missingVendorIds).toStrictEqual([]);
 });

--- a/src/vendors.ts
+++ b/src/vendors.ts
@@ -1,3 +1,11 @@
+/**
+ * THIS FILE IS NO LONGER USED. IT IS KEPT FOR REFERENCE ONLY AND WILL BE
+ * DELETED SOON.
+ *
+ * THE EQUIVALENT FILE IS NOW LOCATED AT:
+ * https://github.com/guardian/csnx/tree/main/libs/%40guardian/libs/src/consent-management-platform
+ */
+
 /*********************
  * The list of vendors in this file is used in the function 'getConsentfFor'
  * when additional checks on consent are used.


### PR DESCRIPTION
## What does this change?

- adds a comment to each file in the CMP package source code marking it as having moved
- 

## Why?

creates an undo point if the [move to CSNX](https://github.com/guardian/csnx/pull/1128) needs to be reverted


