### PR TITLE
Add runtime id to monitoring

### DIFF
--- a/.github/workflows/monitoring-CI.yml
+++ b/.github/workflows/monitoring-CI.yml
@@ -11,8 +11,6 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write # to be able to comment on released pull requests
-    env:
-      LAMBDA_RUNTIME_ID: ${{ secrets.LAMBDA_RUNTIME_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/cdk/lib/monitoring.ts
+++ b/cdk/lib/monitoring.ts
@@ -30,7 +30,7 @@ export class Monitoring extends GuStack {
 
 		const lambdaBaseName = 'cmp-monitoring';
 
-		const runTimeId = process.env.LAMBDA_RUNTIME_ID;
+		const runTimeId = "0cdcfbdefbc5e7d3343f73c2e2dd3cba17d61dea0686b404502a0c9ce83931b9";
 
 		const prodDurationInMinutes = 2;
 


### PR DESCRIPTION
<!--

### Production Release

To add this PR to the next release:
    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch.
    - Once merged, changeset will create a new PR titled 'Version Packages'

### Beta Release

To trigger a beta release:

    - Run `yarn changeset add` locally to create a changeset and follow the instructions.
    - Push these changes to your branch
    - Apply the `[beta] @guardian/consent-management-platform` label to your pull request. This action will automatically trigger the [`cmp-beta-release-on-label.yml`](../.github/workflows/cmp-beta-release-on-label.yml) workflow.
    - Upon completion, the beta version will be posted by the `github-actions bot` in your pull request.
    - After testing the published beta, feel free to delete the generated .yml file if you decide not to update the cmp version.
-->

## What does this change?
Adding the runtime id to the cdk. Removing the runtime id secret
## Why?
In this PR (https://github.com/guardian/consent-management-platform/pull/989), I added the lambda node js runtime id as a secret. This has made local testing more difficult without actually removing the id from the repo (monitoring cdk snapshot)
## Link to Trello
