### PR TITLE
Remove CMP App group due to package being deprecated.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'sunday'
-    labels:
-      - 'dependencies'
-      - 'javascript'
-    groups:
-      cmp-app:
-        update-types:
-          - 'minor'
-          - 'patch'
-  - package-ecosystem: 'npm'
     directory: '/cdk'
     schedule:
       interval: 'weekly'

--- a/cypress/e2e/sourcepoint-tcfv2.cy.js
+++ b/cypress/e2e/sourcepoint-tcfv2.cy.js
@@ -39,7 +39,7 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	const buttonTitle = 'Yes, I’m happy';
+	const buttonTitle = 'Yes, I accept';
 
 	it(`should give all consents when clicking "${buttonTitle}"`, () => {
 		cy.visit(url);


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
Stop creating dependabot updates for the base directory.
Update failing test.

## Why?
This was migrated to csnx and deprecated.
## Link to Trello
