### PR TITLE
Fix Monitoring by defining the NodeJS runtime version

### DIFF
--- a/.github/workflows/monitoring-CI.yml
+++ b/.github/workflows/monitoring-CI.yml
@@ -65,6 +65,8 @@ jobs:
       - name: CDK Synth
         working-directory: './cdk'
         run: yarn synth
+        env:
+          LAMBDA_RUNTIME_ID: ${{ secrets.LAMBDA_RUNTIME_ID }}
 
       - name: ZIP Lambda files
         working-directory: './cdk'

--- a/.github/workflows/monitoring-CI.yml
+++ b/.github/workflows/monitoring-CI.yml
@@ -11,6 +11,8 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write # to be able to comment on released pull requests
+    env:
+      LAMBDA_RUNTIME_ID: ${{ secrets.LAMBDA_RUNTIME_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -65,8 +67,6 @@ jobs:
       - name: CDK Synth
         working-directory: './cdk'
         run: yarn synth
-        env:
-          LAMBDA_RUNTIME_ID: ${{ secrets.LAMBDA_RUNTIME_ID }}
 
       - name: ZIP Lambda files
         working-directory: './cdk'

--- a/cdk/lib/__snapshots__/monitoring.test.ts.snap
+++ b/cdk/lib/__snapshots__/monitoring.test.ts.snap
@@ -47,7 +47,7 @@ exports[`The Monitoring stack matches the snapshot 1`] = `
         },
         "Runtime": "nodejs18.x",
         "RuntimeManagementConfig": {
-          "RuntimeVersionArn": "0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9",
+          "RuntimeVersionArn": "arn:aws:lambda:eu-west-1::runtime:0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9",
           "UpdateRuntimeOn": "Manual",
         },
         "Tags": [

--- a/cdk/lib/__snapshots__/monitoring.test.ts.snap
+++ b/cdk/lib/__snapshots__/monitoring.test.ts.snap
@@ -46,6 +46,10 @@ exports[`The Monitoring stack matches the snapshot 1`] = `
           ],
         },
         "Runtime": "nodejs18.x",
+        "RuntimeManagementConfig": {
+          "RuntimeVersionArn": "0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9",
+          "UpdateRuntimeOn": "Manual",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -30,6 +30,8 @@ export class Monitoring extends GuStack {
 
 		const lambdaBaseName = 'cmp-monitoring';
 
+		const runTimeId = process.env.LAMBDA_RUNTIME_ID;
+
 		const prodDurationInMinutes = 2;
 
 		const policyStatement = new PolicyStatement({
@@ -38,7 +40,7 @@ export class Monitoring extends GuStack {
 			resources: ['*'],
 		});
 
-		const runTimeManagementArn = `arn:aws:lambda:${region}::runtime:0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9`
+		const runTimeManagementArn = `arn:aws:lambda:${region}::runtime:${runTimeId}`
 
 		const monitoringLambdaFunction = new GuLambdaFunction(
 			this,

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -38,6 +38,8 @@ export class Monitoring extends GuStack {
 			resources: ['*'],
 		});
 
+		const runTimeManagement = `arn:aws:lambda:${region}::runtime:0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9`
+
 		const monitoringLambdaFunction = new GuLambdaFunction(
 			this,
 			lambdaBaseName,
@@ -47,7 +49,7 @@ export class Monitoring extends GuStack {
 				fileName: `${lambdaBaseName}-lambda-${region}.zip`,
 				handler: 'index.handler',
 				runtime: Runtime.NODEJS_18_X,
-				runtimeManagementMode: RuntimeManagementMode.manual("0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9"),
+				runtimeManagementMode: RuntimeManagementMode.manual(runTimeManagement),
 				timeout: Duration.seconds(300),
 				memorySize: 2048,
 				initialPolicy: [policyStatement],

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -38,7 +38,7 @@ export class Monitoring extends GuStack {
 			resources: ['*'],
 		});
 
-		const runTimeManagement = `arn:aws:lambda:${region}::runtime:0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9`
+		const runTimeManagementArn = `arn:aws:lambda:${region}::runtime:0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9`
 
 		const monitoringLambdaFunction = new GuLambdaFunction(
 			this,
@@ -49,7 +49,7 @@ export class Monitoring extends GuStack {
 				fileName: `${lambdaBaseName}-lambda-${region}.zip`,
 				handler: 'index.handler',
 				runtime: Runtime.NODEJS_18_X,
-				runtimeManagementMode: RuntimeManagementMode.manual(runTimeManagement),
+				runtimeManagementMode: RuntimeManagementMode.manual(runTimeManagementArn),
 				timeout: Duration.seconds(300),
 				memorySize: 2048,
 				initialPolicy: [policyStatement],

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -16,7 +16,7 @@ import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, RuleTargetInput, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Runtime, RuntimeManagementMode } from 'aws-cdk-lib/aws-lambda';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
@@ -47,6 +47,7 @@ export class Monitoring extends GuStack {
 				fileName: `${lambdaBaseName}-lambda-${region}.zip`,
 				handler: 'index.handler',
 				runtime: Runtime.NODEJS_18_X,
+				runtimeManagementMode: RuntimeManagementMode.manual("0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9"),
 				timeout: Duration.seconds(300),
 				memorySize: 2048,
 				initialPolicy: [policyStatement],

--- a/monitoring/package.json
+++ b/monitoring/package.json
@@ -18,13 +18,13 @@
     "dotenv": "^16.3.1",
     "inquirer": "^8.2.6",
     "playwright-aws-lambda": "^0.10.0",
-    "playwright-core": "^1.40.1",
+    "playwright-core": "^1.44.0",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.490.0",
-		"@babel/parser": "^7.23.6",
+    "@babel/parser": "^7.23.6",
     "@guardian/eslint-config-typescript": "^9.0.1",
     "@guardian/prettier": "^7.0.0",
     "@guardian/tsconfig": "^0.2.0",

--- a/monitoring/yarn.lock
+++ b/monitoring/yarn.lock
@@ -4724,10 +4724,10 @@ playwright-aws-lambda@^0.10.0:
   dependencies:
     lambdafs "^2.1.1"
 
-playwright-core@^1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.1.tgz#442d15e86866a87d90d07af528e0afabe4c75c05"
-  integrity sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==
+playwright-core@^1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.0.tgz#316c4f0bca0551ffb88b6eb1c97bc0d2d861b0d5"
+  integrity sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
- Update playwright
- Fixing the runtime version to previous Lambda Runtime ARN.
## Why?
The automatic update is incompatible with playwright-aws-lambda

https://github.com/JupiterOne/playwright-aws-lambda/issues/74

Tested in CODE

## Link to Trello
