### PR TITLE
Update clickSaveAndCloseSecondLayer function in eu test

### DIFF
--- a/synthetics/src/jurisdiction-checks/tcfv2-consent-or-pay-eu.js
+++ b/synthetics/src/jurisdiction-checks/tcfv2-consent-or-pay-eu.js
@@ -264,7 +264,12 @@ const checkConsentOrPaySecondLayer = async (
 
 	await acceptAllInReducedPrivacySettingsPanel(page, config);
 
-	await clickSaveAndCloseSecondLayer(config, page);
+	await clickSaveAndCloseSecondLayer(
+		config,
+		page,
+		config.iframeDomainUrlSecondLayer,
+		ELEMENT_ID.TCFV2_SECOND_LAYER_SAVE_AND_EXIT,
+	);
 
 	await isUsingPersonalisedAds(page);
 


### PR DESCRIPTION
<!--

-->

## What does this change?
This fixes the `clickSaveAndCloseSecondLayer` function in the `tcfv2-consent-or-pay-eu` test.

## Why?
This particular test was failing.
## Link to Trello
